### PR TITLE
Fix yaml.load safety warning.

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -55,7 +55,7 @@ class RepositoriesParser(object):
             filename = REPOSITORIES_FILENAME
 
         with open(filename, 'r') as f:
-            repos = yaml.load(f, Loader=yaml.FullLoader)
+            repos = yaml.load(f, Loader=yaml.SafeLoader)
 
         return repos
 

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -55,7 +55,7 @@ class RepositoriesParser(object):
             filename = REPOSITORIES_FILENAME
 
         with open(filename, 'r') as f:
-            repos = yaml.load(f)
+            repos = yaml.load(f, Loader=yaml.FullLoader)
 
         return repos
 

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -201,7 +201,7 @@ def test_improper_metrics_repo(improper_metrics_repo):
     assert not metrics
 
     with open(EMAIL_FILE, 'r') as email_file:
-        emails = yaml.load(email_file)
+        emails = yaml.load(email_file, Loader=yaml.FullLoader)
 
     # should send 1 email
     assert len(emails) == 1
@@ -247,7 +247,7 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
         assert False, "Expected exception"
 
     with open(EMAIL_FILE, 'r') as email_file:
-        emails = yaml.load(email_file)
+        emails = yaml.load(email_file, Loader=yaml.FullLoader)
 
     # should send 1 email
     assert len(emails) == 1
@@ -298,7 +298,7 @@ def test_check_for_expired_metrics(expired_repo):
                     True, None, None, None, None, 'dev')
 
     with open(EMAIL_FILE, 'r') as email_file:
-        emails = yaml.load(email_file)
+        emails = yaml.load(email_file, Loader=yaml.FullLoader)
 
     # should send 1 email
     assert len(emails) == 1


### PR DESCRIPTION
When running the probe scraper, I saw a message like:
  `/path/to/probe-scraper/probe_scraper/parsers/repositories.py:58: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.`

The recommended fix is to change a call like
  `yaml.load('myfile.yaml')`
to
  `yaml.load('myfile.yaml', Loader=yaml.FullLoader)`

So here we make this change for each `yaml.load` call in the tests, and use the `SafeLoader` in the main code.