### PR TITLE
Update the scalar parser and disable strict type checks

### DIFF
--- a/probe_scraper/parsers/scalars.py
+++ b/probe_scraper/parsers/scalars.py
@@ -29,7 +29,7 @@ class ScalarsParser:
         if len(filenames) > 1:
             raise Exception('We don\'t support loading from more than one file.')
 
-        scalars = parse_scalars.load_scalars(filenames[0])
+        scalars = parse_scalars.load_scalars(filenames[0], strict_type_checks=False)
 
         # Get the probe information in a standard format.
         return transform_scalar_info(scalars)

--- a/probe_scraper/parsers/third_party/parse_scalars.py
+++ b/probe_scraper/parsers/third_party/parse_scalars.py
@@ -4,35 +4,33 @@
 
 import re
 import yaml
-from shared_telemetry_utils import add_expiration_postfix
+import shared_telemetry_utils as utils
+
+from shared_telemetry_utils import ParserError
 
 # The map of containing the allowed scalar types and their mapping to
-# nsITelemetry::SCALAR_* type constants.
+# nsITelemetry::SCALAR_TYPE_* type constants.
+
+BASE_DOC_URL = 'https://firefox-source-docs.mozilla.org/toolkit/components/' + \
+               'telemetry/telemetry/collection/scalars.html'
+
 SCALAR_TYPES_MAP = {
-    'uint': 'nsITelemetry::SCALAR_COUNT',
-    'string': 'nsITelemetry::SCALAR_STRING',
-    'boolean': 'nsITelemetry::SCALAR_BOOLEAN'
+    'uint': 'nsITelemetry::SCALAR_TYPE_COUNT',
+    'string': 'nsITelemetry::SCALAR_TYPE_STRING',
+    'boolean': 'nsITelemetry::SCALAR_TYPE_BOOLEAN'
 }
 
-# This is a list of flags that determine which process the scalar is allowed
-# to record from.
-KNOWN_PROCESS_FLAGS = {
-    'all': 'RecordedProcessType::All',
-    'all_childs': 'RecordedProcessType::AllChilds',
-    'main': 'RecordedProcessType::Main',
-    'content': 'RecordedProcessType::Content',
-    'gpu': 'RecordedProcessType::Gpu',
-}
 
 class ScalarType:
     """A class for representing a scalar definition."""
 
-    def __init__(self, group_name, probe_name, definition):
+    def __init__(self, category_name, probe_name, definition, strict_type_checks):
         # Validate and set the name, so we don't need to pass it to the other
         # validation functions.
-        self.validate_names(group_name, probe_name)
+        self._strict_type_checks = strict_type_checks
+        self.validate_names(category_name, probe_name)
         self._name = probe_name
-        self._group_name = group_name
+        self._category_name = category_name
 
         # Validating the scalar definition.
         self.validate_types(definition)
@@ -40,39 +38,41 @@ class ScalarType:
 
         # Everything is ok, set the rest of the data.
         self._definition = definition
-        definition['expires'] = add_expiration_postfix(definition['expires'])
+        self._expires = utils.add_expiration_postfix(definition['expires'])
 
-    def validate_names(self, group_name, probe_name):
-        """Validate the group and probe name:
-            - Group name must be alpha-numeric + '.', no leading/trailing digit or '.'.
+    def validate_names(self, category_name, probe_name):
+        """Validate the category and probe name:
+            - Category name must be alpha-numeric + '.', no leading/trailing digit or '.'.
             - Probe name must be alpha-numeric + '_', no leading/trailing digit or '_'.
 
-        :param group_name: the name of the group the probe is in.
+        :param category_name: the name of the category the probe is in.
         :param probe_name: the name of the scalar probe.
