### PR TITLE
Hardcode &browser's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ dependencies of of the application change. For example, in an Android project,
 this would usually be all `build.gradle` files, but might include more if the
 build is more complex.
 
+> **Note:** There is an alternative method to hardcode the dependencies in the `repositories.yaml` file, but this is not recommended for regular use since it requires keeping the dependencies manually in sync with the application. To use this method, set the `dependencies` parameter to a list of library names. There is no guarantee this parameter will be supported going forward.
+
 ### Adding a library
 
 All **libraries** must define `library_names`.

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -26,6 +26,7 @@ class Repository(object):
         self.dependencies_url = definition.get("dependencies_url", None)
         self.dependencies_format = definition.get("dependencies_format", None)
         self.dependencies_files = definition.get("dependencies_files", [])
+        self.dependencies = definition.get("dependencies", [])
 
     def get_metrics_file_paths(self):
         return self.metrics_file_paths

--- a/probe_scraper/scrapers/dependency_scraper.py
+++ b/probe_scraper/scrapers/dependency_scraper.py
@@ -53,6 +53,9 @@ def parse_dependencies(repository, commit_hash):
     Loads and parses the dependencies for the given repository at the given
     commit hash.
     """
+    if len(repository.dependencies):
+        return dict((x, {"type": "dependency"}) for x in repository.dependencies)
+
     if repository.dependencies_url is None:
         return {}
 

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -28,6 +28,13 @@ reference-browser:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
   url: 'https://github.com/mozilla-mobile/reference-browser'
+  dependencies_files:
+    - build.gradle
+    - app/build.gradle
+    - buildSrc/src/main/java/Dependencies.kt
+  dependencies:
+    - org.mozilla.components:service-glean
+    - org.mozilla.components:lib-crash
 fenix-nightly:
   app_id: org-mozilla-fenix-nightly
   notification_emails:
@@ -46,6 +53,10 @@ firefox-for-fire-tv:
   notification_emails:
     - frank@mozilla.com
   url: 'https://github.com/mozilla-mobile/firefox-tv'
+  dependencies_files:
+    - build.gradle
+    - app/build.gradle
+    - buildSrc/src/main/java/Dependencies.kt
 lib-crash:
   app_id: lib-crash
   notification_emails:
@@ -57,4 +68,3 @@ lib-crash:
     - 'components/lib/crash/metrics.yaml'
   library_names:
     - org.mozilla.components:lib-crash
-  

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -33,6 +33,12 @@
           "gradle"
         ]
       },
+      "dependencies": {
+        "type": "array",
+        "item": {
+          "type": "string"
+        }
+      },
       "library_names": {
         "type": "array",
         "item": {


### PR DESCRIPTION
This hardcodes &brower's dependencies, rather than taking the approach Fenix takes (and proposed in https://github.com/mozilla-mobile/reference-browser/pull/848) where the dependencies are written by the app's build to an artifact, and then probe_scraper parses that.

One thing I noticed in the course of this is that *no* dependencies or metrics are generated for an app if they don't define `dependencies_files` (since the scraper doesn't have a commit/file pair to hang them on to).  Therefore, I've added these to `reference-browser` and FFTV, but I'm a little uncertain that's the right solution since I thought FFTV was working?