### PR TITLE
Bug 1592705 - Add vrbrowser app id

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -107,3 +107,14 @@ engine-gecko-nightly:
     - 'toolkit/components/telemetry/geckoview/streaming/metrics.yaml'
   library_names:
     - org.mozilla.components:browser-engine-gecko-nightly
+firefox-reality:
+  app_id: org-mozilla-vrbrowser
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+    - dmu@mozilla.com
+  url: 'https://github.com/MozillaReality/FirefoxReality'
+  metrics_files:
+    - 'app/metrics.yaml'
+  dependencies:
+    - org.mozilla.components:service-glean

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -118,3 +118,4 @@ firefox-reality:
     - 'app/metrics.yaml'
   dependencies:
     - org.mozilla.components:service-glean
+    - org.mozilla.components:support-sync-telemetry


### PR DESCRIPTION
I'm not sure about the "dependencies" piece - I used [this code](https://github.com/MozillaReality/FirefoxReality/blob/master/versions.gradle#L54-L67) as reference.