### PR TITLE
1584182: Move browser-storage-sync to support-sync-telemetry

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -19,7 +19,7 @@ fenix:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:lib-crash
-    - org.mozilla.components:browser-storage-sync
+    - org.mozilla.components:support-sync-telemetry
     - org.mozilla.components:browser-engine-gecko-beta
 reference-browser:
   app_id: org-mozilla-reference-browser
@@ -42,7 +42,7 @@ fenix-nightly:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:lib-crash
-    - org.mozilla.components:browser-storage-sync
+    - org.mozilla.components:support-sync-telemetry
     - org.mozilla.components:browser-engine-gecko-nightly
 firefox-for-fire-tv:
   app_id: org-mozilla-tv-firefox
@@ -67,11 +67,12 @@ sync:
   notification_emails:
     - frank@mozilla.com
     - lina@mozilla.com
+    - grisha@mozilla.com
   url: 'https://github.com/mozilla-mobile/android-components'
   metrics_files:
-    - 'components/browser/storage-sync/metrics.yaml'
+    - 'components/support/sync-telemetry/metrics.yaml'
   library_names:
-    - org.mozilla.components:browser-storage-sync
+    - org.mozilla.components:support-sync-telemetry
 engine-gecko:
   app_id: engine-gecko
   notification_emails:


### PR DESCRIPTION
This is in support of the changes in https://github.com/mozilla-mobile/android-components/pull/4480.

tl;dr: The metrics that were formerly sent by `browser-storage-sync` have been moved to a helper component in `support-sync-telemetry` (which will in the future be used by other sync products).

None of the metrics were actually renamed, so I think this is a safe, non-schema-changing transformation, but could you please confirm, @fbertsch ?  This is the sort of change we haven't really anticipated...

Cc: @grigoryk