### PR TITLE
Update the test files to add the required 'expires' key

### DIFF
--- a/tests/resources/metrics.yaml
+++ b/tests/resources/metrics.yaml
@@ -12,6 +12,7 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: '2015-07-11'
 
   os:
     type: string
@@ -26,3 +27,4 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: never

--- a/tests/resources/test_repo_files/improper/0/metrics.yaml
+++ b/tests/resources/test_repo_files/improper/0/metrics.yaml
@@ -10,3 +10,4 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: never

--- a/tests/resources/test_repo_files/normal/0/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/0/metrics.yaml
@@ -12,6 +12,7 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: '2015-07-11'
 
   os:
     type: string
@@ -26,3 +27,4 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: never

--- a/tests/resources/test_repo_files/normal/1/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/1/metrics.yaml
@@ -12,6 +12,7 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: '2015-07-11'
 
   os:
     type: string
@@ -26,3 +27,4 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: never

--- a/tests/resources/test_repo_files/normal/2/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/2/metrics.yaml
@@ -12,6 +12,7 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: '2015-07-11'
 
   os:
     type: string
@@ -26,3 +27,4 @@ example:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
     notification_emails:
       - telemetry-client-dev@mozilla.com
+    expires: never


### PR DESCRIPTION
The glean scraper were updated, and so we broke this consumer. Nice? No :(  I wonder if:

- we should version pin the parsers, so that don't break on new releases;
- have a "relaxed" mode in the parsers, like the desktop ones, which doesn't fail hard and is happy to ingest historical data that might not have all the latest properties.