### PR TITLE
Bug 1610616 - Create bugs for expiring probes

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -15,8 +15,8 @@ from probe_scraper.parsers.histograms import HistogramsParser
 from probe_scraper.parsers.scalars import ScalarsParser
 from probe_scraper.parsers.utils import get_major_version
 
-BUGZILLA_BUG_URL = "https://bugzilla-dev.allizom.org/rest/bug"
-BUGZILLA_USER_URL = "https://bugzilla-dev.allizom.org/rest/user"
+BUGZILLA_BUG_URL = "https://bugzilla.mozilla.org/rest/bug"
+BUGZILLA_USER_URL = "https://bugzilla.mozilla.org/rest/user"
 
 BASE_URI = "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/"
 HISTOGRAMS_FILE = "Histograms.json"
@@ -96,7 +96,7 @@ def search_bugs(version, request_header):
 
 def create_bug(probe_name, version, emails, request_header):
     description_notes = ("No emails associated with the probe have a "
-                         "corresponding Bugzilla account" if len(emails) > 0 else "")
+                         "corresponding Bugzilla account." if len(emails) == 0 else "")
 
     create_params = {
         "product": "Toolkit",

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -23,7 +23,7 @@ HISTOGRAMS_FILE = "Histograms.json"
 SCALARS_FILE = "Scalars.yaml"
 EVENTS_FILE = "Events.yaml"
 
-BUG_WHITEBOARD_TAG = 'probe-expiry-alert'
+BUG_WHITEBOARD_TAG = "probe-expiry-alert"
 BUG_SUMMARY_TEMPLATE = "Remove or update probe expiring in Firefox {version}: {probe}"
 BUG_RESOLVED_COMMENT_TEMPLATE = "This probe is no longer expiring in Firefox {version}."
 
@@ -87,7 +87,7 @@ def check_bugzilla_user_exists(email, request_headers):
 
 def search_bugs(version, request_header):
     search_query_params = {
-        "summary": BUG_SUMMARY_TEMPLATE.format(version=version, probe=''),
+        "summary": BUG_SUMMARY_TEMPLATE.format(version=version, probe=""),
         "whiteboard": BUG_WHITEBOARD_TAG,
     }
     return requests.get(BUGZILLA_BUG_URL, params=search_query_params,

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -20,6 +20,8 @@ from probe_scraper.parsers.utils import get_major_version
 FROM_EMAIL = "telemetry-alerts@mozilla.com"
 DEFAULT_TO_EMAIL = "dev-telemetry-alerts@lists.mozilla.org"
 
+BUGZILLA_URL = "https://bugzilla-dev.allizom.org/rest/bug"
+
 BASE_URI = "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/"
 HISTOGRAMS_FILE = "Histograms.json"
 SCALARS_FILE = "Scalars.yaml"
@@ -112,6 +114,10 @@ def send_emails_for_expiring_probes(expired_probes, expiring_probes,
     logging.info(f"Sent emails to {len(probes_by_email_by_state)} recipients")
 
 
+def file_bugs(expiring_probes, current_version, dryrun=True):
+    pass
+
+
 def download_file(url, output_filepath):
     content = requests.get(url).text
     with open(output_filepath, "w") as output_file:
@@ -158,9 +164,11 @@ def main(current_date, dryrun):
     # Only send emails on Wednesdays, run the rest for debugging/error detection
     if not dryrun and current_date.weekday() != 2:
         logging.info("Skipping emails because it is not Wednesday")
-        return
+        #return
 
-    send_emails_for_expiring_probes(expired_probes, expiring_probes, current_version, dryrun)
+    file_bugs(expiring_probes, current_version, dryrun)
+
+    #send_emails_for_expiring_probes(expired_probes, expiring_probes, current_version, dryrun)
 
 
 if __name__ == "__main__":

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -139,7 +139,7 @@ def file_bugs(probes, version, bugzilla_api_key, create_bugs=False):
     print(f"Found {len(found_bugs)} previously created bugs for version {version}")
 
     for bug in found_bugs:
-        probe_name = bug["summary"].split(" ")[-1]
+        probe_name = bug["summary"].split()[-1]
         if probe_name in probes.keys():
             probes.pop(probe_name)
 

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -47,7 +47,7 @@ The following Firefox probes will expire in the next major Firefox nightly relea
 
 What to do about this:
 1. If one, some, or all of the metrics are no longer needed, please remove them from their definitions files (Histograms.json, Scalars.yaml, Events.yaml).
-2. If one, some, or all of the metrics are still required, please submit a Data Collection Review [2] and patch to extend their expiry.
+2. If one, some, or all of the metrics are still required, please submit a Data Collection Review [2] and patch to extend their expiry.  There is a shorter form for data collection renewal [3].
 
 If you have any problems, please ask for help on the #fx-metrics Slack channel or the #telemetry Matrix room at https://chat.mozilla.org/#/room/#telemetry:mozilla.org. We'll give you a hand.
 
@@ -55,6 +55,7 @@ Your Friendly, Neighborhood Telemetry Team
 
 [1] https://wiki.mozilla.org/Release_Management/Calendar
 [2] https://wiki.mozilla.org/Firefox/Data_Collection
+[3] https://github.com/mozilla/data-review/blob/master/renewal_request.md
 
 This is an automated message sent from probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
 """  # noqa

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -8,6 +8,7 @@ from typing import List
 import argparse
 import datetime
 import os
+import re
 import tempfile
 
 import requests
@@ -27,34 +28,28 @@ SCALARS_FILE = "Scalars.yaml"
 EVENTS_FILE = "Events.yaml"
 
 BUG_WHITEBOARD_TAG = "probe-expiry-alert"
-BUG_SUMMARY_TEMPLATE = "Remove or update probe expiring in Firefox {version}: {probe}"
-BUG_RESOLVED_COMMENT_TEMPLATE = "This probe is no longer expiring in Firefox {version}."
+BUG_SUMMARY_TEMPLATE = "Remove or update probes expiring in Firefox {version}: {probe}"
 
 BUG_DESCRIPTION_TEMPLATE = """
-The following Firefox probe will expire in the next major Firefox nightly release: version {version} [1].
+The following Firefox probes will expire in the next major Firefox nightly release: version {version} [1].
 
-`{probe_name}`
+```
+{probes}
+```
 
 What to do about this:
 1. If one, some, or all of the metrics are no longer needed, please remove them from their definitions files (Histograms.json, Scalars.yaml, Events.yaml).
 2. If one, some, or all of the metrics are still required, please submit a Data Collection Review [2] and patch to extend their expiry.
 
-If you have any problems, please ask for help on the #fx-metrics Slack channel. We'll give you a hand.
+If you have any problems, please ask for help on the #fx-metrics Slack channel or the #telemetry Matrix room at https://chat.mozilla.org/#/room/#telemetry:mozilla.org. We'll give you a hand.
 
 Your Friendly, Neighborhood Telemetry Team
 
 [1] https://wiki.mozilla.org/Release_Management/Calendar
 [2] https://wiki.mozilla.org/Firefox/Data_Collection
 
-This is an automated bug created by probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
-
-{notes}
+This is an automated message sent from probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
 """  # noqa
-
-PROBE_LIST_FORMAT_STRING = """
-The following probes {verb} in Firefox version {version}:
-{probes}
-"""
 
 
 @dataclass
@@ -63,20 +58,18 @@ class ProbeDetails:
     product: str
     component: str
     emails: List[str]
+    previous_bug: int
 
     def __eq__(self, other):
         if type(other) == str:
             return self.name == other
         elif type(other) == type(self):
             return self.name == other.name
-        else:
-            raise ValueError(f'Incompatible comparison types: {type(self)} == {type(other)}')
+        raise ValueError(f'Incompatible comparison types: {type(self)} == {type(other)}')
 
 
 def bugzilla_request_header(api_key: str):
-    return {
-        "X-BUGZILLA-API-KEY": api_key
-    }
+    return {"X-BUGZILLA-API-KEY": api_key}
 
 
 def get_bug_component(bug_id: int, api_key: str):
@@ -90,6 +83,7 @@ def get_bug_component(bug_id: int, api_key: str):
 def search_bugs(api_key: str):
     search_query_params = {
         "whiteboard": BUG_WHITEBOARD_TAG,
+        "include_fields": "description,summary",
     }
     response = requests.get(BUGZILLA_BUG_URL, params=search_query_params,
                             headers=bugzilla_request_header(api_key))
@@ -97,33 +91,60 @@ def search_bugs(api_key: str):
     return response.json()["bugs"]
 
 
+def get_longest_prefix(values, tolerance=0):
+    """
+    Return the longest matching prefix among the list of strings.
+    If a prefix is less than 2 characters, return the first string.
+    Tolerance allows some characters to not match.
+    """
+    if len(values) == 1:
+        return values[0]
+    if len(values) == 0:
+        return ''
+
+    longest_match = []
+    for c in zip(*values):
+        if len(set(c)) > min([1 + tolerance, len(values) - 1]):
+            break
+        longest_match.append(c[0])
+
+    if len(longest_match) < 2:
+        return values[0]
+
+    return ''.join(longest_match) + '*'
+
+
 def create_bug(probes: List[ProbeDetails], version: str,  api_key: str):
-    description_notes = ("No emails associated with the probe have a "
-                         "corresponding Bugzilla account." if len(probes[0].emails) == 0 else "")
-    # TODO: THIS WHOLE THING
-    #create_params = {
-    #    "product": "Toolkit",
-    #    "component": "Telemetry",
-    #    "summary": BUG_SUMMARY_TEMPLATE.format(version=version, probe=probe_name),
-    #    "description": BUG_DESCRIPTION_TEMPLATE.format(
-    #        version=version, probe_name=probe_name, notes=description_notes),
-    #    "version": "unspecified",
-    #    "type": "task",
-    #    "whiteboard": BUG_WHITEBOARD_TAG,
-    #    "flags": [
-    #        {
-    #            "name": "needinfo",
-    #            "type_id": 800,
-    #            "status": "?",
-    #            "requestee": email,
-    #        }
-    #        for email in emails
-    #    ],
-    #}
-    #create_response = requests.post(BUGZILLA_BUG_URL, json=create_params,
-    #                                headers=headers=bugzilla_request_header(api_key))
-    #create_response.raise_for_status()
-    #print(f"Created bug {str(create_response.json())} for probe {probe_name}")
+    probe_names = [probe.name for probe in probes]
+    probe_prefix = get_longest_prefix(probe_names, tolerance=1)
+
+    create_params = {
+        "product": probes[0].product,
+        "component": probes[0].component,
+        "summary": BUG_SUMMARY_TEMPLATE.format(version=version, probe=probe_prefix),
+        "description": BUG_DESCRIPTION_TEMPLATE.format(
+            version=version, probes="\n".join(probe_names)),
+        "version": "unspecified",
+        "type": "task",
+        "whiteboard": BUG_WHITEBOARD_TAG,
+        "see_also": 1396144,  # TODO: probes[0].previous_bug,
+        "flags": [
+            {
+                "name": "needinfo",
+                "type_id": 800,
+                "status": "?",
+                "requestee": email,
+            }
+            for email in probes[0].emails
+        ],
+    }
+    create_response = requests.post(BUGZILLA_BUG_URL, json=create_params,
+                                    headers=bugzilla_request_header(api_key))
+    try:  # TODO: remove catch
+        create_response.raise_for_status()
+    except requests.HTTPError:
+        print(create_response.json())
+    print(f"Created bug {str(create_response.json())} for {probe_prefix}")
 
 
 def check_bugzilla_user_exists(email: str, api_key: str):
@@ -162,12 +183,16 @@ def find_expiring_probes(probes: dict, target_version: str,
         expiry_version = details["expiry_version"]
 
         if expiry_version == target_version:
-            product, component = (
-                get_bug_component(max(details["bug_numbers"]), bugzilla_api_key)
-                if len(details["bug_numbers"]) > 0 else ("Firefox", "General")
-            )
+            if len(details["bug_numbers"]) == 0:
+                last_bug_number = None
+                product = "Firefox"
+                component = "General"
+            else:
+                last_bug_number = max(details["bug_numbers"])
+                product, component = (get_bug_component(last_bug_number, bugzilla_api_key))
             expiring_probes.append(
-                ProbeDetails(name, product, component, details.get("notification_emails", [])))
+                ProbeDetails(name, product, component,
+                             details.get("notification_emails", []), last_bug_number))
 
     return expiring_probes
 
@@ -182,19 +207,27 @@ def file_bugs(probes: List[ProbeDetails], version: str,
         - if no bug exists for a given probe, create a bug
     """
     found_bugs = search_bugs(bugzilla_api_key)
-    print(f"Found {len(found_bugs)} previously created bugs for version {version}")
 
     new_expiring_probes = probes.copy()
-    #for bug in found_bugs:
-    #    probe_name = bug["summary"].split()[-1]
-    #    if probe_name in [probe.name for probe in probes]:
-    #        new_expiring_probes.remove(probe_name)
+    for bug in found_bugs:
+        # Regex for version and probe names requires bug description to be BUG_DESCRIPTION_TEMPLATE
+        if re.search("release: version (\d+)", bug["description"]).group(1) != version:
+            continue
+        probes_in_bug = re.search("```(.*)```", bug["description"], re.DOTALL).group(1).split()
+        for probe_name in probes_in_bug:
+            if probe_name in [probe.name for probe in probes]:
+                new_expiring_probes.remove(probe_name)
+
+    print(f"Found previously created bugs for {len(probes) - len(new_expiring_probes)} probes "
+          f"for version {version}")
 
     # group by component and email
     probes_by_component_by_email_set = defaultdict(list)
     for probe in new_expiring_probes:
         probes_by_component_by_email_set[
             (probe.product, probe.component, ','.join(sorted(probe.emails)))].append(probe)
+
+    print(f"creating {len(probes_by_component_by_email_set)} new bugs")
 
     for grouping, probe_group in probes_by_component_by_email_set.items():
         if create_bugs:
@@ -229,14 +262,14 @@ def main(current_date: datetime.datetime, dryrun: bool, bugzilla_api_key: str):
     # Only send create bugs on Wednesdays, run the rest for debugging/error detection
     create_bugs = not dryrun and current_date.weekday() == 2
 
-    # find emails with no bugzilla account and group probes by bug component and emails
+    # find emails with no bugzilla account
     emails_wo_accounts = defaultdict(list)
-
     for probe_name, email_list in [(probe.name, probe.emails) for probe in expiring_probes]:
         for i, email in enumerate(email_list.copy()):
-            if not check_bugzilla_user_exists(email, bugzilla_api_key):
+            if (email in emails_wo_accounts.keys() or
+                    not check_bugzilla_user_exists(email, bugzilla_api_key)):
                 emails_wo_accounts[email].append(probe_name)
-                email_list.pop(i)
+                email_list.remove(email)
 
     file_bugs(expiring_probes, next_version, bugzilla_api_key, create_bugs=create_bugs)
 

--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -98,9 +98,9 @@ def find_existing_bugs(version: str, api_key: str) -> Set[str]:
 
     probes_with_bugs = set()
     for bug in found_bugs:
-        if re.search("release: version (\d+)", bug["description"]).group(1) != version:
+        if re.search(r"release: version (\d+)", bug["description"]).group(1) != version:
             continue
-        probes_in_bug = re.search("```(.*)```", bug["description"], re.DOTALL).group(1).split()
+        probes_in_bug = re.search(r"```(.*)```", bug["description"], re.DOTALL).group(1).split()
         for probe_name in probes_in_bug:
             probes_with_bugs.add(probe_name)
 
@@ -143,7 +143,7 @@ def get_longest_prefix(values: List[str], tolerance: int = 0) -> str:
     return sorted(prefix_count.items(), key=lambda item: item[1], reverse=True)[0][0] + '*'
 
 
-def create_bug(probes: List[ProbeDetails], version: str,  api_key: str) -> int:
+def create_bug(probes: List[ProbeDetails], version: str, api_key: str) -> int:
     probe_names = [probe.name for probe in probes]
     probe_prefix = get_longest_prefix(probe_names, tolerance=1)
 

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -92,8 +92,8 @@ def test_main_runs_once_per_week(mock_file_bugs, mock_get_version,
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
 @mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
 def test_dryrun_doesnt_create_bugs(mock_file_bugs, mock_get_version,
-                                 mock_download_file, mock_scalars_parser,
-                                 mock_histograms_parser, mock_events_parser):
+                                   mock_download_file, mock_scalars_parser,
+                                   mock_histograms_parser, mock_events_parser):
     mock_events_parser.return_value = {}
     mock_histograms_parser.return_value = {}
     mock_scalars_parser.return_value = {}
@@ -191,4 +191,3 @@ def test_search_bugs_param_creation(mock_get):
 @mock.patch("requests.post")
 def test_create_bug_param_creation(mock_post):
     probe_expiry_alert.create_bug("p1", "12", ["a@test.com", "b@test.com"], {})
-

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -1,8 +1,9 @@
+import datetime
 from dataclasses import dataclass
 from unittest import mock
-import datetime
 
 from probe_scraper import probe_expiry_alert
+from probe_scraper.probe_expiry_alert import ProbeDetails
 
 
 @dataclass
@@ -22,8 +23,9 @@ def test_find_expiring_probes_no_expiring():
     expiring_probes = probe_expiry_alert.find_expiring_probes(
         probes,
         "75",
+        "",
     )
-    expected = {}
+    expected = []
     assert expiring_probes == expected
 
 
@@ -32,34 +34,54 @@ def test_find_expiring_probes_channel_no_probes():
     expiring_probes = probe_expiry_alert.find_expiring_probes(
         probes,
         "75",
+        "",
     )
-    expected = {}
+    expected = []
     assert expiring_probes == expected
 
 
-def test_find_expiring_probes_expiring():
+@mock.patch("probe_scraper.probe_expiry_alert.get_bug_component")
+def test_find_expiring_probes_expiring(mock_get_bug_component):
+    mock_get_bug_component.return_value = "prod", "comp"
+
     probes = {
         "p1": {
             "expiry_version": "74",
             "notification_emails": ["test@email.com"],
+            "bug_numbers": [],
         },
         "p2": {
             "expiry_version": "75",
             "notification_emails": ["test@email.com"],
+            "bug_numbers": [1],
         },
         "p3": {
-            "expiry_version": "75"
+            "expiry_version": "75",
+            "bug_numbers": [],
         },
     }
     expiring_probes = probe_expiry_alert.find_expiring_probes(
         probes,
         "75",
+        "",
     )
-    expected = {
-        "p2": ["test@email.com"],
-        "p3": [],
-    }
-    assert expiring_probes == expected
+    expected = [
+        {
+            "name": "p2",
+            "product": "prod",
+            "component": "comp",
+            "emails": ["test@email.com"],
+            "previous_bug": 1,
+        },
+        {
+            "name": "p3",
+            "product": "Firefox",
+            "component": "General",
+            "emails": [],
+            "previous_bug": None,
+        },
+    ]
+    assert [probe.__dict__ for probe in expiring_probes] == expected
 
 
 @mock.patch("probe_scraper.parsers.events.EventsParser.parse")
@@ -68,9 +90,11 @@ def test_find_expiring_probes_expiring():
 @mock.patch("probe_scraper.probe_expiry_alert.download_file")
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
 @mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
-def test_main_runs_once_per_week(mock_file_bugs, mock_get_version,
-                                 mock_download_file, mock_scalars_parser,
-                                 mock_histograms_parser, mock_events_parser):
+@mock.patch("probe_scraper.probe_expiry_alert.send_emails")
+def test_not_dryrun_only_once_per_week(mock_send_emails, mock_file_bugs, mock_get_version,
+                                       mock_download_file, mock_scalars_parser,
+                                       mock_histograms_parser, mock_events_parser):
+    mock_file_bugs.return_value = {}
     mock_events_parser.return_value = {}
     mock_histograms_parser.return_value = {}
     mock_scalars_parser.return_value = {}
@@ -79,10 +103,78 @@ def test_main_runs_once_per_week(mock_file_bugs, mock_get_version,
         base_date = datetime.date(2020, 1, 1)
         probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), False, "")
 
-    mock_file_bugs.assert_has_calls([mock.call({}, "76", "", create_bugs=False)] * 6 +
-                                    [mock.call({}, "76", "", create_bugs=True)],
+    mock_file_bugs.assert_has_calls([mock.call([], "76", "", dryrun=False)] +
+                                    [mock.call([], "76", "", dryrun=True)] * 6,
                                     any_order=True)
     assert mock_file_bugs.call_count == 7
+    mock_send_emails.assert_has_calls([mock.call({}, {}, "76", dryrun=False)] +
+                                      [mock.call({}, {}, "76", dryrun=True)] * 6,
+                                      any_order=True)
+    assert mock_send_emails.call_count == 7
+
+
+@mock.patch("probe_scraper.probe_expiry_alert.find_existing_bugs")
+@mock.patch("probe_scraper.probe_expiry_alert.create_bug")
+def test_no_bugs_created_on_dryrun(mock_create_bug, mock_find_bugs):
+    mock_find_bugs.return_value = set()
+    expiring_probes = [
+        ProbeDetails("p1", "", "", [], 1),
+        ProbeDetails("p2", "", "", ['a@test.com'], 1),
+    ]
+
+    probe_expiry_alert.file_bugs(expiring_probes, "76", "", dryrun=True)
+
+    assert mock_create_bug.call_count == 0
+
+
+@mock.patch("probe_scraper.probe_expiry_alert.find_existing_bugs")
+@mock.patch("probe_scraper.probe_expiry_alert.create_bug")
+def test_bugs_created_not_dryrun(mock_create_bug, mock_find_bugs):
+    mock_find_bugs.return_value = []
+    expiring_probes = [
+        ProbeDetails("p1", "1", "2", [], 1),
+        ProbeDetails("p2", "3", "4", ['a@test.com'], 1),
+    ]
+
+    probe_expiry_alert.file_bugs(expiring_probes, "76", "", dryrun=False)
+
+    assert mock_create_bug.call_count == 2
+
+
+@mock.patch("boto3.client")
+def test_no_email_sent_on_dryrun(mock_boto_client):
+    probes_by_email = {
+        "a@test.com": ["p1", "p2"],
+        "b@test.com": ["p1", "p2"],
+        "c@test.com": ["p3"],
+    }
+    probe_to_bug_id = {
+        "p1": 1,
+        "p2": 2,
+        "p3": 3,
+    }
+
+    probe_expiry_alert.send_emails(probes_by_email, probe_to_bug_id, "75", dryrun=True)
+
+    assert mock_boto_client.call_count == 0
+
+
+@mock.patch("boto3.client")
+def test_send_email_not_dryrun(mock_boto_client):
+    probes_by_email = {
+        "a@test.com": ["p1", "p2"],
+        "b@test.com": ["p1", "p2"],
+        "c@test.com": ["p3"],
+    }
+    probe_to_bug_id = {
+        "p1": 1,
+        "p2": 2,
+        "p3": 3,
+    }
+
+    probe_expiry_alert.send_emails(probes_by_email, probe_to_bug_id, "75", dryrun=False)
+
+    assert mock_boto_client.call_count == 4
 
 
 @mock.patch("probe_scraper.parsers.events.EventsParser.parse")
@@ -90,104 +182,122 @@ def test_main_runs_once_per_week(mock_file_bugs, mock_get_version,
 @mock.patch("probe_scraper.parsers.scalars.ScalarsParser.parse")
 @mock.patch("probe_scraper.probe_expiry_alert.download_file")
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
+@mock.patch("probe_scraper.probe_expiry_alert.check_bugzilla_user_exists")
 @mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
-def test_dryrun_doesnt_create_bugs(mock_file_bugs, mock_get_version,
-                                   mock_download_file, mock_scalars_parser,
-                                   mock_histograms_parser, mock_events_parser):
-    mock_events_parser.return_value = {}
-    mock_histograms_parser.return_value = {}
-    mock_scalars_parser.return_value = {}
-    mock_get_version.return_value = "75"
-    for weekday in range(7):
-        base_date = datetime.date(2020, 1, 1)
-        probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), True, "")
-
-    mock_file_bugs.assert_has_calls([mock.call({}, "76", "", create_bugs=False)] * 7,
-                                    any_order=True)
-    assert mock_file_bugs.call_count == 7
-
-
-@mock.patch("probe_scraper.parsers.events.EventsParser.parse")
-@mock.patch("probe_scraper.parsers.histograms.HistogramsParser.parse")
-@mock.patch("probe_scraper.parsers.scalars.ScalarsParser.parse")
-@mock.patch("probe_scraper.probe_expiry_alert.download_file")
-@mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
-@mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
-def test_main_run(mock_file_bugs, mock_get_version, mock_download_file,
-                  mock_scalars_parser, mock_histograms_parser, mock_events_parser):
+@mock.patch("probe_scraper.probe_expiry_alert.send_emails")
+def test_main_run(mock_send_emails, mock_file_bugs, mock_user_exists,
+                  mock_get_version, mock_download_file, mock_scalars_parser,
+                  mock_histograms_parser, mock_events_parser):
+    mock_user_exists.return_value = False
     mock_events_parser.return_value = {
         "p1": {
             "expiry_version": "76",
             "notification_emails": ["test@email.com"],
+            "bug_numbers": [],
         }
     }
     mock_histograms_parser.return_value = {
         "p2": {
             "expiry_version": "75",
             "notification_emails": ["test@email.com"],
+            "bug_numbers": [],
         }
     }
     mock_scalars_parser.return_value = {
         "p3": {
             "expiry_version": "77",
             "notification_emails": ["test@email.com"],
+            "bug_numbers": [],
         }
     }
     mock_get_version.return_value = "75"
 
-    probe_expiry_alert.main(datetime.date(2020, 1, 8), True, "")
+    probe_expiry_alert.main(datetime.date(2020, 1, 8), False, "")
 
-    expected_expiring_probes = {
-        "p1": [
-            "test@email.com",
-        ]
-    }
-    mock_file_bugs.assert_called_once_with(expected_expiring_probes, "76", "", create_bugs=False)
-
-
-@mock.patch("probe_scraper.probe_expiry_alert.search_bugs")
-@mock.patch("probe_scraper.probe_expiry_alert.create_bug")
-def test_bugs_created_only_for_new_probes(mock_create_bugs, mock_search_bugs):
-    mock_search_bugs.return_value = [
-        {"summary": "p2"},
-        {"summary": "p3"}
+    expected_expiring_probes = [
+        ProbeDetails("p1", "Firefox", "General", [], None)
     ]
-    probes = {
-        "p1": [],
-        "p2": [],
-        "p3": [],
-        "p4": [],
-    }
-    probe_expiry_alert.file_bugs(probes, "1", "", create_bugs=True)
+    mock_file_bugs.assert_called_once_with(expected_expiring_probes, "76", "", dryrun=False)
+
+
+@mock.patch("probe_scraper.probe_expiry_alert.find_existing_bugs")
+@mock.patch("probe_scraper.probe_expiry_alert.create_bug")
+def test_bugs_created_only_for_new_probes(mock_create_bugs, mock_find_bugs):
+    mock_find_bugs.return_value = {"p2", "p3"}
+    probes = [
+        ProbeDetails("p1", "", "", ["email1"], 1),
+        ProbeDetails("p2", "", "", [], 1),
+        ProbeDetails("p3", "", "", [], 1),
+        ProbeDetails("p4", "", "", ["email2"], 1),
+    ]
+    probe_expiry_alert.file_bugs(probes, "1", "", dryrun=False)
 
     assert mock_create_bugs.call_count == 2
     mock_create_bugs.has_calls([
-        mock.call("p1", "1", [], mock.ANY),
-        mock.call("p4", "1", [], mock.ANY)
+        mock.call(ProbeDetails("p1", "", "", ["email1"], 1), "1", mock.ANY),
+        mock.call(ProbeDetails("p4", "", "", ["email2"], 1), "1", mock.ANY),
     ], any_order=True)
 
 
-@mock.patch("probe_scraper.probe_expiry_alert.check_bugzilla_user_exists")
-@mock.patch("probe_scraper.probe_expiry_alert.search_bugs")
-@mock.patch("probe_scraper.probe_expiry_alert.create_bug")
-def test_bugs_do_not_contain_invalid_accounts(mock_create_bugs, mock_search_bugs,
-                                              mock_account_check):
-    mock_search_bugs.return_value = []
-    mock_account_check.side_effect = lambda email, x: email.startswith("invalid")
+@mock.patch("requests.post")
+def test_create_bug(mock_post):
+    mock_response = mock.MagicMock()
+    mock_response.json = mock.MagicMock(return_value={"id": 2})
+    mock_post.return_value = mock_response
 
-    probes = {
-        "p1": ["invalid1@test.com", "a@test.com", "invalid2@test.com"],
-    }
-    probe_expiry_alert.file_bugs(probes, "1", "", create_bugs=True)
+    probes = [
+        ProbeDetails("p1", "prod", "comp", ["a@test.com", "b@test.com"], 1),
+        ProbeDetails("p1", "prod", "comp", ["a@test.com", "b@test.com"], 1),
+    ]
+    bug_id = probe_expiry_alert.create_bug(probes, "76", "")
 
-    mock_create_bugs.called_once_with("p1", "1", ["a@test.com"], mock.ANY)
+    assert bug_id == 2
 
 
 @mock.patch("requests.get")
-def test_search_bugs_param_creation(mock_get):
-    probe_expiry_alert.search_bugs({})
+def test_bug_description_parser(mock_get):
+    """
+    Checking if current expiring probes have already had bugs filed uses regex on the bug
+    description.  So if the bug description changes such that the regex fails, this test
+    should fail.
+    """
+    search_results = {
+        "bugs": [
+            {
+                "summary": "",
+                "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
+                    version="76", probes="\np1\np2 \n", notes=""),
+            },
+            {
+                "summary": "",
+                "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
+                    version="77", probes="\n p3 p4", notes=""),
+            },
+            {
+                "summary": "",
+                "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
+                    version="76", probes="\np5 p6\n", notes=""),
+            },
+        ]
+    }
+    mock_response = mock.MagicMock()
+    mock_response.json = mock.MagicMock(return_value=search_results)
+    mock_get.return_value = mock_response
+
+    probes_with_bugs = probe_expiry_alert.find_existing_bugs("76", "")
+
+    assert probes_with_bugs == {"p1", "p2", "p5", "p6"}
 
 
-@mock.patch("requests.post")
-def test_create_bug_param_creation(mock_post):
-    probe_expiry_alert.create_bug("p1", "12", ["a@test.com", "b@test.com"], {})
+def test_get_longest_prefix():
+    values = [
+        "FX_PICTURE_IN_PICTURE_WINDOW_OPEN_DURATION",
+        "pictureinpicture.opened_method",
+        "pictureinpicture.closed_method",
+        "",
+    ]
+    assert probe_expiry_alert.get_longest_prefix(values, 0) == values[0]
+    assert probe_expiry_alert.get_longest_prefix(values, 1) == values[0]
+    assert probe_expiry_alert.get_longest_prefix(values, 2) == "pictureinpicture.*"
+    assert probe_expiry_alert.get_longest_prefix([]) == ""
+    assert probe_expiry_alert.get_longest_prefix(["abc"]) == "abc"

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -185,7 +185,7 @@ def test_bugs_do_not_contain_invalid_accounts(mock_create_bugs, mock_search_bugs
 
 @mock.patch("requests.get")
 def test_search_bugs_param_creation(mock_get):
-    probe_expiry_alert.search_bugs("123", {})
+    probe_expiry_alert.search_bugs({})
 
 
 @mock.patch("requests.post")

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from collections import defaultdict
 from unittest import mock
 import datetime
 
@@ -57,78 +56,10 @@ def test_find_expiring_probes_expiring():
         "75",
     )
     expected = {
-        "p2": ["test@email.com", probe_expiry_alert.DEFAULT_TO_EMAIL],
-        "p3": [probe_expiry_alert.DEFAULT_TO_EMAIL],
+        "p2": ["test@email.com"],
+        "p3": [],
     }
     assert expiring_probes == expected
