### PR TITLE
Add appservices:logins component.

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -26,6 +26,7 @@ fenix:
     - org.mozilla.components:lib-crash
     - org.mozilla.components:support-sync-telemetry
     - org.mozilla.components:browser-engine-gecko-beta
+    - org.mozilla.appservices:logins
 reference-browser:
   app_id: org-mozilla-reference-browser
   notification_emails:
@@ -51,6 +52,7 @@ fenix-nightly:
     - org.mozilla.components:lib-crash
     - org.mozilla.components:support-sync-telemetry
     - org.mozilla.components:browser-engine-gecko-nightly
+    - org.mozilla.appservices:logins
 firefox-for-fire-tv:
   app_id: org-mozilla-tv-firefox
   notification_emails:
@@ -134,3 +136,14 @@ firefox-reality:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:support-sync-telemetry
+logins-store:
+  app_id: logins-store
+  notification_emails:
+    - rfkelly@mozilla.com
+    - lina@mozilla.com
+    - application-services@mozilla.com
+  url: 'https://github.com/mozilla/application-services'
+  metrics_files:
+    - 'components/logins/android/metrics.yaml'
+  library_names:
+    - org.mozilla.appservices:logins


### PR DESCRIPTION
Over in https://github.com/mozilla/application-services/pull/2225 we landed some metrics for the application-services "logins" component. The new release hasn't worked its way into Fenix yet, but it will shortly, and I'm told that we need to get ourselves an entry in the file here before submitted metrics will start showing up for analysis.

Does this look about right?