### PR TITLE
Update for glean_parser changes

### DIFF
--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from glean_parser.parser import parse_metrics
+from glean_parser.parser import parse_objects
 from pathlib import Path
 
 
@@ -15,7 +15,7 @@ class GleanMetricsParser:
 
     def parse(self, filenames, config):
         paths = [Path(fname) for fname in filenames]
-        results = parse_metrics(paths, config)
+        results = parse_objects(paths, config)
         errors = [err for err in results]
 
         return (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 GitPython
 boto3
-glean_parser
+glean_parser==0.24
 jsonschema
 python-dateutil
 pyyaml

--- a/tests/resources/metrics.yaml
+++ b/tests/resources/metrics.yaml
@@ -1,3 +1,5 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0 
+
 example:
   duration:
     type: timespan

--- a/tests/resources/test_repo_files/normal/0/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/0/metrics.yaml
@@ -1,3 +1,5 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
 example:
   duration:
     type: timespan

--- a/tests/resources/test_repo_files/normal/1/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/1/metrics.yaml
@@ -1,3 +1,5 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
 example:
   duration:
     type: timespan

--- a/tests/resources/test_repo_files/normal/2/metrics.yaml
+++ b/tests/resources/test_repo_files/normal/2/metrics.yaml
@@ -1,3 +1,5 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+
 example:
   duration:
     type: timespan


### PR DESCRIPTION
These are just updates for changes to `glean_parser` in https://github.com/mozilla/glean_parser/pull/58.  That other PR is likely to go through some changes before landing, but I thought it wouldn't hurt to have this in the wings.

Basically it amounts to:
- `parse_metrics` is now `parse_objects` (because it parses metrics and ping objects)
- all `metrics.yaml` files *must* have a `$schema` key so we can tell them apart from `pings.yaml` files.