### PR TITLE
Bug 1654788: Upgrade glean_parser to handle new data_sensitivity metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ awscli==1.16.263
 beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.9.250
-glean_parser==1.18.2
+glean_parser==1.27.0
 jsonschema==3.1.1
 python-dateutil==2.8.0
 PyYAML==5.1.2


### PR DESCRIPTION
probe-scraper started failing last night with:

```
    glean.internal.metrics:
      android_sdk_version:
        bugs:
        - https://bugzilla.mozilla.org/1525606
        data_reviews:
        - https://bugzilla.mozilla.org/show_bug.cgi?id=1525606#c14
        data_sensitivity:
        - technical
        description: 'The optional Android specific SDK version of the software
          running on this

          hardware device.

          '
        expires: never
        lifetime: application
        notification_emails:
        - glean-team@mozilla.com
        send_in_pings:
        - glean_client_info
        type: string
    ```

    Additional properties are not allowed ('data_sensitivity' was
    unexpected)

    Documentation for this node:
        Describes a single metric.

        See https://mozilla.github.io/glean_parser/metrics-yaml.html./app/probe_cache/glean/678459233982815917eea9a053537232724a91df/glean-core/metrics.yaml:
 ```

This upgrades glean_parser to a version that understands this new metadata.