### PR TITLE
Fix probe types in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ probe_scraper_cache.sqlite
 temp/
 _tmp/
 _out/
+_temp/

--- a/notebooks/load_and_run.ipynb
+++ b/notebooks/load_and_run.ipynb
@@ -47,6 +47,51 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!rm -rf $repo_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!rm -rf $output_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!rm -rf $cache_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!git config --global user.email \"gfritzsche@mozilla.com\" && \\\n",
+    "git config --global user.name \"Georg Fritzsche\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": false
    },
    "outputs": [],

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -25,9 +25,9 @@ class DummyParser:
 PARSERS = {
     # This lists the available probe registry parsers:
     # parser type -> parser
-    'histograms': HistogramsParser(),
-    'scalars': ScalarsParser(),
-    'events': EventsParser(),
+    'histogram': HistogramsParser(),
+    'scalar': ScalarsParser(),
+    'event': EventsParser(),
 }
 
 
@@ -44,11 +44,11 @@ def main(temp_dir, out_dir):
     # Parse probe data from files into the form:
     # channel_name -> {
     #   node_id -> {
-    #     histograms: {
+    #     histogram: {
     #       name: ...,
     #       ...
     #     },
-    #     scalars: {
+    #     scalar: {
     #       ...
     #     },
     #   },

--- a/probe_scraper/scraper.py
+++ b/probe_scraper/scraper.py
@@ -13,15 +13,15 @@ from collections import defaultdict
 
 
 REGISTRY_FILES = {
-    'histograms': [
+    'histogram': [
         'toolkit/components/telemetry/Histograms.json',
         'dom/base/UseCounters.conf',
         'dom/base/nsDeprecatedOperationList.h',
     ],
-    'scalars': [
+    'scalar': [
         'toolkit/components/telemetry/Scalars.yaml',
     ],
-    'events': [
+    'event': [
         'toolkit/components/telemetry/Events.yaml',
     ],
 }
@@ -173,9 +173,9 @@ def scrape(folder=None):
         channels: [channel_name, ...],
         version: string,
         registries: {
-          histograms: [path, ...]
-          events: [path, ...]
-          scalars: [path, ...]
+          histogram: [path, ...]
+          event: [path, ...]
+          scalar: [path, ...]
         }
       },
       ...

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -54,11 +54,11 @@ def extract_node_data(node_id, channel, probe_type, probe_data, result_data):
     probe_data should have the form:
     {
       node_id: {
-        histograms: {
+        histogram: {
           name: ...,
           ...
         },
-        scalars: {
+        scalar: {
           ...
         },
       },

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -3,11 +3,11 @@ import pprint
 
 # incoming probe_data is of the form:
 #   node_id -> {
-#     histograms: {
+#     histogram: {
 #       name: ...,
 #       ...
 #     },
-#     scalars: {
+#     scalar: {
 #       ...
 #     },
 #   }
@@ -35,7 +35,7 @@ IN_NODE_DATA = {
 IN_PROBE_DATA = {
     "release": {
         "node_id_1": {
-            "histograms": {
+            "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
                     "description": "A description.",
@@ -53,7 +53,7 @@ IN_PROBE_DATA = {
 
         },
         "node_id_2": {
-            "histograms": {
+            "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
                     "description": "A description.",
@@ -70,7 +70,7 @@ IN_PROBE_DATA = {
              }
         },
         "node_id_3": {
-            "histograms": {
+            "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
                     "description": "A description.",
@@ -90,7 +90,7 @@ IN_PROBE_DATA = {
 }
 
 OUT_PROBE_DATA = {
-    'histograms/TEST_HISTOGRAM_1': {
+    'histogram/TEST_HISTOGRAM_1': {
         'history': {
             'release': [
                 {
@@ -129,16 +129,16 @@ OUT_PROBE_DATA = {
             ]
         },
         'name': 'TEST_HISTOGRAM_1',
-        'type': 'histograms'
+        'type': 'histogram'
     }
 }
 
 
 def test_probes_equal():
     DATA = IN_PROBE_DATA["release"]
-    histogram_node1 = DATA["node_id_1"]["histograms"]["TEST_HISTOGRAM_1"]
-    histogram_node2 = DATA["node_id_2"]["histograms"]["TEST_HISTOGRAM_1"]
-    histogram_node3 = DATA["node_id_3"]["histograms"]["TEST_HISTOGRAM_1"]
+    histogram_node1 = DATA["node_id_1"]["histogram"]["TEST_HISTOGRAM_1"]
+    histogram_node2 = DATA["node_id_2"]["histogram"]["TEST_HISTOGRAM_1"]
+    histogram_node3 = DATA["node_id_3"]["histogram"]["TEST_HISTOGRAM_1"]
     assert(not transform.probes_equal('histogram', histogram_node1, histogram_node2))
     assert(transform.probes_equal('histogram', histogram_node2, histogram_node3))
 


### PR DESCRIPTION
As it turns out the output contained ”histograms” for “type” instead of
“histogram”, “events” instead of “event”, “scalars” instead of “scalar”.

That e.g. broke the fx-data-explorers dashboard links.