### PR TITLE
Handle the multiple metrics files in glean

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -6,6 +6,7 @@ glean:
   url: 'https://github.com/mozilla/glean'
   metrics_files:
     - 'glean-core/android/metrics.yaml'
+    - 'glean-core/metrics.yaml'
   library_names:
     - org.mozilla.components:service-glean
 fenix:


### PR DESCRIPTION
https://github.com/mozilla/glean/pull/448 refactored the metrics.yaml files in
glean into a cross-platform file and an Android-specific file. Both are
required to know all of the metrics that Glean sends.

We were "getting lucky" before now since we didn't add any metrics, so they
were getting included by being in the historical versions of
`glean-core/android/metrics.yaml`.