### PR TITLE
Bug 1657392 - Add min date for glean fx desktop

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -26,7 +26,8 @@ MIN_DATES = {
     "firefox-android-nightly": FENIX_DATE,
     "firefox-android-beta": FENIX_DATE,
     "firefox-android-release": FENIX_DATE,
-    "reference-browser": "2019-04-01 00:00:00"
+    "reference-browser": "2019-04-01 00:00:00",
+    "firefox-desktop": "2020-07-29 00:00:00",
 }
 
 


### PR DESCRIPTION
Looks like `pings.yaml` was backed out in [this change](https://github.com/mozilla/gecko-dev/commit/340c8521a54ad4d4a32dd16333676a6ff85aaec2#diff-4ff831b76cf47490a251503f15220433), which causes us to fail in the probe-scraper.

I tested this change locally and scraping works as expected.