### PR TITLE
Revert "Add buckets enumeration to output"

### DIFF
--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -21,7 +21,6 @@ def extract_histogram_data(histogram):
         "keyed": "details/keyed",
         "kind": "details/kind",
         "record_in_processes": "details/record_in_processes",
-        "ranges": "details/buckets",
     }
 
     defaults = {
@@ -30,7 +29,6 @@ def extract_histogram_data(histogram):
         "expiration": "never",
         "bug_numbers": [],
         "alert_emails": [],
-        "ranges": [],
     }
 
     data = {

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -47,7 +47,6 @@ def probes_equal(probe1, probe2):
         "details/n_values",
         "details/low",
         "details/high",
-        "details/buckets",
         # Events.
         "details/methods",
         "details/objects",

--- a/tests/test_histogram_parser.py
+++ b/tests/test_histogram_parser.py
@@ -68,7 +68,7 @@ def test_histogram_parser():
     ]
 
     REQUIRED_DETAILS = [
-        "low", "high", "keyed", "kind", "n_buckets", "record_in_processes", "buckets"
+        "low", "high", "keyed", "kind", "n_buckets", "record_in_processes"
     ]
 
     for name, data in parsed_histograms.iteritems():


### PR DESCRIPTION
This reverts commit 665b1970a49f3459e60b54c11d80171d96283409.

Old `Histograms.json` contains things like "10000" or "16 * 1024 * 1024"
for fields like `low`, `high` or `n_values` (e.g. strings & expressions,
not numbers). See #9.

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1521742