### PR TITLE
Make probe expiry alerts only run on mondays

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -104,6 +104,10 @@ def parse_args():
 
 
 def main(dryrun):
+    # Only run on Mondays
+    if datetime.date.today().weekday() != 0:
+        return
+
     probe_info = requests.get(PROBE_INFO_BASE_URL + "firefox/all/main/all_probes").json()
 
     release_dates = release_calendar.get_release_dates()

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -105,7 +105,7 @@ def parse_args():
 
 def main(dryrun):
     # Only run on Mondays
-    if datetime.date.today().weekday() != 0:
+    if datetime.date.today().weekday() != 1:
         return
 
     probe_info = requests.get(PROBE_INFO_BASE_URL + "firefox/all/main/all_probes").json()


### PR DESCRIPTION
To copy glean alerts behaviour.  I thought it would be easy to do this in airflow but it is not because the probe scraper dag runs daily.