### PR TITLE
Fix missing var error

### DIFF
--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -149,7 +149,7 @@ def load_moz_central_probes(cache_dir, out_dir, fx_version, min_fx_version, fire
     if fx_version:
         min_fx_version = fx_version
         max_fx_version = fx_version
-    elif min_fx_version:
+    else:
         max_fx_version = None
 
     if firefox_channel:


### PR DESCRIPTION
When testing locally, we always use `--firefox-version` or `--min-firefox-version`. This bug only happened when _neither_ are specified, in which case `max_fx_version` wouldn't be specified either, causing it to fail.