### PR TITLE
Keep git commits sorted in their log order

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -178,7 +178,7 @@ def check_for_expired_metrics(
     for repo_name, commits in repos_metrics.items():
         repo = repo_by_name[repo_name]
         timestamps = list(commit_timestamps[repo_name].items())
-        timestamps.sort(key=lambda x: x[1], reverse=True)
+        timestamps.sort(key=lambda x: (-x[1][0], x[1][1]))
         last_commit_hash = timestamps[0][0]
         metrics = commits[last_commit_hash]
 

--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -178,7 +178,7 @@ def check_for_expired_metrics(
     for repo_name, commits in repos_metrics.items():
         repo = repo_by_name[repo_name]
         timestamps = list(commit_timestamps[repo_name].items())
-        timestamps.sort(key=lambda x: -x[1])
+        timestamps.sort(key=lambda x: x[1], reverse=True)
         last_commit_hash = timestamps[0][0]
         metrics = commits[last_commit_hash]
 

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -37,6 +37,9 @@ def get_commits(repo, filename):
     most_recent_commit = enumerate(repo.git.log('-n', '1', log_format).split('\n'))
     commits = set(change_commits) | set(most_recent_commit)
 
+    # Store the index in the ref-log as well as the timestamp, so that the
+    # ordering of commits will be deterministic and always in the correct
+    # order.
     result = {}
     for index, entry in commits:
         commit, timestamp = entry.strip('"').split(sep)

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -11,6 +11,7 @@ COMMITS_KEY = "git-commits"
 HISTORY_KEY = "history"
 NAME_KEY = "name"
 TYPE_KEY = "type"
+REFLOG_KEY = "reflog-index"
 
 
 def is_test_probe(probe_type, name):
@@ -247,10 +248,15 @@ def make_item_defn(definition, commit, commit_timestamps):
             "first": pretty_ts(commit_timestamps[commit][0]),
             "last": pretty_ts(commit_timestamps[commit][0])
         }
+        definition[REFLOG_KEY] = {
+            "first": commit_timestamps[commit][1],
+            "last": commit_timestamps[commit][1]
+        }
     else:
         # we've seen this definition, update the `last` commit
         definition[COMMITS_KEY]["last"] = commit
         definition[DATES_KEY]["last"] = pretty_ts(commit_timestamps[commit][0])
+        definition[REFLOG_KEY]["last"] = commit_timestamps[commit][1]
 
     return definition
 
@@ -277,7 +283,7 @@ def metrics_equal(def1, def2):
 
 def ping_equal(def1, def2):
     # Test all keys except the ones the probe-scraper adds
-    ignored_keys = set([DATES_KEY, COMMITS_KEY, HISTORY_KEY])
+    ignored_keys = set([DATES_KEY, COMMITS_KEY, HISTORY_KEY, REFLOG_KEY])
     all_keys = set(def1.keys()).union(def2.keys()).difference(ignored_keys)
 
     return all((
@@ -332,7 +338,7 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
     """
     :param commit_timestamps - of the form
       <repo_name>: {
-        <commit-hash>: <commit-timestamp>,
+        <commit-hash>: (<commit-timestamp>, <commit-index>),
         ...
       }
 
@@ -369,13 +375,20 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
         }
     """
 
+    # We need to sort by timestamp in ascending order, but reflog index in
+    # descending order.
+    def timestamp_sorter(entry):
+        return (entry[0], -entry[1])
+
     all_items = {}
     for repo_name, commits in data.items():
         repo_items = {}
 
         # iterate through commits, sorted by timestamp of the commit
-        sorted_commits = sorted(iter(commits.items()),
-                                key=lambda x_y: commit_timestamps[repo_name][x_y[0]])
+        sorted_commits = sorted(
+            iter(commits.items()),
+            key=lambda x_y: timestamp_sorter(commit_timestamps[repo_name][x_y[0]])
+        )
 
         for commit_hash, items in sorted_commits:
             for item, definition in items.items():

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -244,13 +244,13 @@ def make_item_defn(definition, commit, commit_timestamps):
             "last": commit
         }
         definition[DATES_KEY] = {
-            "first": pretty_ts(commit_timestamps[commit]),
-            "last": pretty_ts(commit_timestamps[commit])
+            "first": pretty_ts(commit_timestamps[commit][0]),
+            "last": pretty_ts(commit_timestamps[commit][0])
         }
     else:
         # we've seen this definition, update the `last` commit
         definition[COMMITS_KEY]["last"] = commit
-        definition[DATES_KEY]["last"] = pretty_ts(commit_timestamps[commit])
+        definition[DATES_KEY]["last"] = pretty_ts(commit_timestamps[commit][0])
 
     return definition
 

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -95,12 +95,16 @@ OUT_METRICS_DATA = {
                     "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
                     "notification_emails": ["telemetry-client-dev@mozilla.com"],
                     "git-commits": {
-                        "first": "0",
-                        "last": "3"
+                        "first": "3",
+                        "last": "0"
                     },
                     "dates": {
-                        "first": "1970-01-01 00:00:00",
-                        "last": "1970-01-01 00:00:03"
+                        "first": "1969-12-31 23:59:57",
+                        "last": "1970-01-01 00:00:00"
+                    },
+                    "reflog-index": {
+                        "first": 3,
+                        "last": 0
                     }
                 }
             ]
@@ -136,12 +140,16 @@ OUT_PING_DATA = {
                     "include_client_id": True,
                     "send_if_empty": False,
                     "git-commits": {
-                        "first": "0",
-                        "last": "3"
+                        "first": "3",
+                        "last": "0"
                     },
                     "dates": {
-                        "first": "1970-01-01 00:00:00",
-                        "last": "1970-01-01 00:00:03"
+                        "first": "1969-12-31 23:59:57",
+                        "last": "1970-01-01 00:00:00"
+                    },
+                    "reflog-index": {
+                        "first": 3,
+                        "last": 0
                     }
                 }
             ]
