### PR TITLE
Fix #93: Improve repositories schema

### DIFF
--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -23,10 +23,16 @@
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "metrics\\.yaml$"
+          "pattern": "(metrics|pings)\\.yaml$"
         }
       },
       "dependencies": {
+        "type": "array",
+        "item": {
+          "type": "string"
+        }
+      },
+      "dependencies_files": {
         "type": "array",
         "item": {
           "type": "string"
@@ -44,7 +50,8 @@
       "url",
       "notification_emails"
     ],
-    "type": "object"
+    "type": "object",
+    "additionalProperties": false
   },
   "type": "object"
 }

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -23,7 +23,7 @@
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "(metrics|pings)\\.yaml$"
+          "pattern": "metrics\\.yaml$"
         }
       },
       "dependencies": {

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -1,5 +1,8 @@
 {
   "$schema": "http://json-schema.org/schema#",
+  "propertyNames": {
+    "pattern": "^[a-z][a-z0-9-]{0,29}$"
+  },
   "additionalProperties": {
     "properties": {
       "app_id": {

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -21,7 +21,7 @@ def parser():
 @pytest.fixture
 def incorrect_repos_file():
     data = {
-        "some_repo": {
+        "some-repo": {
             # missing `notification_emails`
             "app_id": "mobile-metrics-example",
             "url": "www.github.com/fbertsch/mobile-metrics-example",
@@ -46,13 +46,32 @@ def correct_repos_file():
     return write_to_temp_file(data)
 
 
+@pytest.fixture
+def not_kebab_case_repos_file():
+    data = {
+        "some_repo": {
+            "app_id": "mobile-metrics-example",
+            "url": "www.github.com/fbertsch/mobile-metrics-example",
+            "notification_emails": ["frank@mozilla.com"],
+            "metrics_files": ["metrics.yaml"]
+        }
+    }
+
+    return write_to_temp_file(data)
+
+
 def test_repositories(parser):
     parser.validate()
 
 
-def test_repositories_parser_correct(parser, incorrect_repos_file):
+def test_repositories_parser_incorrect(parser, incorrect_repos_file):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         parser.validate(incorrect_repos_file)
+
+
+def test_repositories_parser_not_kebab_case(parser, not_kebab_case_repos_file):
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        parser.validate(not_kebab_case_repos_file)
 
 
 def test_repositories_class(parser, correct_repos_file):


### PR DESCRIPTION
This tightens things up by adding `"additionalProperties": false`, which lead to noticing that `dependencies_files` was never declared.

Also adds the ability to specify `pings.yaml` files, which would be required by libraries that specify custom pings.