-        :raises ValueError: if the length of the names exceeds the limit or they don't
+        :raises ParserError: if the length of the names exceeds the limit or they don't
                 conform our name specification.
         """
 
-        # Enforce a maximum length on group and probe names.
+        # Enforce a maximum length on category and probe names.
         MAX_NAME_LENGTH = 40
-        for n in [group_name, probe_name]:
+        for n in [category_name, probe_name]:
             if len(n) > MAX_NAME_LENGTH:
-                raise ValueError("Name '{}' exceeds maximum name length of {} characters."\
-                                .format(n, MAX_NAME_LENGTH))
+                raise ParserError(("Name '{}' exceeds maximum name length of {} characters.\n"
+                                   "See: {}#the-yaml-definition-file")
+                                  .format(n, MAX_NAME_LENGTH, BASE_DOC_URL))
 
         def check_name(name, error_msg_prefix, allowed_char_regexp):
             # Check if we only have the allowed characters.
             chars_regxp = r'^[a-zA-Z0-9' + allowed_char_regexp + r']+$'
             if not re.search(chars_regxp, name):
-                raise ValueError(error_msg_prefix + " name must be alpha-numeric. Got: '{}'".format(name))
+                raise ParserError((error_msg_prefix + " name must be alpha-numeric. Got: '{}'.\n"
+                                  "See: {}#the-yaml-definition-file").format(name, BASE_DOC_URL))
 
             # Don't allow leading/trailing digits, '.' or '_'.
             if re.search(r'(^[\d\._])|([\d\._])$', name):
-                raise ValueError(error_msg_prefix +
-                    " name must not have a leading/trailing digit, a dot or underscore. Got: '{}'"\
-                    .format(name))
+                raise ParserError((error_msg_prefix + " name must not have a leading/trailing "
+                                   "digit, a dot or underscore. Got: '{}'.\n"
+                                   " See: {}#the-yaml-definition-file").format(name, BASE_DOC_URL))
 
-        check_name(group_name, 'Group', r'\.')
+        check_name(category_name, 'Category', r'\.')
         check_name(probe_name, 'Probe', r'_')
 
     def validate_types(self, definition):
@@ -81,24 +81,27 @@ class ScalarType:
             - Checks that all the fields have the expected types.
 
         :param definition: the dictionary containing the scalar properties.
-        :raises TypeError: if a scalar definition field is of the wrong type.
-        :raise KeyError: if a required field is missing or unknown fields are present.
+        :raises ParserError: if a scalar definition field is of the wrong type.
+        :raises ParserError: if a required field is missing or unknown fields are present.
         """
+
+        if not self._strict_type_checks:
+            return
 
         # The required and optional fields in a scalar type definition.
         REQUIRED_FIELDS = {
-            'bug_numbers': list, # This contains ints. See LIST_FIELDS_CONTENT.
+            'bug_numbers': list,  # This contains ints. See LIST_FIELDS_CONTENT.
             'description': basestring,
             'expires': basestring,
             'kind': basestring,
-            'notification_emails': list # This contains strings. See LIST_FIELDS_CONTENT.
+            'notification_emails': list,  # This contains strings. See LIST_FIELDS_CONTENT.
+            'record_in_processes': list,
         }
 
         OPTIONAL_FIELDS = {
             'cpp_guard': basestring,
             'release_channel_collection': basestring,
             'keyed': bool,
-            'record_in_processes': list,
         }
 
         # The types for the data within the fields that hold lists.
@@ -115,18 +118,23 @@ class ScalarType:
         # Checks that all the required fields are available.
         missing_fields = [f for f in REQUIRED_FIELDS.keys() if f not in definition]
         if len(missing_fields) > 0:
-            raise KeyError(self._name + ' - missing required fields: ' + ', '.join(missing_fields))
+            raise ParserError(self._name + ' - missing required fields: ' +
+                              ', '.join(missing_fields) +
+                              '.\nSee: {}#required-fields'.format(BASE_DOC_URL))
 
         # Do we have any unknown field?
         unknown_fields = [f for f in definition.keys() if f not in ALL_FIELDS]
         if len(unknown_fields) > 0:
-            raise KeyError(self._name + ' - unknown fields: ' + ', '.join(unknown_fields))
+            raise ParserError(self._name + ' - unknown fields: ' + ', '.join(unknown_fields) +
+                              '.\nSee: {}#required-fields'.format(BASE_DOC_URL))
 
         # Checks the type for all the fields.
