### PR TITLE
Update scraper to new nightly mozilla-central hg tags

### DIFF
--- a/probe_scraper/scraper.py
+++ b/probe_scraper/scraper.py
@@ -29,7 +29,7 @@ REGISTRY_FILES = {
 CHANNELS = {
     'nightly': {
         'base_uri': 'https://hg.mozilla.org/mozilla-central/',
-        'tag_regex': '^FIREFOX_AURORA_[0-9]+_BASE$',
+        'tag_regex': '^FIREFOX_(AURORA|BETA)_[0-9]+_BASE$',
     },
     'aurora': {
         'base_uri': 'https://hg.mozilla.org/releases/mozilla-aurora/',


### PR DESCRIPTION
Aurora is going away, so Nightly/mozilla-central is now using BETA
instead of AURORA merge tags:
[hg.mozilla.org/mozilla-central/tags](https://hg.mozilla.org/mozilla-central/tags)