### PR TITLE
Remove non-nightly gecko metrics.yaml files

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -88,8 +88,6 @@ engine-gecko:
     - geckoview-team@mozilla.com
   url: 'https://github.com/mozilla/gecko-dev'
   branch: release
-  metrics_files:
-    - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
   library_names:
     - org.mozilla.components:browser-engine-gecko
 engine-gecko-beta:
@@ -101,8 +99,6 @@ engine-gecko-beta:
     - geckoview-team@mozilla.com
   url: 'https://github.com/mozilla/gecko-dev'
   branch: beta
-  metrics_files:
-    - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
   library_names:
     - org.mozilla.components:browser-engine-gecko-beta
 engine-gecko-nightly:


### PR DESCRIPTION
These are missing from those branches because the metrics.yaml
file hasn't been released yet. We'll need to add it back in
when they are.