### PR TITLE
Change default alert email, change alerts to run on wednesdays

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -13,7 +13,7 @@ from probe_scraper import emailer
 from probe_scraper.parsers.utils import get_major_version
 
 FROM_EMAIL = "telemetry-alerts@mozilla.com"
-DEFAULT_TO_EMAIL = "dev-telemetry-alerts@mozilla.com"
+DEFAULT_TO_EMAIL = "dev-telemetry-alerts@lists.mozilla.org"
 PROBE_INFO_BASE_URL = "https://probeinfo.telemetry.mozilla.org/"
 
 EMAIL_BODY_FORMAT_STRING = """
@@ -132,7 +132,7 @@ def main(current_date, dryrun):
     logging.info(f"Found {len(expiring_probes)} expiring probes in nightly {next_version}")
 
     # Only send emails on Tuesdays, run the rest for debugging/error detection
-    if current_date.weekday() != 1:
+    if current_date.weekday() != 2:
         logging.info("Skipping emails because it is not Tuesday")
         return
 

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -234,7 +234,7 @@ def test_main_run(mock_send_emails, mock_get_version, mock_requests_get):
     mock_requests_get.return_value = ResponseWrapper(probes)
     mock_get_version.return_value = '75'
 
-    probe_expiry_alert.main(datetime.date(2020, 1, 7), True)
+    probe_expiry_alert.main(datetime.date(2020, 1, 8), True)
 
     expected_expired_probes = {
         "p2": [


### PR DESCRIPTION
Update email to actual dev-telemetry-alerts so we know what's going on.  @fbertsch should the default to email in `runner.py` change too?

Also change alerts to run on wednesdays to better align with the release process per Sebastian Hengst.  The proposed schedule would look like this:
```
Monday: version increased to N
Tuesday: version increase simulation using version N + 1, bugs get filed
for probes which will break builds or tests
Wednesday: probe-scraper generates alerts for all histograms expiring in
version N + 1, developer only handles the ones not reported on Tuesday
or backlogs them
```