-
-
-@mock.patch("boto3.client")
-def test_send_email_dryrun_doesnt_send(mock_boto_client):
-    expiring_probes = {
-        "p1": ["email"]
-    }
-    probe_expiry_alert.send_emails_for_expiring_probes(
-        {},
-        expiring_probes,
-        "75",
-        dryrun=False,
-    )
-    # make sure send_raw_email is the right method
-    mock_boto_client().send_raw_email.assert_called_once()
-
-    probe_expiry_alert.send_emails_for_expiring_probes(
-        {},
-        expiring_probes,
-        "75",
-        dryrun=True,
-    )
-    mock_boto_client().send_raw_email.assert_called_once()
-
-
-@mock.patch("probe_scraper.emailer.send_ses")
-def test_send_email(mock_send_email):
-    expired_probes = {
-        "expired_probe_1": ["email1", "email2"],
-        "expired_probe_2": ["email1"],
-    }
-    expiring_probes = {
-        "expiring_probe_1": ["email1"],
-        "expiring_probe_2": ["email1"],
-    }
-
-    send_email_args = defaultdict(list)
-
-    def update_call_args(*args, **kwargs):
-        send_email_args[kwargs["recipients"]].append(kwargs["body"])
-
-    mock_send_email.side_effect = update_call_args
-
-    probe_expiry_alert.send_emails_for_expiring_probes(
-        expired_probes,
-        expiring_probes,
-        "75",
-        dryrun=True,
-    )
-
-    assert mock_send_email.call_count == 2
-
-    assert "email1" in send_email_args.keys()
-    assert "email2" in send_email_args.keys()
-    assert len(send_email_args["email1"]) == 1
-    assert len(send_email_args["email2"]) == 1
-
-    email_body = send_email_args["email2"][0]
-    assert email_body.count("expiring_probe_1") == 0
-    assert email_body.count("expiring_probe_2") == 0
-    assert email_body.count("expired_probe_1") == 1
-    assert email_body.count("expired_probe_2") == 0
-
-    email_body = send_email_args["email1"][0]
-    assert email_body.count("expiring_probe_1") == 1
-    assert email_body.count("expiring_probe_2") == 1
-    assert email_body.count("expired_probe_1") == 1
-    assert email_body.count("expired_probe_2") == 1
 
 
 @mock.patch("probe_scraper.parsers.events.EventsParser.parse")
