### PR TITLE
1582101: Point probe-scraper at the new Glean metrics.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -3,9 +3,9 @@ glean:
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
-  url: 'https://github.com/mozilla-mobile/android-components'
+  url: 'https://github.com/mozilla/glean'
   metrics_files:
-    - 'components/service/glean/metrics.yaml'
+    - 'glean-core/android/metrics.yaml'
   library_names:
     - org.mozilla.components:service-glean
 fenix:


### PR DESCRIPTION
Confirmed locally: The new `metrics.yaml` adds a single metric: `glean.core.migration.successful`.  None were removed (even from the entire history of `metrics.yaml` in the old location.