### PR TITLE
Deliver JSON files GZIP encoded

### DIFF
--- a/notebooks/load_and_run.ipynb
+++ b/notebooks/load_and_run.ipynb
@@ -22,7 +22,10 @@
    "source": [
     "import boto3\n",
     "import botocore\n",
-    "import os"
+    "import os\n",
+    "\n",
+    "from io import BytesIO\n",
+    "from gzip import GzipFile"
    ]
   },
   {
@@ -150,8 +153,32 @@
    "outputs": [],
    "source": [
     "# Get access to the S3 connect API.\n",
-    "client = boto3.client('s3', 'us-west-2')\n",
-    "transfer = boto3.s3.transfer.S3Transfer(client)"
+    "client = boto3.client('s3', 'us-west-2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def gzip_compress(source_file):\n",
+    "    \"\"\" Apply GZIP compression to the content of the provided file.\n",
+    "\n",
+    "    :param source_file: the absolute path of the file to compress.\n",
+    "    :return: The gzip compressed content of the input file.\n",
+    "    \"\"\"\n",
+    "    with open(source_file) as fi:\n",
+    "        text_body = fi.read().decode(\"utf-8\")\n",
+    "\n",
+    "    gz_body = BytesIO()\n",
+    "    gz = GzipFile(None, 'wb', 9, gz_body)\n",
+    "    gz.write(text_body.encode('utf-8'))\n",
+    "    gz.close()\n",
+    "    \n",
+    "    return gz_body.getvalue()"
    ]
   },
   {
@@ -162,12 +189,15 @@
    },
    "outputs": [],
    "source": [
-    "# Copy the files to S3.\n",
+    "# GZIP-compress the files, then copy them to S3. Allow caching for 8 hours.\n",
     "for file_name in OUTPUT_FILES:\n",
     "    source_path = os.path.join(output_dir, file_name)\n",
     "    key_path = S3_DATA_PATH + file_name\n",
     "    print \"uploading \" + file_name + \" to s3: \" + key_path\n",
-    "    transfer.upload_file(source_path, S3_PUBLIC_BUCKET, key_path)"
+    "    client.put_object(ACL='public-read', Bucket=S3_PUBLIC_BUCKET,\n",
+    "                      Key=key_path, Body=gzip_compress(source_path),\n",
+    "                      ContentEncoding='gzip', CacheControl='max-age=28800',\n",
+    "                      ContentType='application/json')"
    ]
   },
   {


### PR DESCRIPTION
This will additionally set the CacheControl header to 8 hours.

@mreid-moz , can you review this? It's meant to fix #17 . I've already manually tested it and one of the resulting files is available [here](https://analysis-output.telemetry.mozilla.org/probe-scraper/data/test_general.json). Firefox renders it properly and all the interesting headers appear to be there.