### PR TITLE
Update application-services repo definitions to use branch `main`.

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -164,10 +164,11 @@ logins-store:
   notification_emails:
     - rfkelly@mozilla.com
     - lina@mozilla.com
-    - application-services@mozilla.com
+    - sync-team@mozilla.com
   url: 'https://github.com/mozilla/application-services'
   metrics_files:
     - 'components/logins/android/metrics.yaml'
+  branch: main
   library_names:
     - org.mozilla.appservices:logins
 support-migration:
@@ -282,9 +283,11 @@ android-places:
   app_id: android-places
   notification_emails:
     - frank@mozilla.com
+    - sync-team@mozilla.com
   url: 'https://github.com/mozilla/application-services'
   metrics_files:
     - 'components/places/android/metrics.yaml'
+  branch: main
   library_names:
     - org.mozilla.components:places
 mozphab:


### PR DESCRIPTION
We recently switch from `master` to `main` as the default branch for the `application-services` repo, this updates the probe-scraper repository definitions to look in the right place. I expect this will fix #200.