### PR TITLE
Mark use counters as enabled on release (opt-out)

### DIFF
--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -52,7 +52,7 @@ def extract_histogram_data(histogram, version):
 
     # Use Counters are shipped on release since 65.
     # If the parsers would set this flag, we couldn't differentiate between versions.
-    if version >= "65":
+    if int(version) >= 65:
         if histogram.name().startswith("USE_COUNTER2_"):
             optout = True
 

--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -6,7 +6,7 @@ from .third_party import histogram_tools
 from .utils import set_in_nested_dict, get_major_version
 
 
-def extract_histogram_data(histogram):
+def extract_histogram_data(histogram, version):
     props = {
         # source_field: target_field
         "cpp_guard": "cpp_guard",
@@ -49,6 +49,13 @@ def extract_histogram_data(histogram):
     optout = False
     if hasattr(histogram, "dataset"):
         optout = getattr(histogram, "dataset")().endswith('_OPTOUT')
+
+    # Use Counters are shipped on release since 65.
+    # If the parsers would set this flag, we couldn't differentiate between versions.
+    if version >= "65":
+        if histogram.name().startswith("USE_COUNTER2_"):
+            optout = True
+
     data["optout"] = optout
 
     # Normalize some field values.
@@ -67,8 +74,8 @@ def extract_histogram_data(histogram):
     return data
 
 
-def transform_probe_info(probes):
-    return dict((probe.name(), extract_histogram_data(probe)) for probe in probes)
+def transform_probe_info(probes, version):
+    return dict((probe.name(), extract_histogram_data(probe, version)) for probe in probes)
 
 
 class HistogramsParser:
@@ -77,4 +84,4 @@ class HistogramsParser:
         parsed_probes = list(histogram_tools.from_files(filenames))
 
         # Get the probe information in a standard format.
-        return transform_probe_info(parsed_probes)
+        return transform_probe_info(parsed_probes, version)

--- a/probe_scraper/parsers/third_party/histogram_tools.py
+++ b/probe_scraper/parsers/third_party/histogram_tools.py
@@ -114,6 +114,10 @@ symbol that should guard C/C++ definitions associated with the histogram."""
         self._is_use_counter = name.startswith("USE_COUNTER2_")
         if self._is_use_counter:
             definition.setdefault('record_in_processes', ['main', 'content'])
+            # Use Counters are opt-out by default since 65, but we can't mark them as such here,
+            # as it would apply to all old and new versions.
+            # They are special-cased in the probe-scraper parser later.
+            #definition.setdefault('releaseChannelCollection', 'opt-out')
         self.verify_attributes(name, definition)
         self._name = name
         self._description = definition['description']

--- a/tests/test_histogram_parser.py
+++ b/tests/test_histogram_parser.py
@@ -5,7 +5,7 @@ def is_string(s):
     return isinstance(s, str)
 
 
-def test_histogram_parser():
+def histogram_parser(version, usecounter_optout):
     FILES = [
         "tests/resources/Histograms.json",
         "tests/resources/nsDeprecatedOperationList.h",
@@ -58,7 +58,7 @@ def test_histogram_parser():
 
     # Parse the histograms from the test definitions.
     parser = HistogramsParser()
-    parsed_histograms = parser.parse(FILES, "55")
+    parsed_histograms = parser.parse(FILES, version)
 
     # Check that all expected histogram keys are present.
     ALL_KEYS = HISTOGRAMS + USE_COUNTERS + DEPRECATED_OPERATIONS
@@ -83,3 +83,16 @@ def test_histogram_parser():
         # Check that we have all the needed details.
         for field in REQUIRED_DETAILS:
             assert field in data['details']
+
+        if name.startswith("USE_COUNTER2_"):
+            assert data["optout"] == usecounter_optout
+
+
+# Test for an old Firefox version.
+def test_histogram_parser_old():
+    histogram_parser("55", usecounter_optout=False)
+
+
+# Test for a newer Firefox version with Use Counters on release
+def test_histogram_parser_new():
+    histogram_parser("70", usecounter_optout=True)


### PR DESCRIPTION
This was done on desktop in [bug 1510566](https://bugzilla.mozilla.org/show_bug.cgi?id=1510566), but we forgot to import it here
as well.

