### PR TITLE
1569766: Upgrade glean_parser to 1.0.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 GitPython
 boto3
-glean_parser==0.24
+glean_parser==1.0
 jsonschema
 python-dateutil
 pyyaml


### PR DESCRIPTION
A new glean_parser 1.0.0 release (with no changes from the prior release) has been made so that we can start using semver here and automatically get non-API-breaking bugfixes from glean_parser.