### PR TITLE
WIP: 1569184: Automatically extract dependencies from gradle apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ will be just about your specific repository.
 
 ### Adding an application
 
-All **applications** in `repositories.yaml` must also define `dependencies_url`,
+All **applications** in `repositories.yaml` must also define
 `dependencies_format` and `dependencies_files`.
 
 Glean metrics are emitted by the application using Glean, any libraries it uses
@@ -33,21 +33,11 @@ that application.
 Currently, probe-scraper has support for reading dependencies from the following
 platforms and build systems:
 
-- **gradle for Android:** Obtain the dependencies for your application using
-  `./gradlew app:dependencies --configuration implementation`
+- `gradle`: `probe_scraper` will obtain the dependencies for your
+  application using `./gradlew app:dependencies --configuration implementation`
 
-Configure the application's CI system to store the output of one of the above
-commands at a publicly accessible URL that contains the git commit hash of the
-application that generated it.
-
-Set the `dependencies_url` parameter for the application in `repositories.yaml`
-to this URL, using the `{commit_hash}` marker to indicate the part that should be replaced
-with a git commit hash. Also set the `dependencies_format` parameter to the name
+Set the `dependencies_format` parameter to the name
 of the build system in use (currently only `gradle` is supported).
-
-For example, [here were the
-changes](https://github.com/mozilla-mobile/fenix/pull/1996) to make this work
-for Fenix, which uses Taskcluster for CI.
 
 Set the `dependencies_files` parameter to a list of files that change when
 dependencies of of the application change. For example, in an Android project,

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -23,7 +23,6 @@ class Repository(object):
         self.app_id = definition.get("app_id")
         self.metrics_file_paths = definition.get("metrics_files", [])
         self.library_names = definition.get("library_names", None)
-        self.dependencies_url = definition.get("dependencies_url", None)
         self.dependencies_format = definition.get("dependencies_format", None)
         self.dependencies_files = definition.get("dependencies_files", [])
         self.dependencies = definition.get("dependencies", [])

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -20,7 +20,7 @@ from .parsers.histograms import HistogramsParser
 from .parsers.metrics import GleanMetricsParser
 from .parsers.repositories import RepositoriesParser
 from .parsers.scalars import ScalarsParser
-from .scrapers import dependency_scraper, git_scraper, moz_central_scraper
+from .scrapers import git_scraper, moz_central_scraper
 from schema import And, Optional, Schema
 
 
@@ -190,8 +190,9 @@ def check_glean_metric_structure(data):
 
 def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run):
     repositories = RepositoriesParser().parse(repositories_file)
-    commit_timestamps, repos_metrics_data, emails = git_scraper.scrape(cache_dir, repositories)
-    repositories_by_name = dict((x.name, x) for x in repositories)
+    commit_timestamps, repos_metrics_data, dependencies, emails = git_scraper.scrape(
+        cache_dir, repositories
+    )
 
     check_glean_metric_structure(repos_metrics_data)
 
@@ -205,11 +206,9 @@ def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run):
     #   ...
     # }
     metrics = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-    dependencies = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
     for repo_name, commits in repos_metrics_data.items():
         for commit_hash, paths in commits.items():
             metrics_files = [p for p in paths if p.endswith(GLEAN_METRICS_FILENAME)]
-            dependency_files = [p for p in paths if not p.endswith(GLEAN_METRICS_FILENAME)]
 
             try:
                 config = {'allow_reserved': repo_name == 'glean'}
@@ -232,16 +231,10 @@ def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run):
                         "message": msg
                     })
 
-            if dependency_files:
-                dependencies[repo_name][commit_hash] = dependency_scraper.parse_dependencies(
-                    repositories_by_name[repo_name],
-                    commit_hash
-                )
-
     metrics_by_repo = {repo: {} for repo in repos_metrics_data}
     metrics_by_repo.update(transform_probes.transform_by_hash(commit_timestamps, metrics))
 
-    dependencies_by_repo = {repo: {} for repo in repos_metrics_data}
+    dependencies_by_repo = {repo: {} for repo in dependencies}
     dependencies_by_repo.update(transform_probes.transform_by_hash(commit_timestamps, dependencies))
 
     write_glean_metric_data(metrics_by_repo, dependencies_by_repo, out_dir)

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -20,7 +20,6 @@ fenix:
     - build.gradle
     - app/build.gradle
     - buildSrc/src/main/java/Dependencies.kt
-  dependencies_url: 'https://index.taskcluster.net/v1/task/project.mobile.fenix.v2.branch.master.revision.{commit_hash}/artifacts/public/dependencies.txt'
   dependencies_format: gradle
 reference-browser:
   app_id: org-mozilla-reference-browser
@@ -46,7 +45,6 @@ fenix-nightly:
     - build.gradle
     - app/build.gradle
     - buildSrc/src/main/java/Dependencies.kt
-  dependencies_url: 'https://index.taskcluster.net/v1/task/project.mobile.fenix.v2.branch.master.revision.{commit_hash}/artifacts/public/dependencies.txt'
   dependencies_format: gradle
 firefox-for-fire-tv:
   app_id: org-mozilla-tv-firefox

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -23,10 +23,6 @@
           "pattern": "metrics\\.yaml$"
         }
       },
-      "dependencies_url": {
-        "type": "string",
-        "format": "uri"
-      },
       "dependencies_format": {
         "type": "string",
         "enum": [


### PR DESCRIPTION
This is a first pass at automatically extracting the dependencies for gradle-based Android products within probe-scraper itself, rather than depending on the app uploading an artifact.

The biggest structural change is that the handling of dependencies happens as a subtask of the `git_scraper`, since it needs a full git clone to do its work, and we wouldn't want to clone these twice.

The biggest problem with this approach is how slow it is.  It takes a really long time to run gradle on what is currently for Fenix 204 commits.  It seems like caching might be the answer (since the dependencies should be constant for a given commit), but I'm not sure how best to handle persistent caching in the EMR environment (or whatever problems that would create).

This also needs updated installation  docs for local testing -- for now see https://github.com/mozilla/telemetry-airflow/pull/571 -- and needs updated tests.  But I'd put this up for discussion first.