### PR TITLE
[WIP] Glean support

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -13,6 +13,7 @@ REPOSITORIES_SCHEMA = "schemas/repositories.json"
 HISTOGRAM_KEY = "histogram"
 SCALAR_KEY = "scalar"
 EVENT_KEY = "event"
+GLEAN_KEY = "glean"
 
 
 class Repository(object):
@@ -29,8 +30,13 @@ class Repository(object):
         self.histogram_file_paths = definition.get("histogram_file_paths", [])
         self.scalar_file_paths = definition.get("scalar_file_paths", [])
         self.event_file_paths = definition.get("event_file_paths", [])
+        self.glean_file_paths = definition.get("glean_file_paths", [])
 
     def get_probe_paths(self):
+        glean_paths = self.get_glean_paths()
+        if (len(glean_paths) > 0):
+            return glean_paths
+
         return (self.get_histogram_paths() +
                 self.get_scalar_paths() +
                 self.get_event_paths())
@@ -43,6 +49,9 @@ class Repository(object):
 
     def get_event_paths(self):
         return [(EVENT_KEY, p) for p in self.event_file_paths]
+
+    def get_glean_paths(self):
+        return [(GLEAN_KEY, p) for p in self.glean_file_paths]
 
     def to_dict(self):
         # Remove null elements

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -38,6 +38,7 @@ PARSERS = {
     'histogram': HistogramsParser(),
     'scalar': ScalarsParser(),
     'event': EventsParser(),
+    'glean': DummyParser()
 }
 
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -136,7 +136,8 @@ def check_git_probe_structure(data):
             And(str, lambda x: len(x) == 40): {
                 Optional("histogram"): [And(str, lambda x: os.path.exists(x))],
                 Optional("event"): [And(str, lambda x: os.path.exists(x))],
-                Optional("scalar"): [And(str, lambda x: os.path.exists(x))]
+                Optional("scalar"): [And(str, lambda x: os.path.exists(x))],
+                Optional("glean"): [And(str, lambda x: os.path.exists(x))]
             }
         }
     })

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -11,3 +11,12 @@ mobile_metrics_example:
     - Histograms.json
   scalar_file_paths:
     - Scalars.yaml
+
+glean_android_example:
+  app_name: glean_android_sample
+  os: Android
+  notification_emails:
+    - aplacitelli@mozilla.com
+  url: 'https://github.com/mozilla-mobile/android-components'
+  glean_file_paths:
+    - samples/glean/metrics.yaml

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -39,6 +39,13 @@
           "type": "string",
           "pattern": "yaml$"
         }
+      },
+      "glean_file_paths": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "pattern": "yaml$"
+        }
       }
     },
     "required": [


### PR DESCRIPTION
This is the super basic thing that allows calling a glean parser from the scraper. The idea was to use the real  [glean parser](https://github.com/mozilla/glean_parser/) to get the metric info out. Ideally, one could write a new template for the probe-scraper format (like [this](https://github.com/mozilla/glean_parser/tree/master/glean_parser/templates) for the Kotlin code) and let the parser.. generate. @mdboom might know more about this or suggest better ways! :)