### PR TITLE
Modifying Probe scraper runner to do the s3 syncs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3
 MAINTAINER Harold Woo <hwoo@mozilla.com>
 
+ENV PYTHONUNBUFFERED=1
+
 ARG APP_NAME=probe-scraper
 ENV APP_NAME=${APP_NAME}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+awscli==1.16.263
 GitPython==3.0.3
 boto3==1.9.250
 glean_parser==1.8

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -145,7 +145,8 @@ def improper_metrics_repo():
 
 
 def test_normal_repo(normal_repo):
-    runner.main(cache_dir, out_dir, None, None, False, True, repositories_file, True, None, None)
+    runner.main(cache_dir, out_dir, None, None, False, True, repositories_file,
+                True, None, None, None, None, 'dev')
 
     path = os.path.join(out_dir, "glean", normal_repo_name, "metrics")
 
@@ -185,7 +186,8 @@ def test_normal_repo(normal_repo):
 
 
 def test_improper_metrics_repo(improper_metrics_repo):
-    runner.main(cache_dir, out_dir, None, None, False, True, repositories_file, True, None, None)
+    runner.main(cache_dir, out_dir, None, None, False, True, repositories_file,
+                True, None, None, None, None, 'dev')
 
     path = os.path.join(out_dir, "glean", improper_repo_name, "metrics")
     with open(path, 'r') as data:
@@ -233,9 +235,8 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
         f.write(yaml.dump(repositories_info))
 
     try:
-        runner.main(
-            cache_dir, out_dir, None, None, False, True, repositories_file, True, None, None
-        )
+        runner.main(cache_dir, out_dir, None, None, False, True, repositories_file,
+                    True, None, None, None, None, 'dev')
     except ValueError:
         pass
     else:
@@ -289,9 +290,8 @@ def test_check_for_expired_metrics(expired_repo):
             return datetime.date(2019, 10, 14)
 
     with unittest.mock.patch("probe_scraper.glean_checks.datetime.date", new=MockDate):
-        runner.main(
-            cache_dir, out_dir, None, None, False, True, repositories_file, True, None, None
-        )
+        runner.main(cache_dir, out_dir, None, None, False, True, repositories_file,
+                    True, None, None, None, None, 'dev')
 
     with open(EMAIL_FILE, 'r') as email_file:
         emails = yaml.load(email_file)


### PR DESCRIPTION
Since we will run in a container via GKEPodOperator instead of EMR -> scriptrunner jar -> bash -> python -> bash

Replaces logic in:
https://github.com/mozilla/telemetry-airflow/blob/master/jobs/probe_scraper.sh

TODO:
- [x]  Create aws creds with aws prod access to both the s3 cloudfront prod bucket and the telemetry-airflow-cache bucket. 
- [x] Copy cache data over from aws dev -> prod bucket
- [x]  Add creds to wtmo, and secret sops repo
- [x]  Test
- [x]  This should merge along with a PR to telemetry-airflow that modifies the probe-scraper.py dag to use GKEPodOperator. Also make sure to sync the cache from aws dev to prod before the first migrated run