### PR TITLE
bug 1650782 - Reroute emails previously sent to dev-telemetry-alerts to glean-team

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -20,7 +20,7 @@ from probe_scraper.parsers.scalars import ScalarsParser
 from probe_scraper.parsers.utils import get_major_version
 
 FROM_EMAIL = "telemetry-alerts@mozilla.com"
-DEFAULT_TO_EMAIL = "dev-telemetry-alerts@lists.mozilla.org"
+DEFAULT_TO_EMAIL = "glean-team@mozilla.com"
 
 BUGZILLA_BUG_URL = "https://bugzilla.mozilla.org/rest/bug"
 BUGZILLA_USER_URL = "https://bugzilla.mozilla.org/rest/user"
@@ -256,7 +256,7 @@ def find_expiring_probes(probes: dict, target_version: str,
 
 def send_emails(probes_by_email: Dict[str, List[str]], probe_to_bug_id: Dict[str, int],
                 version: str, dryrun: bool = True):
-    # send all probes to dev-telemetry-alerts for debugging
+    # send all probes to glean-team for debugging
     probes_by_email[DEFAULT_TO_EMAIL] = list(set(sum(probes_by_email.values(), [])))
 
     email_count = 0

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -33,7 +33,7 @@ class DummyParser:
 
 
 FROM_EMAIL = "telemetry-alerts@mozilla.com"
-DEFAULT_TO_EMAIL = "dev-telemetry-alerts@mozilla.com"
+DEFAULT_TO_EMAIL = "glean-team@mozilla.com"
 FIRST_APPEARED_DATE_KEY = "first_added"
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -264,7 +264,7 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
         'repo_alice@example.com',
         'repo_bob@example.com',
         # Everything goes here
-        'dev-telemetry-alerts@mozilla.com'
+        'glean-team@mozilla.com'
     ])
 
 
@@ -311,5 +311,5 @@ def test_check_for_expired_metrics(expired_repo):
         # Repo owners
         'repo_alice@example.com',
         # Everything goes here
-        'dev-telemetry-alerts@mozilla.com'
+        'glean-team@mozilla.com'
     ])


### PR DESCRIPTION
dev-telemetry-alerts is to be decommissioned.