@@ -136,18 +67,22 @@ def test_send_email(mock_send_email):
 @mock.patch("probe_scraper.parsers.scalars.ScalarsParser.parse")
 @mock.patch("probe_scraper.probe_expiry_alert.download_file")
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
-@mock.patch("probe_scraper.probe_expiry_alert.send_emails_for_expiring_probes")
-def test_main_runs_once_per_week(mock_send_emails, mock_get_version, mock_download_file,
-                                 mock_scalars_parser, mock_histograms_parser, mock_events_parser):
+@mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
+def test_main_runs_once_per_week(mock_file_bugs, mock_get_version,
+                                 mock_download_file, mock_scalars_parser,
+                                 mock_histograms_parser, mock_events_parser):
     mock_events_parser.return_value = {}
     mock_histograms_parser.return_value = {}
     mock_scalars_parser.return_value = {}
     mock_get_version.return_value = "75"
     for weekday in range(7):
         base_date = datetime.date(2020, 1, 1)
-        probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), False)
+        probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), False, "")
 
-    mock_send_emails.assert_called_once()
+    mock_file_bugs.assert_has_calls([mock.call({}, "76", "", create_bugs=False)] * 6 +
+                                    [mock.call({}, "76", "", create_bugs=True)],
+                                    any_order=True)
+    assert mock_file_bugs.call_count == 7
 
 
 @mock.patch("probe_scraper.parsers.events.EventsParser.parse")
