### PR TITLE
1557843: Add lib-crash to probe_scraper

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -46,3 +46,15 @@ firefox-for-fire-tv:
   notification_emails:
     - frank@mozilla.com
   url: 'https://github.com/mozilla-mobile/firefox-tv'
+lib-crash:
+  app_id: lib-crash
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+  url: 'https://github.com/mozilla-mobile/android-components'
+  metrics_files:
+    - 'components/lib/crash/metrics.yaml'
+  library_names:
+    - org.mozilla.components:lib-crash
+  


### PR DESCRIPTION
This will be required to get crash counts once https://github.com/mozilla-mobile/android-components/pull/3099 lands.

Cc: @travis79 
