### PR TITLE
1568485: Add engine-gecko dependencies to repositories.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To scrape a git repository for probe definitions, an entry needs to be added in 
 - `notification_emails`: Where emails about probe-scraper failures and improper files will be forwarded to. These
 will be just about your specific repository.
 - `url`: The URL of the repository to scrape. It should be able to be cloned directly from that URL.
+- `branch` (optional): The branch in the repository to use. (Defaults to `master`).
 - `metrics_files`: A list of relative paths to `metrics.yaml` files
 
 ### Adding an application

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -19,6 +19,7 @@ class Repository(object):
     def __init__(self, name, definition):
         self.name = name
         self.url = definition.get("url")
+        self.branch = definition.get("branch", "master")
         self.notification_emails = definition.get("notification_emails")
         self.app_id = definition.get("app_id")
         self.metrics_file_paths = definition.get("metrics_files", [])

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -51,6 +51,7 @@ def retrieve_files(repo_info, cache_dir):
     if os.path.exists(repo_info.name):
         shutil.rmtree(repo_info.name)
     repo = Repo.clone_from(repo_info.url, repo_info.name)
+    repo.git.checkout(repo_info.branch)
 
     try:
         for rel_path in repo_info.get_change_files():

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -72,6 +72,8 @@ engine-gecko:
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
   url: 'https://github.com/mozilla/gecko-dev'
   branch: release
   metrics_files:
@@ -83,6 +85,8 @@ engine-gecko-beta:
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
   url: 'https://github.com/mozilla/gecko-dev'
   branch: beta
   metrics_files:
@@ -94,6 +98,8 @@ engine-gecko-nightly:
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
   url: 'https://github.com/mozilla/gecko-dev'
   metrics_files:
     - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -67,3 +67,35 @@ lib-crash:
     - 'components/lib/crash/metrics.yaml'
   library_names:
     - org.mozilla.components:lib-crash
+engine-gecko:
+  app_id: engine-gecko
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+  url: 'https://github.com/mozilla/gecko-dev'
+  branch: release
+  metrics_files:
+    - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
+  library_names:
+    - org.mozilla.components:browser-engine-gecko
+engine-gecko-beta:
+  app_id: engine-gecko-beta
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+  url: 'https://github.com/mozilla/gecko-dev'
+  branch: beta
+  metrics_files:
+    - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
+  library_names:
+    - org.mozilla.components:browser-engine-gecko-beta
+engine-gecko-nightly:
+  app_id: engine-gecko-nightly
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+  url: 'https://github.com/mozilla/gecko-dev'
+  metrics_files:
+    - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
+  library_names:
+    - org.mozilla.components:browser-engine-gecko-nightly

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -16,6 +16,9 @@
         "type": "string",
         "format": "uri"
       },
+      "branch": {
+        "type": "string"
+      },
       "metrics_files": {
         "type": "array",
         "items": {


### PR DESCRIPTION
Even though there is a scraper for mozilla-central, the repositories.yaml
feature for Glean is currently limited to git repositories.  Therefore, this
uses the read-only mirror of the gecko-dev part of mozilla-central on Github.

There was a small code change required to support only looking on a specific
branch of the repo.