### PR TITLE
Move the minimum Fenix metadata date to 2019-06-27.

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -14,8 +14,8 @@ from datetime import datetime, timedelta
 MIN_DATES = {
     # Previous versions of the file were not schema-compatible
     "glean": "2019-04-11 00:00:00",
-    "fenix": "2019-03-24 00:00:00",
-    "fenix-nightly": "2019-03-24 00:00:00",
+    "fenix": "2019-06-27 00:00:00",
+    "fenix-nightly": "2019-06-27 00:00:00",
     "reference-browser": "2019-04-01 00:00:00"
 }
 


### PR DESCRIPTION
This should resolve this error email about an invalid pings.yaml in Fenix:

Error in processing commit 0d824311956b2cde98ae44cb478bb69cabf45abb
Errors: [/app/probe_cache/fenix/0d824311956b2cde98ae44cb478bb69cabf45abb/app/pings.yaml:
    ```
    activation:
      description: 'This ping is intended to provide a measure of the activation
        of mobile products. It''s generated when Fenix starts, right after Glean
        is initialized. It doesn''t include the client_id, since it might be reporting
        an hashed version of the Google Advertising ID.        '
      include_client_id: false
    ```
    Missing required properties: bugs, data_reviews, notification_emails]