@@ -404,7 +412,7 @@ def test_transform_by_channel():
 def test_transform_metrics_by_hash():
     timestamps = {
         repo: {
-            str(i): i for i in range(4)
+            str(i): (-i, i) for i in range(4)
         } for repo in REPOS
     }
 
@@ -417,7 +425,7 @@ def test_transform_metrics_by_hash():
 def test_transform_pings_by_hash():
     timestamps = {
         repo: {
-            str(i): i for i in range(4)
+            str(i): (-i, i) for i in range(4)
         } for repo in REPOS
     }
 
@@ -460,7 +468,7 @@ def test_sort_ordering():
                     "type": "timespan",
                     "description": "  The duration of the last foreground session.",
                     "time_unit": "second",
-                    "send_in_pings": ["all_pings"],
+                    "send_in_pings": ["custom"],
                     "bugs": [1497894, 1519120],
                     "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
                     "notification_emails": ["telemetry-client-dev@mozilla.com"]
@@ -477,14 +485,26 @@ def test_sort_ordering():
                     "notification_emails": ["telemetry-client-dev@mozilla.com"]
                 },
             },
+            "3": {
+                "example.duration": {
+                    "type": "timespan",
+                    "description": "  The duration of the last foreground session.",
+                    "time_unit": "second",
+                    "send_in_pings": ["all_pings"],
+                    "bugs": [1497894, 1519120],
+                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                    "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                },
+            },
         }
     }
 
     timestamps = {
         "test-repo-0": {
-            "0": 0,
-            "1": 60 * 60 * 24,
-            "2": 2 * 60 * 60 * 24,
+            "0": (2 * 60 * 60 * 24, 0),
+            "1": (60 * 60 * 24, 1),
+            "2": (60 * 60 * 24, 2),
+            "3": (0, 3),
         }
     }
 
@@ -498,6 +518,48 @@ def test_sort_ordering():
                         "type": "timespan",
                         "description": "  The duration of the last foreground session.",
                         "time_unit": "second",
+                        "send_in_pings": ["all_pings"],
+                        "bugs": [1497894, 1519120],
+                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                        "notification_emails": ["telemetry-client-dev@mozilla.com"],
+                        "git-commits": {
+                            "first": "3",
+                            "last": "2"
+                        },
+                        "dates": {
+                            "first": "1970-01-01 00:00:00",
+                            "last": "1970-01-02 00:00:00"
+                        },
+                        "reflog-index": {
+                            "first": 3,
+                            "last": 2
+                        }
+                    },
+                    {
+                        "type": "timespan",
+                        "description": "  The duration of the last foreground session.",
+                        "time_unit": "second",
+                        "send_in_pings": ["custom"],
+                        "bugs": [1497894, 1519120],
+                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                        "notification_emails": ["telemetry-client-dev@mozilla.com"],
+                        "git-commits": {
+                            "first": "1",
+                            "last": "1"
+                        },
+                        "dates": {
+                            "first": "1970-01-02 00:00:00",
+                            "last": "1970-01-02 00:00:00"
+                        },
+                        "reflog-index": {
+                            "first": 1,
+                            "last": 1
+                        }
+                    },
+                    {
+                        "type": "timespan",
+                        "description": "  The duration of the last foreground session.",
+                        "time_unit": "second",
                         "send_in_pings": ["baseline"],
                         "bugs": [1497894, 1519120],
                         "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
@@ -507,25 +569,12 @@ def test_sort_ordering():
                             "last": "0"
                         },
                         "dates": {
-                            "first": "1970-01-01 00:00:00",
-                            "last": "1970-01-01 00:00:00",
-                        }
-                    },
-                    {
-                        "type": "timespan",
-                        "description": "  The duration of the last foreground session.",
-                        "time_unit": "second",
-                        "send_in_pings": ["all_pings"],
-                        "bugs": [1497894, 1519120],
-                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                        "notification_emails": ["telemetry-client-dev@mozilla.com"],
-                        "git-commits": {
-                            "first": "1",
-                            "last": "2"
+                            "first": "1970-01-03 00:00:00",
+                            "last": "1970-01-03 00:00:00"
                         },
-                        "dates": {
-                            "first": "1970-01-02 00:00:00",
-                            "last": "1970-01-03 00:00:00",
+                        "reflog-index": {
+                            "first": 0,
+                            "last": 0
                         }
                     }
                 ]


### PR DESCRIPTION
probe-scraper currently sorts commits based on the committer time, which is the time that commits in a PR are merged into master.  While this is mostly correct, all commits in a PR end up having the exact same timestamp, so their sorting order is non-deterministic.

This retains the order that the commits were reported from git-log (in addition to the timestamp), so that the correct sorting of commits *within* PRs is retained.

This should resolve the problem we were seeing [here](https://github.com/mozilla/mozilla-schema-generator/issues/118), where commits that changed a metric type within a PR would non-deterministically select the ultimate metric type.