### PR TITLE
Drop the ".json" extension from all the files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The code layout consists mainly of:
 ## File formats
 This scraper generates three different JSON file types.
 
-### `revisions.json`
+### `revisions`
 This file contains the revision hashes of the changesets the probe files were scraped. These hashes are mapped to an human-readable version string.
 
 ```
@@ -63,7 +63,7 @@ This file contains the revision hashes of the changesets the probe files were sc
 }
 ```
 
-### `general.json`
+### `general`
 This file contains general properties related to the scraping process. As of today, it only contains the `lastUpdate` property, which is the day and time the scraping was performed, in ISO 8601 format.
 
 ```
@@ -147,8 +147,8 @@ Please refer to the Telemetry data collection [documentation](https://firefox-so
 The processed probe data is serialized to the disk in a directory hierarchy starting from the provided output directory. The directory layout resembles a REST-friendly structure.
 
     |-- product
-        |-- general.json
-        |-- revisions.json
+        |-- general
+        |-- revisions
         |-- channel (or "all")
             |-- ping type
                 |-- probe type (or "all_probes")

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -59,8 +59,8 @@ def write_probe_data(probe_data, revisions, out_dir):
     base_dir = os.path.join(out_dir, "firefox")
 
     print "\nwriting output:"
-    dump_json(general_data(), base_dir, 'general.json')
-    dump_json(revisions, base_dir, 'revisions.json')
+    dump_json(general_data(), base_dir, 'general')
+    dump_json(revisions, base_dir, 'revisions')
 
     # Break down the output by channel. We don't need to write a revisions
     # file in this case, the probe data will contain human readable version


### PR DESCRIPTION
This specifically removes the ".json" extension from the "general.json" and "revisions.json" files. Fixes #35 