### PR TITLE
Retrieve earlier versions of fenix metrics.yaml

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 # Changing these dates can cause files that had metrics to
 # stop being scraped. When the probe-info-service
 # stops reporting those files, the schema-generator
-# will not add them to the schemas, resulting in a 
+# will not add them to the schemas, resulting in a
 # schema-incompatible change that breaks the pipeline.
 MIN_DATES = {
     # Previous versions of the file were not schema-compatible

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -14,8 +14,8 @@ from datetime import datetime, timedelta
 MIN_DATES = {
     # Previous versions of the file were not schema-compatible
     "glean": "2019-04-11 00:00:00",
-    "fenix": "2019-06-27 00:00:00",
-    "fenix-nightly": "2019-06-27 00:00:00",
+    "fenix": "2019-06-04 00:00:00",
+    "fenix-nightly": "2019-06-04 00:00:00",
     "reference-browser": "2019-04-01 00:00:00"
 }
 

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -11,6 +11,12 @@ import traceback
 from datetime import datetime, timedelta
 
 
+# WARNING!
+# Changing these dates can cause files that had metrics to
+# stop being scraped. When the probe-info-service
+# stops reporting those files, the schema-generator
+# will not add them to the schemas, resulting in a 
+# schema-incompatible change that breaks the pipeline.
 MIN_DATES = {
     # Previous versions of the file were not schema-compatible
     "glean": "2019-04-11 00:00:00",


### PR DESCRIPTION
Fenix changed the way some of the metrics are recorded,
and we lost those changes when we stopped scraping the
earlier metrics.yaml files.

namely:
https://github.com/mozilla-mobile/fenix/commit/47c14b07dde9991bbdeb79f58a997744a8714733#diff-dcd3c2fb5158fcd99c56aa5b26b6de5d
https://github.com/mozilla-mobile/fenix/commit/9e5d0a24080131fd1a11c8eb49700cfaa2a32076#diff-dcd3c2fb5158fcd99c56aa5b26b6de5d

Those both need to be include or else we end up with
schema-incompatible changes in the BQ tables.