### PR TITLE
Don't validate object and method names if strict mode is disabled

### DIFF
--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -166,14 +166,15 @@ class EventData:
         type_check_event_fields(self.identifier, name, definition, strict_type_checks)
 
         # Check method & object string patterns.
-        for method in self.methods:
-            string_check(self.identifier, field='methods', value=method,
-                         min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
-                         regex=IDENTIFIER_PATTERN)
-        for obj in self.objects:
-            string_check(self.identifier, field='objects', value=obj,
-                         min_length=1, max_length=MAX_OBJECT_NAME_LENGTH,
-                         regex=IDENTIFIER_PATTERN)
+        if strict_type_checks:
+            for method in self.methods:
+                string_check(self.identifier, field='methods', value=method,
+                             min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
+                             regex=IDENTIFIER_PATTERN)
+            for obj in self.objects:
+                string_check(self.identifier, field='objects', value=obj,
+                             min_length=1, max_length=MAX_OBJECT_NAME_LENGTH,
+                             regex=IDENTIFIER_PATTERN)
 
         # Check release_channel_collection
         rcc_key = 'release_channel_collection'


### PR DESCRIPTION
Due to a bug in the client, we've been sending events that would fail to validate because their name would be too long. See [bug 1472627](https://bugzilla.mozilla.org/show_bug.cgi?id=1472627)