### PR TITLE
Add `first_added` date to probe-info-service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ install:
 before_script:
   - flake8 --max-line-length 100 .
 # command to run tests
-script: pytest tests
+script: pytest tests/ --run-web-tests

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The data is pulled from two different sources:
 
 A web tool to explore the data is available [here](https://telemetry.mozilla.org/probe-dictionary/).
 
+
 ## Adding a New Git Repository
 
 To scrape a git repository for probe definitions, an entry needs to be added in `repositories.yaml`.
@@ -36,15 +37,26 @@ pip install -r test_requirements.txt
 python setup.py develop
 ```
 
-Run tests:
+Run tests. This by default does not run tests that require a web connection:
 ```
-pytest
+pytest tests/
+```
+
+To run all tests, including those that require a web connection:
+```
+pytest tests/ --run-web-tests
 ```
 
 To test whether the code conforms to the style rules, you can run:
 ```
 flake8
 ```
+
+### Tests with Web Dependencies
+
+Any tests that require a web connection to run should be marked with `@pytest.mark.web_dependency`.
+
+These will not run by default, but will run on CI.
 
 ### Performing a Dry-Run
 
@@ -69,6 +81,7 @@ The code layout consists mainly of:
 - `probe_scraper`
   - `runner.py` - the central script, ties the other pieces together
   - `scrapers`
+     - `buildhub.py` - pull build info from the [BuildHub](https://buildhub.moz.tools) service
      - `moz_central_scraper.py` - loads probe registry files for multiple versions from mozilla-central
      - `git_scraper.py` - loads probe registry files from a git repository (no version or channel support yet, just per-commit)
   - `parsers/` - extract probe data from the registry files

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The data is pulled from two different sources:
 
 A web tool to explore the data is available [here](https://telemetry.mozilla.org/probe-dictionary/).
 
-
 ## Adding a New Git Repository
 
 To scrape a git repository for probe definitions, an entry needs to be added in `repositories.yaml`.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-web-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that require a web connection"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-web-tests"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_web = pytest.mark.skip(reason="Need --run-web-tests option to run")
+    for item in items:
+        if "web_dependency" in item.keywords:
+            item.add_marker(skip_web)

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,6 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--run-web-tests"):
-        # --runslow given in cli: do not skip slow tests
         return
     skip_web = pytest.mark.skip(reason="Need --run-web-tests option to run")
     for item in items:

--- a/probe_scraper/parsers/events.py
+++ b/probe_scraper/parsers/events.py
@@ -60,7 +60,7 @@ class EventsParser:
         # Events.yaml had a format change in 53, see bug 1329620.
         # We don't have important event usage yet, so lets skip
         # backwards compatibility for now.
-        if version and int(version) < 53:
+        if version and version < 53:
             return {}
 
         if len(filenames) > 1:

--- a/probe_scraper/parsers/events.py
+++ b/probe_scraper/parsers/events.py
@@ -56,11 +56,13 @@ def extract_events_data(e):
 
 
 class EventsParser:
-    def parse(self, filenames, version=None):
+    def parse(self, filenames, version=None, channel=None):
         # Events.yaml had a format change in 53, see bug 1329620.
         # We don't have important event usage yet, so lets skip
         # backwards compatibility for now.
-        if version and version < 53:
+        if (version and channel) and (
+          ((channel != "nightly" and version < 53)
+           or (channel == "nightly" and version < 54))):
             return {}
 
         if len(filenames) > 1:

--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -72,7 +72,7 @@ def transform_probe_info(probes):
 
 
 class HistogramsParser:
-    def parse(self, filenames, version=None):
+    def parse(self, filenames, version=None, channel=None):
         # Call the histogram tools for each file.
         parsed_probes = list(histogram_tools.from_files(filenames))
 

--- a/probe_scraper/parsers/scalars.py
+++ b/probe_scraper/parsers/scalars.py
@@ -34,7 +34,7 @@ def transform_scalar_info(probes):
 
 
 class ScalarsParser:
-    def parse(self, filenames, version=None):
+    def parse(self, filenames, version=None, channel=None):
         if len(filenames) > 1:
             raise Exception('We don\'t support loading from more than one file.')
 

--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -193,10 +193,10 @@ class EventData:
         # Check extra_keys.
         extra_keys = definition.get('extra_keys', {})
         if len(extra_keys.keys()) > MAX_EXTRA_KEYS_COUNT:
-            raise ValueError, "%s: number of extra_keys exceeds limit %d" %\
-                              (self.identifier, MAX_EXTRA_KEYS_COUNT)
+            raise ValueError("%s: number of extra_keys exceeds limit %d" %\
+                              (self.identifier, MAX_EXTRA_KEYS_COUNT))
         if strict_type_checks:
-            for key in extra_keys.iterkeys():
+            for key in extra_keys.keys():
                 string_check(self.identifier, field='extra_keys', value=key,
                              min_length=1, max_length=MAX_EXTRA_KEY_NAME_LENGTH,
                              regex=IDENTIFIER_PATTERN)
@@ -326,7 +326,7 @@ def load_events(filename, strict_type_checks=True):
     #       <event definition>
     #      ...
     #   ...
-    for category_name, category in events.iteritems():
+    for category_name, category in events.items():
         if(strict_type_checks):
             string_check("top level structure", field='category', value=category_name,
                          min_length=1, max_length=MAX_CATEGORY_NAME_LENGTH,
@@ -336,7 +336,7 @@ def load_events(filename, strict_type_checks=True):
         if strict_type_checks and not category or len(category) == 0:
             raise ValueError(category_name + ' must contain at least one entry')
 
-        for name, entry in category.iteritems():
+        for name, entry in category.items():
             if(strict_type_checks):
                 string_check(category_name, field='event name', value=name,
                              min_length=1, max_length=MAX_METHOD_NAME_LENGTH,

--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -325,19 +325,21 @@ def load_events(filename, strict_type_checks=True):
     #       <event definition>
     #      ...
     #   ...
-    for category_name, category in events.items():
-        string_check("top level structure", field='category', value=category_name,
-                     min_length=1, max_length=MAX_CATEGORY_NAME_LENGTH,
-                     regex=IDENTIFIER_PATTERN)
+    for category_name, category in events.iteritems():
+        if(strict_type_checks):
+            string_check("top level structure", field='category', value=category_name,
+                         min_length=1, max_length=MAX_CATEGORY_NAME_LENGTH,
+                         regex=IDENTIFIER_PATTERN)
 
         # Make sure that the category has at least one entry in it.
-        if not category or len(category) == 0:
+        if strict_type_checks and not category or len(category) == 0:
             raise ValueError(category_name + ' must contain at least one entry')
 
-        for name, entry in category.items():
-            string_check(category_name, field='event name', value=name,
-                         min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
-                         regex=IDENTIFIER_PATTERN)
+        for name, entry in category.iteritems():
+            if(strict_type_checks):
+                string_check(category_name, field='event name', value=name,
+                             min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
+                             regex=IDENTIFIER_PATTERN)
             event_list.append(EventData(category_name, name, entry,
                                         strict_type_checks=strict_type_checks))
 

--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -192,13 +192,14 @@ class EventData:
 
         # Check extra_keys.
         extra_keys = definition.get('extra_keys', {})
-        if len(list(extra_keys.keys())) > MAX_EXTRA_KEYS_COUNT:
-            raise ValueError("%s: number of extra_keys exceeds limit %d" %\
-                              (self.identifier, MAX_EXTRA_KEYS_COUNT))
-        for key in extra_keys.keys():
-            string_check(self.identifier, field='extra_keys', value=key,
-                         min_length=1, max_length=MAX_EXTRA_KEY_NAME_LENGTH,
-                         regex=IDENTIFIER_PATTERN)
+        if len(extra_keys.keys()) > MAX_EXTRA_KEYS_COUNT:
+            raise ValueError, "%s: number of extra_keys exceeds limit %d" %\
+                              (self.identifier, MAX_EXTRA_KEYS_COUNT)
+        if strict_type_checks:
+            for key in extra_keys.iterkeys():
+                string_check(self.identifier, field='extra_keys', value=key,
+                             min_length=1, max_length=MAX_EXTRA_KEY_NAME_LENGTH,
+                             regex=IDENTIFIER_PATTERN)
 
         # Check expiry.
         if not 'expiry_version' in definition and not 'expiry_date' in definition:

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -124,7 +124,7 @@ def parse_moz_central_probes(scraped_data):
 
 
 def add_first_appeared_dates(probes_by_channel, first_appeared_dates):
-    for channel, probes in list(probes_by_channel.items()):
+    for channel, probes in probes_by_channel.items():
         for probe_id, info in probes.items():
             if channel == "all":
                 dates = first_appeared_dates[probe_id]

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -117,7 +117,7 @@ def parse_moz_central_probes(scraped_data):
     for channel, revisions in scraped_data.iteritems():
         for revision, details in revisions.iteritems():
             for probe_type, paths in details["registries"].iteritems():
-                results = PARSERS[probe_type].parse(paths, details["version"])
+                results = PARSERS[probe_type].parse(paths, details["version"], channel)
                 probes[channel][revision][probe_type] = results
 
     return probes

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -114,9 +114,9 @@ def parse_moz_central_probes(scraped_data):
     """
 
     probes = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    for channel, revisions in scraped_data.iteritems():
-        for revision, details in revisions.iteritems():
-            for probe_type, paths in details["registries"].iteritems():
+    for channel, revisions in scraped_data.items():
+        for revision, details in revisions.items():
+            for probe_type, paths in details["registries"].items():
                 results = PARSERS[probe_type].parse(paths, details["version"], channel)
                 probes[channel][revision][probe_type] = results
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -99,8 +99,8 @@ def write_repositories_data(repos, out_dir):
 def parse_moz_central_probes(scraped_data):
     """
     Parse probe data from files into the form:
-    channel_name -> {
-      node_id -> {
+    channel_name: {
+      node_id: {
         histogram: {
           name: ...,
           ...

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -30,7 +30,8 @@ class DummyParser:
 
 FROM_EMAIL = "telemetry-alerts@mozilla.com"
 DEFAULT_TO_EMAIL = "dev-telemetry-alerts@mozilla.com"
-
+FIRST_APPEARED_DATE_KEY = "first_added"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 PARSERS = {
     # This lists the available probe registry parsers:
@@ -95,29 +96,55 @@ def write_repositories_data(repos, out_dir):
     dump_json(json_data, os.path.join(out_dir, "mobile-metrics"), "repositories")
 
 
-def load_moz_central_probes(cache_dir, out_dir):
-    # Scrape probe data from repositories.
-    node_data = moz_central_scraper.scrape(cache_dir)
+def parse_moz_central_probes(scraped_data):
+    """
+    Parse probe data from files into the form:
+    channel_name -> {
+      node_id -> {
+        histogram: {
+          name: ...,
+          ...
+        },
+        scalar: {
+          ...
+        },
+      },
+      ...
+    }
+    """
 
-    # Parse probe data from files into the form:
-    # channel_name -> {
-    #   node_id -> {
-    #     histogram: {
-    #       name: ...,
-    #       ...
-    #     },
-    #     scalar: {
-    #       ...
-    #     },
-    #   },
-    #   ...
-    # }
     probes = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    for channel, nodes in node_data.items():
-        for node_id, details in nodes.items():
-            for probe_type, paths in details['registries'].items():
+    for channel, revisions in scraped_data.iteritems():
+        for revision, details in revisions.iteritems():
+            for probe_type, paths in details["registries"].iteritems():
                 results = PARSERS[probe_type].parse(paths, details["version"])
-                probes[channel][node_id][probe_type] = results
+                probes[channel][revision][probe_type] = results
+
+    return probes
+
+
+def add_first_appeared_dates(probes_by_channel, first_appeared_dates):
+    for channel, probes in list(probes_by_channel.items()):
+        for probe_id, info in probes.items():
+            if channel == "all":
+                dates = first_appeared_dates[probe_id]
+            else:
+                dates = {k: v for k, v in first_appeared_dates[probe_id].items() if k == channel}
+
+            dates = {k: v.strftime(DATE_FORMAT) for k, v in dates.items()}
+            probes_by_channel[channel][probe_id][FIRST_APPEARED_DATE_KEY] = dates
+
+    return probes_by_channel
+
+
+def load_moz_central_probes(cache_dir, out_dir, fx_version):
+
+    # Scrape probe data from repositories.
+    node_data = moz_central_scraper.scrape(cache_dir,
+                                           min_fx_version=fx_version,
+                                           max_fx_version=fx_version)
+
+    probes = parse_moz_central_probes(node_data)
 
     # Transform extracted data: get both the monolithic and by channel probe data.
     revisions = transform_revisions.transform(node_data)
@@ -126,8 +153,22 @@ def load_moz_central_probes(cache_dir, out_dir):
     probes_by_channel["all"] = transform_probes.transform(probes, node_data,
                                                           break_by_channel=False)
 
+    # Scrape all revisions from buildhub
+    revision_data = moz_central_scraper.scrape_channel_revisions(cache_dir,
+                                                                 min_fx_version=fx_version,
+                                                                 max_fx_version=fx_version)
+    revision_probes = parse_moz_central_probes(revision_data)
+
+    # Get the minimum revision and date per probe-channel
+    revision_dates = transform_revisions.transform(revision_data)
+    first_appeared_dates = transform_probes.get_minimum_date(revision_probes, revision_data,
+                                                             revision_dates)
+
+    # Add in the first appeared dates
+    probes_by_channel_with_dates = add_first_appeared_dates(probes_by_channel, first_appeared_dates)
+
     # Serialize the probe data to disk.
-    write_moz_central_probe_data(probes_by_channel, revisions, out_dir)
+    write_moz_central_probe_data(probes_by_channel_with_dates, revisions, out_dir)
 
 
 def check_git_probe_structure(data):
@@ -193,6 +234,7 @@ def load_git_probes(cache_dir, out_dir, repositories_file, dry_run):
 
 def main(cache_dir,
          out_dir,
+         firefox_version,
          process_moz_central_probes,
          process_git_probes,
          repositories_file,
@@ -200,7 +242,7 @@ def main(cache_dir,
 
     process_both = not (process_moz_central_probes or process_git_probes)
     if process_moz_central_probes or process_both:
-        load_moz_central_probes(cache_dir, out_dir)
+        load_moz_central_probes(cache_dir, out_dir, firefox_version)
     if process_git_probes or process_both:
         load_git_probes(cache_dir, out_dir, repositories_file, dry_run)
 
@@ -215,6 +257,11 @@ if __name__ == "__main__":
                         help='Directory to store output files in.',
                         action='store',
                         default='.')
+    parser.add_argument('--firefox-version',
+                        help='Version of Firefox to scrape',
+                        action='store',
+                        type=int,
+                        required=False)
     parser.add_argument('--repositories-file',
                         help='Repositories YAML file location.',
                         action='store',
@@ -234,6 +281,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     main(args.cache_dir,
          args.out_dir,
+         args.firefox_version,
          args.only_moz_central_probes,
          args.only_git_probes,
          args.repositories_file,

--- a/probe_scraper/scrapers/buildhub.py
+++ b/probe_scraper/scrapers/buildhub.py
@@ -134,7 +134,7 @@ class Buildhub(object):
         total_hits = 0
         results = []
 
-        for i in xrange(2**20):
+        for i in range(2**20):
             data = self._paginate_revision_dates(i, channel, min_version, product, locale,
                                                  platform, max_version, verbose, window)
 

--- a/probe_scraper/scrapers/buildhub.py
+++ b/probe_scraper/scrapers/buildhub.py
@@ -1,0 +1,159 @@
+from datetime import datetime
+import pprint
+import requests
+import re
+
+
+class NoDataFoundException(Exception):
+    pass
+
+
+class Buildhub(object):
+
+    search_url = "https://buildhub.moz.tools/api/search"
+    default_window = 1000
+
+    date_formats = ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S.%f")
+
+    def _paginate_revision_dates(self, iteration, channel, min_version, product,
+                                 locale, platform, max_version, verbose, window):
+        query_str = [
+            {"term": {"source.product": product}},
+            {"term": {"target.channel": channel}},
+            {"range": {"target.version": {"gte": str(min_version)}}},
+            {"term": {"target.locale": locale}},
+            {"term": {"target.platform": platform}}
+        ]
+
+        if max_version is not None:
+            query_str.append({
+                "bool": {
+                    "should": [
+                        {"range": {"target.version": {"lte": str(max_version)}}},
+                        {"prefix": {"target.version": str(max_version)}}
+                    ]
+                }
+            })
+
+        body = {
+            "query": {
+                "bool": {
+                    "filter": query_str
+                }
+            },
+            "size": window
+        }
+
+        if iteration != 0:
+            body["from"] = iteration * window
+
+        if verbose:
+            print("------QUERY STRING------\n")
+            pprint.pprint(body)
+
+        response = requests.post(url=Buildhub.search_url, json=body)
+        data = response.json()
+
+        if verbose:
+            print("------QUERY RESULTS------\n")
+            pprint.pprint(data)
+
+        return data
+
+    def _distinct_and_clean(self, records):
+        """
+        For more information on the schema of the records,
+        see the Buildhub API documentation:
+        https://buildhub.readthedocs.io/en/latest/api.html#more-about-the-data-schema
+        """
+        cleaned_records = {}
+
+        for record in records:
+            # %:z not supported, see https://bugs.python.org/msg169952
+            # Drop the tz portion entirely
+            d = record["_source"]["download"]["date"]
+            if re.search(r"\+\d{2}:\d{2}$", d):
+                d = d[:-6]
+
+            date = None
+            try:
+                date = datetime.strptime(d, Buildhub.date_formats[0])
+            except ValueError:
+                pass
+
+            if date is None:
+                date = datetime.strptime(d, Buildhub.date_formats[1])
+
+            entry = {
+                "date": date,
+                "revision": record["_source"]["source"]["revision"],
+                "version": record["_source"]["target"]["version"]
+            }
+
+            revision = entry["revision"]
+            min_entry = entry
+
+            if revision in cleaned_records:
+                if cleaned_records[revision] != entry:
+                    min_entry = min((entry, cleaned_records[revision]), key=lambda x: x["date"])
+
+            cleaned_records[revision] = min_entry
+
+        return sorted(cleaned_records.values(), key=lambda x: x["date"])
+
+    def get_revision_dates(self, channel, min_version, product="firefox", locale="en-US",
+                           platform="win64", max_version=None, verbose=False, window=500):
+        """
+        Retrieve the revisions and publish-dates for a given filter set.
+        The combination of channel, product, local, and platform almost
+        gives a set of unique (revision, publication-dates). For example,
+        `win64` includes x86 and arm-64 builds. As such we de-duplicate
+        the result set and include the build with the earliest publication
+        date.
+
+        :param channel: The release channel
+        :param min_version: The minimum version to include
+        :param product: Defaults to firefox
+        :param locale: Defaults to en-US
+        :param platform: Defaults to win64
+        :param max_version: Optional maximum version to include
+        :param verbose: Verbose output of query string and results
+        :param window: Number of records to retrieve at a time
+
+        returns a list of records of type
+        {
+            "revision": <revision>,
+            "version": <version>,
+            "date": <date>
+        }
+        """
+
+        # See: "99" > "65" == True, "100" > "65" == False
+        assert min_version < 100, "Lexographical comparison of versions fails after version 100"
+
+        total_hits = 0
+        results = []
+
+        for i in xrange(2**20):
+            data = self._paginate_revision_dates(i, channel, min_version, product, locale,
+                                                 platform, max_version, verbose, window)
+
+            # hits/total gives total number of records, including
+            # those outside the window. We need to know the number
+            # inside the window.
+            hits = len(data["hits"]["hits"])
+
+            if hits:
+                total_hits += hits
+                results.append(data)
+
+            # optimization, removes the last no-result window
+            if hits < window:
+                break
+
+        if total_hits == 0:
+            raise NoDataFoundException("No data found for channel {} and minimum \
+                                       version {}".format(channel, min_version))
+
+        all_records = [record for result in results for record in result["hits"]["hits"]]
+        return self._distinct_and_clean(all_records)

--- a/probe_scraper/scrapers/buildhub.py
+++ b/probe_scraper/scrapers/buildhub.py
@@ -77,12 +77,12 @@ class Buildhub(object):
 
             date = None
             try:
-                date = datetime.strptime(d, Buildhub.date_formats[0])
+                date = datetime.strptime(d, self.date_formats[0])
             except ValueError:
                 pass
 
             if date is None:
-                date = datetime.strptime(d, Buildhub.date_formats[1])
+                date = datetime.strptime(d, self.date_formats[1])
 
             entry = {
                 "date": date,

--- a/probe_scraper/scrapers/buildhub.py
+++ b/probe_scraper/scrapers/buildhub.py
@@ -122,9 +122,9 @@ class Buildhub(object):
 
         returns a list of records of type
         {
+            "date": <date>
             "revision": <revision>,
             "version": <version>,
-            "date": <date>
         }
         """
 

--- a/probe_scraper/scrapers/moz_central_scraper.py
+++ b/probe_scraper/scrapers/moz_central_scraper.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 import requests
 import requests_cache
+from buildhub import Buildhub
 
 from collections import defaultdict
 
@@ -41,7 +42,7 @@ CHANNELS = {
     },
 }
 
-MIN_FIREFOX_VERSION = 30
+MIN_FIREFOX_VERSION = 64
 ERROR_CACHE_FILENAME = 'probe_scraper_errors_cache.json'
 
 
@@ -62,39 +63,67 @@ def load_tags(channel):
     return data
 
 
-def extract_tag_data(tag_data, channel):
+def extract_major_version(version_str):
+    """
+    Given a version string, e.g. "62.0a1",
+    extract the major version as an int.
+    """
+    search = re.search(r"^(\d+)\.", version_str)
+    if search is not None:
+        return int(search.group(1))
+    else:
+        raise Exception("Invalid version string " + version_str)
+
+
+def extract_tag_version(channel, version_str):
+    """
+    Given a tag, e.g. FIREFOX_65_0_RELEASE,
+    extract the major version as an int.
+    """
+    if channel == "release":
+        return int(version_str.split('_')[1])
+    elif channel in ["beta", "nightly"]:
+        return int(version_str.split('_')[2])
+    else:
+        raise Exception("Unsupported channel " + channel)
+
+
+def adjust_version(channel, version):
+    """
+    We work with tags that are the start of version N.
+    We want to treat those revisions as the end of version N-1 instead.
+    Nightly only has tags of the type FIREFOX_AURORA_NN_BASE, so it doesn't
+    need this.
+    """
+    if channel != "nightly":
+        return version - 1
+    return version
+
+
+def extract_tag_data(tag_data, channel, min_fx_version, max_fx_version):
     tag_regex = CHANNELS[channel]['tag_regex']
     tip_node_id = tag_data["node"]
     tags = [t for t in tag_data["tags"] if re.match(tag_regex, t["tag"])]
     results = []
+    latest_version = -1
 
     for tag in tags:
-        version = ""
-        if channel == "release":
-            version = tag["tag"].split('_')[1]
-        elif channel in ["beta", "nightly"]:
-            version = tag["tag"].split('_')[2]
-        else:
-            raise Exception("Unsupported channel " + channel)
+        version = extract_tag_version(channel, tag["tag"])
+        version = adjust_version(channel, version)
+        latest_version = max(version, latest_version)
 
-        # We work with tags that are the start of version N.
-        # We want to treat those revisions as the end of version N-1 instead.
-        # Nightly only has tags of the type FIREFOX_AURORA_NN_BASE, so it doesn't
-        # need this.
-        if channel != "nightly":
-            version = str(int(version) - 1)
-
-        if int(version) >= MIN_FIREFOX_VERSION:
+        if (version >= min_fx_version and
+           (max_fx_version is None or version <= max_fx_version)):
             results.append({
                 "node": tag["node"],
                 "version": version,
             })
 
-    results = sorted(results, key=lambda r: int(r["version"]))
+    results = sorted(results, key=lambda r: r["version"])
 
-    # Add tip revision.
-    if tip_node_id != results[-1]["node"]:
-        latest_version = str(int(results[-1]["version"]) + 1)
+    # Add tip revision, if we're including the most recent version
+    if (tip_node_id != results[-1]["node"] and
+       (max_fx_version is None or latest_version <= max_fx_version)):
         results.append({
             "node": tip_node_id,
             "version": latest_version,
@@ -161,31 +190,37 @@ def save_error_cache(folder, error_cache):
         json.dump(error_cache, f, sort_keys=True, indent=2)
 
 
-def scrape(folder=None):
+def scrape(folder=None, min_fx_version=None, max_fx_version=None):
     """
     Returns data in the format:
     {
-      node_id: {
-        channels: [channel_name, ...],
-        version: string,
-        registries: {
-          histogram: [path, ...]
-          event: [path, ...]
-          scalar: [path, ...]
-        }
+      <channel>: {
+        <revision>: {
+          "channel": <channel>,
+          "version": <major-version>,
+          "registries": {
+            "event": [<path>, ...],
+            "histogram": [<path>, ...],
+            "scalar": [<path>, ...]
+          }
+        },
+        ...
       },
       ...
     }
     """
+    if min_fx_version is None:
+        min_fx_version = MIN_FIREFOX_VERSION
     if folder is None:
         folder = tempfile.mkdtemp()
+
     error_cache = load_error_cache(folder)
     requests_cache.install_cache('probe_scraper_cache')
     results = defaultdict(dict)
 
     for channel in CHANNELS.keys():
         tags = load_tags(channel)
-        versions = extract_tag_data(tags, channel)
+        versions = extract_tag_data(tags, channel, min_fx_version, max_fx_version)
         save_error_cache(folder, error_cache)
 
         print("\n" + channel + " - extracted version data:")
@@ -202,5 +237,54 @@ def scrape(folder=None):
                 'registries': files,
             }
             save_error_cache(folder, error_cache)
+
+    return results
+
+
+def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=None):
+    """
+    Returns data in the format:
+    {
+      <channel>: {
+        <revision>: {
+          "date": <date>,
+          "version": <version>,
+          "registries": {
+            "histogram": [path, ...],
+            "event": [path, ...],
+            "scalar": [path, ...]
+          }
+        }
+      },
+      ...
+    }
+    """
+    if min_fx_version is None:
+        min_fx_version = MIN_FIREFOX_VERSION
+
+    error_cache = load_error_cache(folder)
+    bh = Buildhub()
+    results = defaultdict(dict)
+
+    for channel in CHANNELS.iterkeys():
+
+        print "\nRetreiving Buildhub results for channel " + channel
+
+        revision_dates = bh.get_revision_dates(channel, min_fx_version, max_version=max_fx_version)
+        num_revisions = len(revision_dates)
+
+        print "  " + str(num_revisions) + " revisions found"
+
+        for i, rd in enumerate(revision_dates):
+            revision = rd["revision"]
+
+            print "  Downloading files for revision number " + str(i+1) + "/" + str(num_revisions)
+            files = download_files(channel, revision, folder, error_cache)
+
+            results[channel][revision] = {
+                'date': rd['date'],
+                'version': extract_major_version(rd["version"]),
+                'registries': files
+            }
 
     return results

--- a/probe_scraper/scrapers/moz_central_scraper.py
+++ b/probe_scraper/scrapers/moz_central_scraper.py
@@ -8,7 +8,7 @@ import json
 import tempfile
 import requests
 import requests_cache
-from buildhub import Buildhub
+from .buildhub import Buildhub
 
 from collections import defaultdict
 
@@ -241,7 +241,7 @@ def scrape(folder=None, min_fx_version=None, max_fx_version=None):
     return results
 
 
-def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=None):
+def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=None, channels=None):
     """
     Returns data in the format:
     {
@@ -266,19 +266,22 @@ def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=No
     bh = Buildhub()
     results = defaultdict(dict)
 
-    for channel in CHANNELS.iterkeys():
+    if channels is None:
+        channels = CHANNELS.keys()
 
-        print "\nRetreiving Buildhub results for channel " + channel
+    for channel in channels:
+
+        print("\nRetreiving Buildhub results for channel " + channel)
 
         revision_dates = bh.get_revision_dates(channel, min_fx_version, max_version=max_fx_version)
         num_revisions = len(revision_dates)
 
-        print "  " + str(num_revisions) + " revisions found"
+        print("  " + str(num_revisions) + " revisions found")
 
         for i, rd in enumerate(revision_dates):
             revision = rd["revision"]
 
-            print "  Downloading files for revision number " + str(i+1) + "/" + str(num_revisions)
+            print("  Downloading files for revision number " + str(i+1) + "/" + str(num_revisions))
             files = download_files(channel, revision, folder, error_cache)
 
             results[channel][revision] = {

--- a/probe_scraper/scrapers/moz_central_scraper.py
+++ b/probe_scraper/scrapers/moz_central_scraper.py
@@ -120,6 +120,7 @@ def extract_tag_data(tag_data, channel, min_fx_version, max_fx_version):
             })
 
     results = sorted(results, key=lambda r: r["version"])
+    latest_version += 1
 
     # Add tip revision, if we're including the most recent version
     if (tip_node_id != results[-1]["node"] and

--- a/probe_scraper/scrapers/moz_central_scraper.py
+++ b/probe_scraper/scrapers/moz_central_scraper.py
@@ -42,7 +42,7 @@ CHANNELS = {
     },
 }
 
-MIN_FIREFOX_VERSION = 64
+MIN_FIREFOX_VERSION = 30
 ERROR_CACHE_FILENAME = 'probe_scraper_errors_cache.json'
 
 

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -179,14 +179,30 @@ def transform(probe_data, node_data, break_by_channel):
         print("\n" + channel + " - transforming probe data:")
         for entry in channel_data:
             node_id = entry['node_id']
-            readable_version = entry["version"]
-            print("  from: " + str({"node": node_id, "version": readable_version}))
-            for probe_type, probes in probe_data[channel][node_id].items():
+
+            readable_version = str(entry["version"])
+            print "  from: " + str({"node": node_id, "version": readable_version})
+            for probe_type, probes in probe_data[channel][node_id].iteritems():
                 # Group the probes by the release channel, if requested
                 extract_node_data(node_id, channel, probe_type, probes, result_data,
                                   readable_version, break_by_channel)
 
     return result_data
+
+
+def get_minimum_date(probe_data, revision_data, revision_dates):
+    probe_histories = transform(probe_data, revision_data, break_by_channel=True)
+    min_dates = defaultdict(lambda: defaultdict(str))
+
+    for channel, probes in probe_histories.items():
+        for probe_id, entry in probes.items():
+            dates = []
+            for history in entry['history'][channel]:
+                revision = history['revisions']['first']
+                dates.append(revision_dates[channel][revision]["date"])
+            min_dates[probe_id][channel] = min(dates)
+
+    return min_dates
 
 
 def make_commit_hash_probe_definition(definition, commit):

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -181,8 +181,8 @@ def transform(probe_data, node_data, break_by_channel):
             node_id = entry['node_id']
 
             readable_version = str(entry["version"])
-            print "  from: " + str({"node": node_id, "version": readable_version})
-            for probe_type, probes in probe_data[channel][node_id].iteritems():
+            print("  from: " + str({"node": node_id, "version": readable_version}))
+            for probe_type, probes in probe_data[channel][node_id].items():
                 # Group the probes by the release channel, if requested
                 extract_node_data(node_id, channel, probe_type, probes, result_data,
                                   readable_version, break_by_channel)

--- a/probe_scraper/transform_revisions.py
+++ b/probe_scraper/transform_revisions.py
@@ -10,7 +10,8 @@ def transform(node_data):
     for channel, nodes in node_data.items():
         for node_id, details in nodes.items():
             results[channel][node_id] = {
-                'version': details['version'],
+                'version': details.get('version'),
+                'date': details.get('date')
             }
 
     return results

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    web_dependency: mark a test that requires a web connection.

--- a/tests/test_buildhub.py
+++ b/tests/test_buildhub.py
@@ -1,0 +1,137 @@
+
+import pytest
+from probe_scraper.scrapers.buildhub import Buildhub, NoDataFoundException
+from datetime import datetime
+
+FX_RELEASE_62_0_3 = {
+    "revision": "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b",
+    "date": datetime(2018, 10, 01, 18, 40, 35),
+    "version": "62.0.3rc1"
+}
+
+VERBOSE = True
+
+
+@pytest.mark.web_dependency
+def test_nightly_count():
+    channel, min_version, max_version = "nightly", 62, 62
+
+    bh = Buildhub()
+    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    assert len(releases) == 97
+
+
+@pytest.mark.web_dependency
+def test_pagination():
+    channel, min_version, max_version = "nightly", 62, 62
+
+    bh = Buildhub()
+    releases = bh.get_revision_dates(channel, min_version, max_version=max_version,
+                                     verbose=VERBOSE, window=10)
+    assert len(releases) == 97
+
+
+@pytest.mark.web_dependency
+def test_duplicate_revisions():
+    channel, min_version, max_version = "nightly", 67, 67
+
+    bh = Buildhub()
+    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    assert len({r["revision"] for r in releases}) == len(releases)
+
+
+@pytest.mark.web_dependency
+def test_release():
+    channel, min_version, max_version = "release", 62, 62
+
+    bh = Buildhub()
+    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+
+    assert FX_RELEASE_62_0_3 in releases
+
+
+@pytest.mark.web_dependency
+def test_min_release():
+    channel, min_version, max_version = "release", 63, 63
+
+    bh = Buildhub()
+    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+
+    assert FX_RELEASE_62_0_3 not in releases
+
+
+@pytest.mark.web_dependency
+def test_no_min_max_version_overlap():
+    channel, min_version, max_version = "release", 63, 62
+    bh = Buildhub()
+
+    with pytest.raises(NoDataFoundException):
+        bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+
+
+@pytest.mark.web_dependency
+def test_no_released_version():
+    channel, min_version = "release", 99
+    bh = Buildhub()
+
+    with pytest.raises(NoDataFoundException):
+        bh.get_revision_dates(channel, min_version, verbose=VERBOSE)
+
+
+def test_version_100():
+    channel, min_version = "release", 100
+    bh = Buildhub()
+
+    with pytest.raises(AssertionError):
+        bh.get_revision_dates(channel, min_version, verbose=VERBOSE)
+
+
+def test_cleaned_dates():
+    bh = Buildhub()
+    records = [
+        {"_source": {
+            "download": {"date": "2019-01-28T23:49:22.717388+00:00"},
+            "source": {"revision": "abc"},
+            "target": {"version": "1"}
+        }},
+        {"_source": {
+            "download": {"date": "2019-01-29T23:49:22Z"},
+            "source": {"revision": "def"},
+            "target": {"version": "2"}
+        }}
+    ]
+
+    expected = [
+        {"revision": "abc",
+         "date": datetime(2019, 1, 28, 23, 49, 22, 717388),
+         "version": "1"},
+        {"revision": "def",
+         "date": datetime(2019, 1, 29, 23, 49, 22),
+         "version": "2"}
+    ]
+
+    assert bh._distinct_and_clean(records) == expected
+
+
+def test_unique_sorted():
+    bh = Buildhub()
+    records = [
+        {"_source": {
+            "download": {"date": "2019-01-28T23:49:22.717388+00:00"},
+            "source": {"revision": "abc"},
+            "target": {"version": "1"}
+        }},
+        {"_source": {
+            "download": {"date": "2019-01-22T23:49:22Z"},
+            "source": {"revision": "abc"},
+            "target": {"version": "2"}
+        }}
+    ]
+
+    expected = [
+        {"revision": "abc",
+         "date": datetime(2019, 1, 22, 23, 49, 22),
+         "version": "2"},
+    ]
+
+    assert bh._distinct_and_clean(records) == expected

--- a/tests/test_buildhub.py
+++ b/tests/test_buildhub.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 FX_RELEASE_62_0_3 = {
     "revision": "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b",
-    "date": datetime(2018, 10, 01, 18, 40, 35),
+    "date": datetime(2018, 10, 1, 18, 40, 35),
     "version": "62.0.3rc1"
 }
 

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -34,7 +34,7 @@ def test_event_parser():
 
 def parse(channel, version):
     parser = EventsParser()
-    return  parser.parse(["tests/test_events.yaml"], version, channel)
+    return parser.parse(["tests/test_events.yaml"], version, channel)
 
 
 def test_channel_version_ignore():

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -8,7 +8,7 @@ def is_string(s):
 def test_event_parser():
     # Parse the events from the test definitions.
     parser = EventsParser()
-    parsed_events = parser.parse(["tests/test_events.yaml"], "55")
+    parsed_events = parser.parse(["tests/test_events.yaml"], 55)
 
     # Make sure we loaded all the events.
     assert len(parsed_events) == 4
@@ -30,3 +30,20 @@ def test_event_parser():
 
         for field in REQUIRED_DETAILS:
             assert field in data["details"]
+
+
+def parse(channel, version):
+    parser = EventsParser()
+    return  parser.parse(["tests/test_events.yaml"], version, channel)
+
+
+def test_channel_version_ignore():
+    assert parse("release", 52) == {}
+    assert parse("release", 53) != {}
+
+    assert parse("beta", 52) == {}
+    assert parse("beta", 53) != {}
+
+    assert parse("nightly", 52) == {}
+    assert parse("nightly", 53) == {}
+    assert parse("nightly", 54) != {}

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -11,7 +11,7 @@ def test_event_parser():
     parsed_events = parser.parse(["tests/test_events.yaml"], 55)
 
     # Make sure we loaded all the events.
-    assert len(parsed_events) == 4
+    assert len(parsed_events) == 5
 
     # Make sure each of them contains all the required fields and details.
     REQUIRED_FIELDS = [

--- a/tests/test_events.yaml
+++ b/tests/test_events.yaml
@@ -36,6 +36,7 @@ telemetry.test:
     release_channel_collection: opt-out
     extra_keys:
       key1: This is just a test description.   
+      pause_behavior_change: This is a too-long extra key
 
 # This is a secondary category used for Telemetry tests.
 # The events here will not be sent out with any pings.

--- a/tests/test_events.yaml
+++ b/tests/test_events.yaml
@@ -27,6 +27,15 @@ telemetry.test:
     notification_emails: ["telemetry-client-dev@mozilla.com"]
     description: This is a test entry with an expired version.
     expiry_version: "3.6"
+  too_long_of_an_event_name:
+    objects: ["object1", "object2"]
+    bug_numbers: [1286606]
+    notification_emails: ["telemetry-client-dev@mozilla.com"]
+    description: This is an opt-out test entry.
+    expiry_date: never
+    release_channel_collection: opt-out
+    extra_keys:
+      key1: This is just a test description.   
 
 # This is a secondary category used for Telemetry tests.
 # The events here will not be sent out with any pings.

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -115,7 +115,7 @@ def improper_scalar_repo():
 
 
 def test_normal_repo(normal_repo):
-    runner.main(cache_dir, out_dir, False, True, repositories_file, True)
+    runner.main(cache_dir, out_dir, None, False, True, repositories_file, True)
 
     path = "{out_dir}/{repo_name}/mobile-metrics/all_probes".format(
            out_dir=out_dir,
@@ -144,7 +144,7 @@ def test_normal_repo(normal_repo):
 
 
 def test_improper_scalar_repo(improper_scalar_repo):
-    runner.main(cache_dir, out_dir, False, True, repositories_file, True)
+    runner.main(cache_dir, out_dir, None, False, True, repositories_file, True)
 
     # should be no output, since it was an improper file
     scalar_path = "{out_dir}/{repo_name}/mobile-metrics/all_probes".format(

--- a/tests/test_moz_central_scraper.py
+++ b/tests/test_moz_central_scraper.py
@@ -1,0 +1,62 @@
+from probe_scraper.scrapers import moz_central_scraper
+from datetime import datetime
+import pytest
+import os
+
+
+def test_extract_major_version():
+    assert moz_central_scraper.extract_major_version("62.0a1") == 62
+    assert moz_central_scraper.extract_major_version("63.0.2") == 63
+    with pytest.raises(Exception):
+        moz_central_scraper.extract_major_version("helloworld")
+
+
+@pytest.mark.web_dependency
+def test_channel_revisions():
+    tmp_dir = "./.test-files"
+    min_fx_version = 62
+    max_fx_version = 62
+
+    res = moz_central_scraper.scrape_channel_revisions(tmp_dir, min_fx_version,
+                                                       max_fx_version=max_fx_version)
+
+    channel = "release"
+    revision = "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b"
+
+    registries = {
+        probe_type: [os.path.join(tmp_dir, "hg", revision, path) for path in paths]
+        for probe_type, paths in moz_central_scraper.REGISTRY_FILES.items()
+    }
+
+    record = {
+        "date": datetime(2018, 10, 01, 15, 55, 45),
+        "version": 62,
+        "registries": registries
+    }
+
+    assert res[channel][revision] == record
+
+
+@pytest.mark.web_dependency
+def test_scrape():
+    tmp_dir = "./.test-files"
+    min_fx_version = 62
+    max_fx_version = 62
+
+    res = moz_central_scraper.scrape(tmp_dir, min_fx_version, max_fx_version=max_fx_version)
+
+    channel = "release"
+    revision = "84219fbf133cacfc6e31c9471ad20ee7162a02af"
+
+    registries = {
+        probe_type: [os.path.join(tmp_dir, "hg", revision, path) for path in paths]
+        for probe_type, paths in moz_central_scraper.REGISTRY_FILES.items()
+    }
+
+    record = {
+        "channel": channel,
+        "version": 62,
+        "registries": registries
+    }
+
+    assert res[channel][revision] == record

--- a/tests/test_moz_central_scraper.py
+++ b/tests/test_moz_central_scraper.py
@@ -16,12 +16,12 @@ def test_channel_revisions():
     tmp_dir = "./.test-files"
     min_fx_version = 62
     max_fx_version = 62
-
-    res = moz_central_scraper.scrape_channel_revisions(tmp_dir, min_fx_version,
-                                                       max_fx_version=max_fx_version)
-
     channel = "release"
     revision = "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b"
+
+    res = moz_central_scraper.scrape_channel_revisions(tmp_dir, min_fx_version,
+                                                       max_fx_version=max_fx_version,
+                                                       channels=[channel])
 
     registries = {
         probe_type: [os.path.join(tmp_dir, "hg", revision, path) for path in paths]
@@ -29,7 +29,7 @@ def test_channel_revisions():
     }
 
     record = {
-        "date": datetime(2018, 10, 01, 15, 55, 45),
+        "date": datetime(2018, 10, 1, 18, 40, 35),
         "version": 62,
         "registries": registries
     }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,71 @@
+from probe_scraper import runner
+from copy import deepcopy
+from datetime import datetime
+
+
+def test_add_first_appeared_dates():
+    probes_by_channel = {
+        "all": {
+            "histogram/test_int_histogram": {
+                "history": {
+                    "nightly": {
+                        "revisions": {
+                            "first": "rev-a",
+                            "last": "rev-b"
+                        }
+                    },
+                    "release": {
+                        "revisions": {
+                            "first": "rev-c",
+                            "last": "rev-d"
+                        }
+                    }
+                }
+            }
+        },
+        "nightly": {
+            "histogram/test_int_histogram": {
+                "history": {
+                    "nightly": {
+                        "revisions": {
+                            "first": "rev-a",
+                            "last": "rev-b"
+                        }
+                    }
+                }
+            }
+        },
+        "release": {
+            "histogram/test_int_histogram": {
+                "history": {
+                    "release": {
+                        "revisions": {
+                            "first": "rev-c",
+                            "last": "rev-d"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    first_appeared_dates = {
+        "histogram/test_int_histogram": {
+            "release": datetime(2019, 1, 1, 0, 0, 0),
+            "nightly": datetime(2018, 12, 1, 0, 0, 0)
+        }
+    }
+
+    expected = deepcopy(probes_by_channel)
+    expected["all"]["histogram/test_int_histogram"]["first_added"] = {
+        "release": "2019-01-01 00:00:00",
+        "nightly": "2018-12-01 00:00:00"
+    }
+    expected["release"]["histogram/test_int_histogram"]["first_added"] = {
+        "release": "2019-01-01 00:00:00",
+    }
+    expected["nightly"]["histogram/test_int_histogram"]["first_added"] = {
+        "nightly": "2018-12-01 00:00:00"
+    }
+
+    assert runner.add_first_appeared_dates(probes_by_channel, first_appeared_dates) == expected

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -1,6 +1,8 @@
 import probe_scraper.transform_probes as transform
 import pprint
 
+from datetime import datetime
+
 # incoming probe_data is of the form:
 #   node_id -> {
 #     histogram: {
@@ -31,6 +33,24 @@ IN_NODE_DATA = {
         },
         "node_id_3": {
             "version": "52",
+        },
+    }
+    for channel in CHANNELS
+}
+
+REVISION_DATES = {
+    channel: {
+        "node_id_1": {
+            "version": "50",
+            "date": datetime(2018, 1, 1, 10, 11, 12)
+        },
+        "node_id_2": {
+            "version": "51",
+            "date": datetime(2018, 2, 2, 10, 11, 12)
+        },
+        "node_id_3": {
+            "version": "52",
+            "date": datetime(2018, 3, 3, 10, 11, 12)
         },
     }
     for channel in CHANNELS
@@ -271,3 +291,14 @@ def test_transform_by_hash():
     expected = out_probe_data(by_channel=True, include_versions=False)
 
     print_and_test(expected, result)
+
+
+def test_get_minimum_date():
+    expected = {
+        "histogram/TEST_HISTOGRAM_1": {
+            "release": datetime(2018, 1, 1, 10, 11, 12),
+            "beta": datetime(2018, 1, 1, 10, 11, 12)
+        }
+    }
+
+    assert transform.get_minimum_date(in_probe_data(), IN_NODE_DATA, REVISION_DATES) == expected


### PR DESCRIPTION
Fixes #65

There are quite a few related changes here:
* Buildhub scraper gets data from the BH API
    - pagination of results included
* moz-central-scraper scrapes the revisions
    - made versions an int until needs to be a str
    - pulled out some behavior into new functions
    - added tests for some behavior
* runner retrieves buildhub-revision data separately
    - merges the first-added dates with the probe-info-service data

New tests:
The new tests include network connection, and are marked as such.
New pytest files disable running these tests automatically.