### PR TITLE
Parse and deploy repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ _out/
 _temp/
 
 *.json
+!schemas/*.json

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import jsonschema
 import yaml
@@ -12,6 +16,9 @@ EVENT_KEY = "event"
 
 
 class Repository(object):
+    """
+    A class representing a repository, read in from `repositories.yaml`
+    """
 
     def __init__(self, name, definition):
         self.name = name
@@ -44,6 +51,9 @@ class Repository(object):
 
 
 class RepositoriesParser(object):
+    """
+    A parser for `repositories.yaml` files, which both validates and retrieves Repository objects
+    """
 
     def _get_repos(self, filename=None):
         if filename is None:

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -1,0 +1,73 @@
+import json
+import jsonschema
+import yaml
+
+
+REPOSITORIES_FILENAME = "repositories.yaml"
+REPOSITORIES_SCHEMA = "schemas/repositories.json"
+
+HISTOGRAM_KEY = "histogram"
+SCALAR_KEY = "scalar"
+EVENT_KEY = "event"
+
+
+class Repository(object):
+
+    def __init__(self, name, definition):
+        self.name = name
+        self.url = definition.get("url")
+        self.notification_emails = definition.get("notification_emails")
+        self.app_name = definition.get("app_name")
+        self.os = definition.get("os")
+        self.histogram_file_paths = definition.get("histogram_file_paths", [])
+        self.scalar_file_paths = definition.get("scalar_file_paths", [])
+        self.event_file_paths = definition.get("event_file_paths", [])
+
+    def get_probe_paths(self):
+        return (self.get_histogram_paths() +
+                self.get_scalar_paths() +
+                self.get_event_paths())
+
+    def get_histogram_paths(self):
+        return [(HISTOGRAM_KEY, p) for p in self.histogram_file_paths]
+
+    def get_scalar_paths(self):
+        return [(SCALAR_KEY, p) for p in self.scalar_file_paths]
+
+    def get_event_paths(self):
+        return [(EVENT_KEY, p) for p in self.event_file_paths]
+
+    def to_dict(self):
+        # Remove null elements
+        # https://google.github.io/styleguide/jsoncstyleguide.xml#Empty/Null_Property_Values
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
+class RepositoriesParser(object):
+
+    def _get_repos(self, filename=None):
+        if filename is None:
+            filename = REPOSITORIES_FILENAME
+
+        with open(filename, 'r') as f:
+            repos = yaml.load(f)
+
+        return repos
+
+    def validate(self, filename=None):
+        repos = self._get_repos(filename)
+
+        with open(REPOSITORIES_SCHEMA, 'r') as f:
+            schema = json.load(f)
+
+        jsonschema.validate(repos, schema)
+
+    def parse(self, filename=None):
+        self.validate(filename)
+        repos = self._get_repos(filename)
+
+        return [
+            Repository(name, definition)
+            for name, definition
+            in repos.items()
+        ]

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -89,9 +89,9 @@ def write_external_probe_data(repo_data, out_dir):
         dump_json(probe_data, data_dir, "all_probes")
 
 
-def write_repositories_data(repos):
+def write_repositories_data(repos, out_dir):
     json_data = [r.to_dict() for r in repos]
-    dump_json(json_data, "mobile-metrics", "repositories")
+    dump_json(json_data, os.path.join(out_dir, "mobile-metrics"), "repositories")
 
 
 def load_moz_central_probes(cache_dir, out_dir):
@@ -182,10 +182,7 @@ def load_git_probes(cache_dir, out_dir, repositories_file, dry_run):
 
     write_external_probe_data(probes_by_repo, out_dir)
 
-    write_repositories_data(repositories)
-
-    print "Emails"
-    print emails
+    write_repositories_data(repositories, out_dir)
 
     for repo_name, email_info in emails.items():
         addresses = email_info["addresses"] + [DEFAULT_TO_EMAIL]

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -16,6 +16,7 @@ from emailer import send_ses
 from parsers.events import EventsParser
 from parsers.histograms import HistogramsParser
 from parsers.scalars import ScalarsParser
+from parsers.repositories import RepositoriesParser
 from scrapers import git_scraper, moz_central_scraper
 from schema import And, Optional, Schema
 import transform_probes
@@ -144,8 +145,8 @@ def check_git_probe_structure(data):
 
 
 def load_git_probes(cache_dir, out_dir, repositories_file, dry_run):
-    commit_timestamps, repos_probes_data, emails, repositories = \
-        git_scraper.scrape(cache_dir, repositories_file)
+    repositories = RepositoriesParser().parse(repositories_file)
+    commit_timestamps, repos_probes_data, emails = git_scraper.scrape(cache_dir, repositories)
 
     check_git_probe_structure(repos_probes_data)
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -89,6 +89,11 @@ def write_external_probe_data(repo_data, out_dir):
         dump_json(probe_data, data_dir, "all_probes")
 
 
+def write_repositories_data(repos):
+    json_data = [r.to_dict() for r in repos]
+    dump_json(json_data, "mobile-metrics", "repositories")
+
+
 def load_moz_central_probes(cache_dir, out_dir):
     # Scrape probe data from repositories.
     node_data = moz_central_scraper.scrape(cache_dir)
@@ -139,7 +144,8 @@ def check_git_probe_structure(data):
 
 
 def load_git_probes(cache_dir, out_dir, repositories_file, dry_run):
-    commit_timestamps, repos_probes_data, emails = git_scraper.scrape(cache_dir, repositories_file)
+    commit_timestamps, repos_probes_data, emails, repositories = \
+        git_scraper.scrape(cache_dir, repositories_file)
 
     check_git_probe_structure(repos_probes_data)
 
@@ -176,6 +182,11 @@ def load_git_probes(cache_dir, out_dir, repositories_file, dry_run):
 
     write_external_probe_data(probes_by_repo, out_dir)
 
+    write_repositories_data(repositories)
+
+    print "Emails"
+    print emails
+
     for repo_name, email_info in emails.items():
         addresses = email_info["addresses"] + [DEFAULT_TO_EMAIL]
         for email in email_info["emails"]:
@@ -188,6 +199,7 @@ def main(cache_dir,
          process_git_probes,
          repositories_file,
          dry_run):
+
     process_both = not (process_moz_central_probes or process_git_probes)
     if process_moz_central_probes or process_both:
         load_moz_central_probes(cache_dir, out_dir)

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -4,7 +4,6 @@
 
 from collections import defaultdict
 from git import Repo
-from probe_scraper.parsers.repositories import RepositoriesParser
 import os
 import shutil
 import tempfile
@@ -56,7 +55,7 @@ def retrieve_files(repo_info, cache_dir):
     return timestamps, results
 
 
-def scrape(folder=None, repositories_file=None):
+def scrape(folder=None, repos=None):
     """
     Returns two data structures. The first is the commit timestamps:
     {
@@ -81,11 +80,8 @@ def scrape(folder=None, repositories_file=None):
     if folder is None:
         folder = tempfile.mkdtemp()
 
-    repo_parser = RepositoriesParser()
-
     results = {}
     timestamps = {}
-    repos = repo_parser.parse(repositories_file)
     emails = {}
 
     for repo_info in repos:
@@ -102,4 +98,4 @@ def scrape(folder=None, repositories_file=None):
                 "message": traceback.format_exc()
             })
 
-    return timestamps, results, emails, repos
+    return timestamps, results, emails

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 boto3
 GitPython
 python-dateutil
+jsonschema
 pyyaml
 requests
 requests_cache

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/schema#", 
+  "additionalProperties": {
+    "properties": {
+      "app_name": {
+        "type": "string"
+      },
+      "os": {
+        "type": "string"
+      },
+      "notification_emails": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "url": {
+        "type": "string",
+        "format": "uri"
+      },
+      "histogram_file_paths": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "(json|yaml)$"
+        }
+      },
+      "scalar_file_paths": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "yaml$"
+        }
+      },
+      "event_file_paths": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "yaml$"
+        }
+      }
+    },
+    "required": [
+      "url",
+      "notification_emails"
+    ],
+    "type": "object"
+  },
+  "type": "object"
+}

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -1,0 +1,62 @@
+from probe_scraper.parsers.repositories import RepositoriesParser
+import pytest
+import jsonschema
+import yaml
+import tempfile
+import os
+
+
+def write_to_temp_file(data):
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, 'w') as tmp:
+        tmp.write(yaml.dump(data))
+    return path
+
+
+@pytest.fixture
+def parser():
+    return RepositoriesParser()
+
+
+@pytest.fixture
+def incorrect_repos_file():
+    data = {
+        "some_repo": {
+            # missing `notification_emails`
+            "url": "www.github.com/fbertsch/mobile-metrics-example"
+        }
+    }
+
+    return write_to_temp_file(data)
+
+
+@pytest.fixture
+def correct_repos_file():
+    data = {
+        "test-repo": {
+            "url": "www.github.com/fbertsch/mobile-metrics-example",
+            "notification_emails": ["frank@mozilla.com"],
+            "histogram_file_paths": ["Histograms.json", "other/Histograms.json"]
+        }
+    }
+
+    return write_to_temp_file(data)
+
+
+def test_repositories(parser):
+    parser.validate()
+
+
+def test_repositories_parser_correct(parser, incorrect_repos_file):
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        parser.validate(incorrect_repos_file)
+
+
+def test_repositories_class(parser, correct_repos_file):
+    repos = parser.parse(correct_repos_file)
+
+    assert len(repos) == 1
+    assert set(repos[0].get_probe_paths()) == {
+        ("histogram", "Histograms.json"),
+        ("histogram", "other/Histograms.json")
+    }


### PR DESCRIPTION
There are a few related changes:
- New classes for parsing `repositories.yaml` and representing
  a repository
- A jsonschema for the `repositories.yaml` file
- A test (so the build fails) for the master `repositories.yaml` file
- Deploy of the `repositories.json` data

That last one will serve as the centralized location of
(appName, os) pairs for all of the ingestion pipeline.