### PR TITLE
Enable writing probe data broken down by channel

### DIFF
--- a/notebooks/load_and_run.ipynb
+++ b/notebooks/load_and_run.ipynb
@@ -39,11 +39,10 @@
     "repo_dir = \"probe-scraper\"\n",
     "output_dir = \"/home/hadoop/analyses/probe_data\"\n",
     "cache_dir = \"/home/hadoop/analyses/probe_cache\"\n",
-    "repo_https_url = \"https://github.com/georgf/probe-scraper\"\n",
+    "repo_https_url = \"https://github.com/mozilla/probe-scraper\"\n",
     "\n",
     "S3_PUBLIC_BUCKET = \"telemetry-public-analysis-2\"\n",
-    "S3_DATA_PATH = \"probe-scraper/data/\"\n",
-    "OUTPUT_FILES = [\"general.json\", \"probes.json\", \"revisions.json\"]"
+    "S3_DATA_PATH = \"probe-scraper/data-rest/\""
    ]
   },
   {
@@ -189,15 +188,17 @@
    },
    "outputs": [],
    "source": [
-    "# GZIP-compress the files, then copy them to S3. Allow caching for 8 hours.\n",
-    "for file_name in OUTPUT_FILES:\n",
-    "    source_path = os.path.join(output_dir, file_name)\n",
-    "    key_path = S3_DATA_PATH + file_name\n",
-    "    print \"uploading \" + file_name + \" to s3: \" + key_path\n",
-    "    client.put_object(ACL='public-read', Bucket=S3_PUBLIC_BUCKET,\n",
-    "                      Key=key_path, Body=gzip_compress(source_path),\n",
-    "                      ContentEncoding='gzip', CacheControl='max-age=28800',\n",
-    "                      ContentType='application/json')"
+    "for path, subdirs, files in os.walk(output_dir):\n",
+    "    relative_path = os.path.relpath(path, output_dir)\n",
+    "    # GZIP-compress the files, then copy them to S3. Allow caching for 8 hours.\n",
+    "    for file_name in files:\n",
+    "        source_path = os.path.join(path, file_name)\n",
+    "        key_path = os.path.join(S3_DATA_PATH, relative_path, file_name)\n",
+    "        print \"uploading \" + file_name + \" to s3: \" + key_path\n",
+    "        client.put_object(ACL='public-read', Bucket=S3_PUBLIC_BUCKET,\n",
+    "                          Key=key_path, Body=gzip_compress(source_path),\n",
+    "                          ContentEncoding='gzip', CacheControl='max-age=28800',\n",
+    "                          ContentType='application/json')"
    ]
   },
   {

--- a/probe_scraper/parsers/events.py
+++ b/probe_scraper/parsers/events.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from third_party import parse_events
-from utils import set_in_nested_dict
+from utils import set_in_nested_dict, get_major_version
 
 
 def extract_events_data(e):
@@ -46,6 +46,7 @@ def extract_events_data(e):
     data["optout"] = optout
 
     # Normalize some field values.
+    data["expiry_version"] = get_major_version(data["expiry_version"])
     if data["expiry_version"] == "default":
         data["expiry_version"] = "never"
 

--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from third_party import histogram_tools
-from utils import set_in_nested_dict
+from utils import set_in_nested_dict, get_major_version
 
 
 def extract_histogram_data(histogram):
@@ -45,6 +45,7 @@ def extract_histogram_data(histogram):
     data["optout"] = optout
 
     # Normalize some field values.
+    data["expiry_version"] = get_major_version(data["expiry_version"])
     if data["expiry_version"] == "default":
         data["expiry_version"] = "never"
     if data["details"]["keyed"] == "true":

--- a/probe_scraper/parsers/scalars.py
+++ b/probe_scraper/parsers/scalars.py
@@ -3,12 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from third_party import parse_scalars
+from utils import get_major_version
 
 
 def extract_scalar_data(s):
     return {
         "description": s.description,
-        "expiry_version": s.expires,
+        "expiry_version": get_major_version(s.expires),
         "cpp_guard": s.cpp_guard,
         "optout": s.dataset.endswith('_OPTOUT'),
         "details": {

--- a/probe_scraper/parsers/utils.py
+++ b/probe_scraper/parsers/utils.py
@@ -15,3 +15,12 @@ def set_in_nested_dict(dictionary, path, value):
     for k in keys[:-1]:
         dictionary = dictionary[k]
     dictionary[keys[-1]] = value
+
+
+def get_major_version(version):
+    """ Extracts the major (leftmost) version of a version string.
+
+    :param version: the version string (e.g. "53.1")
+    :return: a string containing the leftmost number before the first dot
+    """
+    return version.split('.')[0]

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -89,7 +89,7 @@ IN_PROBE_DATA = {
     }
 }
 
-OUT_PROBE_DATA = {
+OUT_PROBE_DATA_MONOLITHIC = {
     'histogram/TEST_HISTOGRAM_1': {
         'history': {
             'release': [
@@ -108,6 +108,10 @@ OUT_PROBE_DATA = {
                     'revisions': {
                         'first': 'node_id_2',
                         'last': 'node_id_3'
+                    },
+                    'versions': {
+                        'first': '51',
+                        'last': '52'
                     }
                 }, {
                     'cpp_guard': None,
@@ -124,12 +128,70 @@ OUT_PROBE_DATA = {
                     'revisions': {
                         'first': 'node_id_1',
                         'last': 'node_id_1'
+                    },
+                    'versions': {
+                        'first': '50',
+                        'last': '50'
                     }
                 }
             ]
         },
         'name': 'TEST_HISTOGRAM_1',
         'type': 'histogram'
+    }
+}
+
+OUT_PROBE_DATA_BY_CHANNEL = {
+    'release': {
+        'histogram/TEST_HISTOGRAM_1': {
+            'history': {
+                'release': [
+                    {
+                        'cpp_guard': None,
+                        'description': 'A description.',
+                        'details': {
+                            'high': 10,
+                            'keyed': False,
+                            'kind': 'exponential',
+                            'low': 1,
+                            'n_buckets': 5
+                        },
+                        'expiry_version': '53.0',
+                        'optout': True,
+                        'revisions': {
+                            'first': 'node_id_2',
+                            'last': 'node_id_3',
+                        },
+                        'versions': {
+                            'first': '51',
+                            'last': '52'
+                        }
+                    }, {
+                        'cpp_guard': None,
+                        'description': 'A description.',
+                        'details': {
+                            'high': 10,
+                            'keyed': False,
+                            'kind': 'exponential',
+                            'low': 1,
+                            'n_buckets': 5
+                        },
+                        'expiry_version': '53.0',
+                        'optout': False,
+                        'revisions': {
+                            'first': 'node_id_1',
+                            'last': 'node_id_1',
+                        },
+                        'versions': {
+                            'first': '50',
+                            'last': '50'
+                        }
+                    }
+                ],
+            },
+            'name': 'TEST_HISTOGRAM_1',
+            'type': 'histogram'
+        }
     }
 }
 
@@ -143,10 +205,19 @@ def test_probes_equal():
     assert(transform.probes_equal('histogram', histogram_node2, histogram_node3))
 
 
-def test_transform():
-    result = transform.transform(IN_PROBE_DATA, IN_NODE_DATA)
+def test_transform_monolithic():
+    result = transform.transform(IN_PROBE_DATA, IN_NODE_DATA, False)
 
     pp = pprint.PrettyPrinter(indent=2)
     print "\nresult:"
     pp.pprint(result)
-    assert(result == OUT_PROBE_DATA)
+    assert(result == OUT_PROBE_DATA_MONOLITHIC)
+
+
+def test_transform_by_channel():
+    result = transform.transform(IN_PROBE_DATA, IN_NODE_DATA, True)
+
+    pp = pprint.PrettyPrinter(indent=2)
+    print "\nresult:"
+    pp.pprint(result)
+    assert(result == OUT_PROBE_DATA_BY_CHANNEL)


### PR DESCRIPTION
This adds a new output mode, alongside the existing one, which allows to write one file for each release channel. Each individual file contains only the probes for that channel.

This adds the output generator for #23 . 