### PR TITLE
Update glean_parser to 1.18.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ awscli==1.16.263
 beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.9.250
-glean_parser==1.15.5
+glean_parser==1.18.2
 jsonschema==3.1.1
 python-dateutil==2.8.0
 PyYAML==5.1.2


### PR DESCRIPTION
Should address this issue:

```
Error in processing commit cfd94bb7f762525f954abd990170cfd82706e71a
Errors: [/app/probe_cache/glean/cfd94bb7f762525f954abd990170cfd82706e71a/glean-core/pings.yaml:
    ```
    baseline:
      bugs:
      - https://bugzilla.mozilla.org/1512938
      - https://bugzilla.mozilla.org/1599877
      data_reviews:
      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
      - https://bugzilla.mozilla.org/show_bug.cgi?id=1599877#c25
      description: 'This ping is intended to provide metrics that are managed
        by the library itself, and not explicitly set by the application or included
        in the application''s `metrics.yaml` file. The `baseline` ping is automatically
        sent when the application is moved to the background.

        '
      include_client_id: true
      notification_emails:
      - glean-team@mozilla.com
      reasons:
        background: 'The ping was submitted before going to background.

          '
        dirty_startup: 'The ping was submitted at startup, because the application
          process was

          killed before the Glean SDK had the chance to generate this ping, when

          going to background, in the last session.


          *Note*: this ping will not contain the `glean.baseline.duration` metric.

          '
    ```

    Additional properties are not allowed ('reasons' was unexpected)./app/probe_cache/glean/cfd94bb7f762525f954abd990170cfd82706e71a/glean-core/pings.yaml:
```