-        wrong_type_names = ['{} must be {}'.format(f, ALL_FIELDS[f].__name__) \
-            for f in definition.keys() if not isinstance(definition[f], ALL_FIELDS[f])]
+        wrong_type_names = ['{} must be {}'.format(f, ALL_FIELDS[f].__name__)
+                            for f in definition.keys()
+                            if not isinstance(definition[f], ALL_FIELDS[f])]
         if len(wrong_type_names) > 0:
-            raise TypeError(self._name + ' - ' + ', '.join(wrong_type_names))
+            raise ParserError(self._name + ' - ' + ', '.join(wrong_type_names) +
+                              '.\nSee: {}#required-fields'.format(BASE_DOC_URL))
 
         # Check that the lists are not empty and that data in the lists
         # have the correct types.
@@ -134,42 +142,58 @@ class ScalarType:
         for field in list_fields:
             # Check for empty lists.
             if len(definition[field]) == 0:
-                raise TypeError("Field '{}' for probe '{}' must not be empty."
-                                .format(field, self._name))
+                raise ParserError(("Field '{}' for probe '{}' must not be empty" +
+                                   ".\nSee: {}#required-fields)")
+                                  .format(field, self._name, BASE_DOC_URL))
             # Check the type of the list content.
             broken_types =\
                 [not isinstance(v, LIST_FIELDS_CONTENT[field]) for v in definition[field]]
             if any(broken_types):
-                raise TypeError("Field '{}' for probe '{}' must only contain values of type {}"
-                                .format(field, self._name, LIST_FIELDS_CONTENT[field].__name__))
+                raise ParserError(("Field '{}' for probe '{}' must only contain values of type {}"
+                                   ".\nSee: {}#the-yaml-definition-file)")
+                                  .format(field, self._name, LIST_FIELDS_CONTENT[field].__name__,
+                                          BASE_DOC_URL))
 
     def validate_values(self, definition):
         """This function checks that the fields have the correct values.
 
         :param definition: the dictionary containing the scalar properties.
-        :raises ValueError: if a scalar definition field contains an unexpected value.
+        :raises ParserError: if a scalar definition field contains an unexpected value.
         """
+
+        if not self._strict_type_checks:
+            return
 
         # Validate the scalar kind.
         scalar_kind = definition.get('kind')
         if scalar_kind not in SCALAR_TYPES_MAP.keys():
-            raise ValueError(self._name + ' - unknown scalar kind: ' + scalar_kind)
+            raise ParserError(self._name + ' - unknown scalar kind: ' + scalar_kind +
+                              '.\nSee: {}'.format(BASE_DOC_URL))
 
         # Validate the collection policy.
         collection_policy = definition.get('release_channel_collection', None)
         if collection_policy and collection_policy not in ['opt-in', 'opt-out']:
-            raise ValueError(self._name + ' - unknown collection policy: ' + collection_policy)
+            raise ParserError(self._name + ' - unknown collection policy: ' + collection_policy +
+                              '.\nSee: {}#optional-fields'.format(BASE_DOC_URL))
 
         # Validate the cpp_guard.
         cpp_guard = definition.get('cpp_guard')
         if cpp_guard and re.match(r'\W', cpp_guard):
-            raise ValueError(self._name + ' - invalid cpp_guard: ' + cpp_guard)
+            raise ParserError(self._name + ' - invalid cpp_guard: ' + cpp_guard +
+                              '.\nSee: {}#optional-fields'.format(BASE_DOC_URL))
 
         # Validate record_in_processes.
         record_in_processes = definition.get('record_in_processes', [])
         for proc in record_in_processes:
-            if proc not in KNOWN_PROCESS_FLAGS.keys():
-                raise ValueError(self._name + ' - unknown value in record_in_processes: ' + proc)
+            if not utils.is_valid_process_name(proc):
+                raise ParserError(self._name + ' - unknown value in record_in_processes: ' + proc +
+                                  '.\nSee: {}'.format(BASE_DOC_URL))
+
+        # Validate the expiration version.
+        expires = definition.get('expires')
+        if not utils.validate_expiration_version(expires):
+            raise ParserError('{} - invalid expires: {}.\nSee: {}#required-fields'
+                              .format(self._name, expires, BASE_DOC_URL))
 
     @property
     def name(self):
