### PR TITLE
Remove missing dep file that doesn't exist for FFTV

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -56,7 +56,6 @@ firefox-for-fire-tv:
   dependencies_files:
     - build.gradle
     - app/build.gradle
-    - buildSrc/src/main/java/Dependencies.kt
 lib-crash:
   app_id: lib-crash
   notification_emails:


### PR DESCRIPTION
I added this, assuming FFTV had this dependencies file like all of the other Android projects.

However, on testing again, it fails with:

```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)                              
  cmdline: git log --format="%H:%ct" buildSrc/src/main/java/Dependencies.kt
  stderr: 'fatal: ambiguous argument 'buildSrc/src/main/java/Dependencies.kt': unknown revision or path not in the working tree.          
```