### PR TITLE
FOGotype is dead, long live Project FOG

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -138,16 +138,6 @@ firefox-reality:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:support-sync-telemetry
-fogotype:
-  app_id: org-mozilla-fogotype
-  notification_emails:
-    - frank@mozilla.com
-    - chutten@mozilla.com
-  url: 'https://github.com/mozilla/gecko-dev'
-  dependencies:
-    - org.mozilla.components:service-glean
-  ping_files:
-    - 'toolkit/components/telemetry/fog/pings.yaml'
 lockwise-android:
   app_id: mozilla-lockbox
   notification_emails:


### PR DESCRIPTION
Is it safe to just remove it?
We deactivated it on Firefox Nightly a while ago and are not interested in any of that data anymore.