@@ -178,12 +202,12 @@ class ScalarType:
 
     @property
     def label(self):
-        """Get the scalar label generated from the scalar and group names."""
-        return self._group_name + '.' + self._name
+        """Get the scalar label generated from the scalar and category names."""
+        return self._category_name + '.' + self._name
 
     @property
     def enum_label(self):
-        """Get the enum label generated from the scalar and group names. This is used to
+        """Get the enum label generated from the scalar and category names. This is used to
         generate the enum tables."""
 
         # The scalar name can contain informations about its hierarchy (e.g. 'a.b.scalar').
@@ -204,7 +228,7 @@ class ScalarType:
     @property
     def expires(self):
         """Get the scalar expiration"""
-        return self._definition['expires']
+        return self._expires
 
     @property
     def kind(self):
@@ -229,12 +253,14 @@ class ScalarType:
     @property
     def record_in_processes(self):
         """Get the non-empty list of processes to record data in"""
-        return self._definition.get('record_in_processes', ['main'])
+        # Before we added content process support in bug 1278556, we only recorded in the
+        # main process.
+        return self._definition.get('record_in_processes', ["main"])
 
     @property
     def record_in_processes_enum(self):
         """Get the non-empty list of flags representing the processes to record data in"""
-        return [KNOWN_PROCESS_FLAGS.get(p) for p in self.record_in_processes]
+        return [utils.process_name_to_enum(p) for p in self.record_in_processes]
 
     @property
     def dataset(self):
@@ -243,21 +269,24 @@ class ScalarType:
         """
         # The collection policy is optional, but we still define a default
         # behaviour for it.
-        release_channel_collection = \
-            self._definition.get('release_channel_collection', 'opt-in')
-        return 'nsITelemetry::' +  ('DATASET_RELEASE_CHANNEL_OPTOUT' \
-            if release_channel_collection == 'opt-out' else 'DATASET_RELEASE_CHANNEL_OPTIN')
+        rcc = self._definition.get('release_channel_collection', 'opt-in')
+        table = {
+            'opt-in': 'OPTIN',
+            'opt-out': 'OPTOUT',
+        }
+        return 'nsITelemetry::DATASET_RELEASE_CHANNEL_' + table[rcc]
 
     @property
     def cpp_guard(self):
         """Get the cpp guard for this scalar"""
         return self._definition.get('cpp_guard')
 
-def load_scalars(filename):
+
+def load_scalars(filename, strict_type_checks=True):
     """Parses a YAML file containing the scalar definition.
 
     :param filename: the YAML file containing the scalars definition.
-    :raises Exception: if the scalar file cannot be opened or parsed.
+    :raises ParserError: if the scalar file cannot be opened or parsed.
     """
 
     # Parse the scalar definitions from the YAML file.
@@ -266,25 +295,28 @@ def load_scalars(filename):
         with open(filename, 'r') as f:
             scalars = yaml.safe_load(f)
     except IOError, e:
-        raise Exception('Error opening ' + filename + ': ' + e.message)
+        raise ParserError('Error opening ' + filename + ': ' + e.message)
     except ValueError, e:
-        raise Exception('Error parsing scalars in ' + filename + ': ' + e.message)
+        raise ParserError('Error parsing scalars in {}: {}'
+                          '.\nSee: {}'.format(filename, e.message, BASE_DOC_URL))
 
     scalar_list = []
 
     # Scalars are defined in a fixed two-level hierarchy within the definition file.
-    # The first level contains the group name, while the second level contains the
-    # probe name (e.g. "group.name: probe: ...").
-    for group_name in scalars:
-        group = scalars[group_name]
+    # The first level contains the category name, while the second level contains the
+    # probe name (e.g. "category.name: probe: ...").
+    for category_name in scalars:
+        category = scalars[category_name]
 
-        # Make sure that the group has at least one probe in it.
-        if not group or len(group) == 0:
-            raise ValueError(group_name + ' must have at least a probe in it')
+        # Make sure that the category has at least one probe in it.
+        if not category or len(category) == 0:
+            raise ParserError('Category "{}" must have at least one probe in it' +
+                              '.\nSee: {}'.format(category_name, BASE_DOC_URL))
 