@@ -155,8 +90,30 @@ def test_main_runs_once_per_week(mock_send_emails, mock_get_version, mock_downlo
 @mock.patch("probe_scraper.parsers.scalars.ScalarsParser.parse")
 @mock.patch("probe_scraper.probe_expiry_alert.download_file")
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
-@mock.patch("probe_scraper.probe_expiry_alert.send_emails_for_expiring_probes")
-def test_main_run(mock_send_emails, mock_get_version, mock_download_file,
+@mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
+def test_dryrun_doesnt_create_bugs(mock_file_bugs, mock_get_version,
+                                 mock_download_file, mock_scalars_parser,
+                                 mock_histograms_parser, mock_events_parser):
+    mock_events_parser.return_value = {}
+    mock_histograms_parser.return_value = {}
+    mock_scalars_parser.return_value = {}
+    mock_get_version.return_value = "75"
+    for weekday in range(7):
+        base_date = datetime.date(2020, 1, 1)
+        probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), True, "")
+
+    mock_file_bugs.assert_has_calls([mock.call({}, "76", "", create_bugs=False)] * 7,
+                                    any_order=True)
+    assert mock_file_bugs.call_count == 7
+
+
+@mock.patch("probe_scraper.parsers.events.EventsParser.parse")
+@mock.patch("probe_scraper.parsers.histograms.HistogramsParser.parse")
+@mock.patch("probe_scraper.parsers.scalars.ScalarsParser.parse")
+@mock.patch("probe_scraper.probe_expiry_alert.download_file")
+@mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
+@mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
+def test_main_run(mock_file_bugs, mock_get_version, mock_download_file,
                   mock_scalars_parser, mock_histograms_parser, mock_events_parser):
     mock_events_parser.return_value = {
         "p1": {
@@ -178,19 +135,32 @@ def test_main_run(mock_send_emails, mock_get_version, mock_download_file,
     }
     mock_get_version.return_value = "75"
 
-    probe_expiry_alert.main(datetime.date(2020, 1, 8), True)
+    probe_expiry_alert.main(datetime.date(2020, 1, 8), True, "")
 
-    expected_expired_probes = {
-        "p2": [
-            "test@email.com",
-            probe_expiry_alert.DEFAULT_TO_EMAIL,
-        ]
-    }
     expected_expiring_probes = {
         "p1": [
             "test@email.com",
-            probe_expiry_alert.DEFAULT_TO_EMAIL,
         ]
     }
-    mock_send_emails.assert_called_once_with(
-        expected_expired_probes, expected_expiring_probes, mock.ANY, True)
+    mock_file_bugs.assert_called_once_with(expected_expiring_probes, "76", "", create_bugs=False)
+
+
+def test_bugs_created_for_new_probes():
+    pass
+
+
+def test_bugs_not_created_for_existing_bugs():
+    pass
+
+
+def test_bugs_do_not_contain_invalid_accounts():
+    pass
+
+
+def test_search_bugs_param_creation():
+    pass
+
+
+def test_create_bug_param_creation():
+    pass
+


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1610616

Here are some example bugs:
 - with ni?: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1396101
 - with no accounts: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1396100

This will create  a bug in toolkit -> telemetry with the whiteboard `probe-expiry-alert` and won't close the bug if the probe is no longer expiring

@chutten any additional bug metadata to add that would make triage easier?