### PR TITLE
Extract descriptions from the parsed events

### DIFF
--- a/probe_scraper/parsers/events.py
+++ b/probe_scraper/parsers/events.py
@@ -27,7 +27,7 @@ def extract_events_data(e):
         "expiry_version": "never",
         "expiry_day": "never",
         "name": e.methods[0],
-        "description": "<TODO>",
+        "description": e.description,
         "cpp_guard": None,
     }
 

--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -222,6 +222,10 @@ class EventData:
         return convert_to_cpp_identifier(self._category, ".")
 
     @property
+    def description(self):
+        return self._definition.get('description')
+
+    @property
     def name(self):
         return self._name
 


### PR DESCRIPTION
This PR enables extracting event descriptions from event data. I've tested it locally and no error is thrown during the execution. The output for `all_probes` looks like this (see the `description` entry):

```json
{
  "event/activity_stream.end#end": {
    "history": {
      "nightly": [
        {
          "cpp_guard": null, 
          "description": "This is recorded with every session ended in Activity Stream.\n", 
          "details": {
            "extra_keys": [
              "user_prefs", 
              "addon_version", 
              "page", 
              "session_id"
            ], 
            "methods": [
              "end"
            ], 
            "objects": [
              "session"
            ], 
            "record_in_processes": [
              "main"
            ]
          }, 
          "expiry_day": 0, 
          "expiry_version": "never", 
          "optout": true, 
          "revisions": {
            "first": "9b69cc60e5848f2f8802c911fd00771b50eed41f", 
            "last": "9b69cc60e5848f2f8802c911fd00771b50eed41f"
          }, 
          "versions": {
            "first": "59", 
            "last": "59"
          }
        }
      ]
    }, 
    "name": "activity_stream.end#end", 
    "type": "event"
  }, 
```

This fixes #7 .