-        for probe_name in group:
+        for probe_name in category:
             # We found a scalar type. Go ahead and parse it.
-            scalar_info = group[probe_name]
-            scalar_list.append(ScalarType(group_name, probe_name, scalar_info))
+            scalar_info = category[probe_name]
+            scalar_list.append(
+                ScalarType(category_name, probe_name, scalar_info, strict_type_checks))
 
     return scalar_list

--- a/probe_scraper/parsers/third_party/shared_telemetry_utils.py
+++ b/probe_scraper/parsers/third_party/shared_telemetry_utils.py
@@ -8,6 +8,8 @@
 from __future__ import print_function
 
 import re
+import yaml
+import sys
 
 # This is a list of flags that determine which process a measurement is allowed
 # to record from.
@@ -20,6 +22,35 @@ KNOWN_PROCESS_FLAGS = {
 }
 
 PROCESS_ENUM_PREFIX = "mozilla::Telemetry::Common::RecordedProcessType::"
+
+
+class ParserError(Exception):
+    """Thrown by different probe parsers. Errors are partitioned into
+    'immediately fatal' and 'eventually fatal' so that the parser can print
+    multiple error messages at a time. See bug 1401612 ."""
+
+    eventual_errors = []
+
+    def __init__(self, *args):
+        Exception.__init__(self, *args)
+
+    def handle_later(self):
+        ParserError.eventual_errors.append(self)
+
+    def handle_now(self):
+        ParserError.print_eventuals()
+        print(self.message, file=sys.stderr)
+        sys.exit(1)
+
+    @classmethod
+    def print_eventuals(cls):
+        while cls.eventual_errors:
+            print(cls.eventual_errors.pop(0).message, file=sys.stderr)
+
+    @classmethod
+    def exit_func(cls):
+        if cls.eventual_errors:
+            cls("Some errors occurred").handle_now()
 
 
 def is_valid_process_name(name):
@@ -90,7 +121,8 @@ class StringTable:
         f.write("const char %s[] = {\n" % name)
         for (string, offset) in entries:
             if "*/" in string:
-                raise ValueError, "String in string table contains unexpected sequence '*/': %s" % string
+                raise ValueError("String in string table contains unexpected sequence '*/': %s" %
+                                 string)
 
             e = explodeToCharArray(string)
             if e:
@@ -111,6 +143,21 @@ def static_assert(output, expression, message):
     print("static_assert(%s, \"%s\");" % (expression, message), file=output)
 
 
+def validate_expiration_version(expiration):
+    """ Makes sure the expiration version has the expected format.
+
+    Allowed examples: "1.0", "20", "300.0a1", "60.0a1", "30.5a1", "never"
+    Disallowed examples: "Never", "asd", "4000000", "60a1"
+
+    :param expiration: the expiration version string.
+    :return: True if the expiration validates correctly, False otherwise.
+    """
+    if expiration != 'never' and not re.match(r'^\d{1,3}(\.\d|\.\da1)?$', expiration):
+        return False
+
+    return True
+
+
 def add_expiration_postfix(expiration):
     """ Formats the expiration version and adds a version postfix if needed.
 
@@ -124,3 +171,15 @@ def add_expiration_postfix(expiration):
         return expiration + "a1"
 
     return expiration
+
+
+def load_yaml_file(filename):
+    """ Load a YAML file from disk, throw a ParserError on failure."""
+    try:
+        with open(filename, 'r') as f:
+            return yaml.safe_load(f)
+    except IOError, e:
+        raise ParserError('Error opening ' + filename + ': ' + e.message)
+    except ValueError, e:
+        raise ParserError('Error parsing processes in {}: {}'
+                          .format(filename, e.message))


### PR DESCRIPTION
This fixes the parser complaining about the scalar definitions containing the "all_children" entry.

This was tested on ATMO. Sample output is available [here](https://drive.google.com/file/d/18c6TtKvl_5GdIR4QPEYbh8epi5UvJ6OF/view?usp=sharing).