### PR TITLE
Switch default branch for Glean and avoid assumption of branch names

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -62,7 +62,7 @@ Your Friendly, Neighborhood Glean Team
 def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
     """
     Checks for duplicate metric names across all libraries used by a particular application.
-    It only checks for metrics that exist in the latest (master) commit in each repo, so that
+    It only checks for metrics that exist in the latest (HEAD) commit in each repo, so that
     it's possible to remove (or disable) the metric in the latest commit and not have this
     check repeatedly fail.
     If duplicates are found, e-mails are queued and this returns True.
@@ -199,7 +199,7 @@ def check_for_expired_metrics(
             continue
 
         metrics_yaml_url = "\n".join(
-            f"{repo.url}/tree/master/{file}" for file in repo.metrics_file_paths
+            f"{repo.url}/tree/HEAD/{file}" for file in repo.metrics_file_paths
         )
 
         emails[f"expired_metrics_{repo_name}"] = {

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -4,6 +4,7 @@ glean:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
   url: 'https://github.com/mozilla/glean'
+  branch: main
   metrics_files:
     - 'glean-core/android/metrics.yaml'
     - 'glean-core/metrics.yaml'

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from git import Repo
+from git import Repo, Head
 from probe_scraper import runner
 from probe_scraper.emailer import EMAIL_FILE
 from probe_scraper.transform_probes import HISTORY_KEY, COMMITS_KEY
@@ -61,6 +61,10 @@ def run_before_tests():
 def get_repo(repo_name):
     directory = os.path.join(test_dir, repo_name)
     repo = Repo.init(directory)
+    # Ensure the default branch is using a fixed name.
+    # User config could change that,
+    # breaking tests with implicit assumptions further down the line.
+    repo.head.reference = Head(repo, 'refs/heads/master')
 
     # We need to synthesize the time stamps of commits to each be a second
     # apart, otherwise the commits may be at exactly the same second, which


### PR DESCRIPTION
In my quest to breaking more software I think I succeeded and broke probe-scraper. The first commit should fix that.

The other commits get rid of some implicit assumptions in how we use git.
GitPython respects user config, which can overwrite some defaults (by e.g. providing a template directory), leading to test failures if the branch name isn't what is expected.
By explicitly setting the head reference before the first commit the assumptions further down the line are upheld.