### PR TITLE
Add missing metrics.yaml file for FFTV

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -63,6 +63,8 @@ firefox-for-fire-tv:
   notification_emails:
     - frank@mozilla.com
   url: 'https://github.com/mozilla-mobile/firefox-tv'
+  metrics_files:
+    - 'app/metrics.yaml'
   dependencies:
     - org.mozilla.components:service-glean
 lib-crash:


### PR DESCRIPTION
Similar to #214 add the metrics.yaml file for Firefox for FireTV.