### PR TITLE
Add main as an alternative default branch

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -15,17 +15,23 @@ class Repository(object):
     """
     A class representing a repository, read in from `repositories.yaml`
     """
+    default_branch = "master"
 
     def __init__(self, name, definition):
         self.name = name
         self.url = definition.get("url")
-        self.branch = definition.get("branch", "master")
+        self.branch = definition.get("branch", Repository.default_branch)
         self.notification_emails = definition.get("notification_emails")
         self.app_id = definition.get("app_id")
         self.metrics_file_paths = definition.get("metrics_files", [])
         self.ping_file_paths = definition.get("ping_files", [])
         self.library_names = definition.get("library_names", None)
         self.dependencies = definition.get("dependencies", [])
+
+    def get_branches(self):
+        if self.branch == Repository.default_branch:
+            return (Repository.default_branch, "main")
+        return (self.branch,)
 
     def get_metrics_file_paths(self):
         return self.metrics_file_paths

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -74,11 +74,11 @@ def retrieve_files(repo_info, cache_dir):
 
     branches = repo_info.get_branches()
     for branch in branches:
-      try:
-        repo.git.checkout(repo_info.branch)
-        break
-      except git.exc.GitCommandError:
-        pass
+        try:
+            repo.git.checkout(repo_info.branch)
+            break
+        except git.exc.GitCommandError:
+            pass
 
     try:
         for rel_path in repo_info.get_change_files():

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from collections import defaultdict
-from git import Repo
+import git
 import os
 import shutil
 import tempfile
@@ -70,8 +70,15 @@ def retrieve_files(repo_info, cache_dir):
 
     if os.path.exists(repo_info.name):
         shutil.rmtree(repo_info.name)
-    repo = Repo.clone_from(repo_info.url, repo_info.name)
-    repo.git.checkout(repo_info.branch)
+    repo = git.Repo.clone_from(repo_info.url, repo_info.name)
+
+    branches = repo_info.get_branches()
+    for branch in branches:
+      try:
+        repo.git.checkout(repo_info.branch)
+        break
+      except git.exc.GitCommandError:
+        pass
 
     try:
         for rel_path in repo_info.get_change_files():

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -58,13 +58,13 @@ def run_before_tests():
     rm_if_exists(cache_dir, out_dir, test_dir)
 
 
-def get_repo(repo_name):
+def get_repo(repo_name, branch='master'):
     directory = os.path.join(test_dir, repo_name)
     repo = Repo.init(directory)
     # Ensure the default branch is using a fixed name.
     # User config could change that,
     # breaking tests with implicit assumptions further down the line.
-    repo.head.reference = Head(repo, 'refs/heads/master')
+    repo.head.reference = Head(repo, f'refs/heads/{branch}')
 
     # We need to synthesize the time stamps of commits to each be a second
     # apart, otherwise the commits may be at exactly the same second, which
@@ -95,10 +95,8 @@ def get_repo(repo_name):
 
     return directory
 
-
-@pytest.fixture
-def normal_repo():
-    location = get_repo(normal_repo_name)
+def proper_repo(branch='master'):
+    location = get_repo(normal_repo_name, branch)
     repositories_info = {
         normal_repo_name: {
             "app_id": "normal-app-name",
@@ -128,6 +126,16 @@ def normal_repo():
         f.write(yaml.dump(repositories_info))
 
     return location
+
+
+@pytest.fixture
+def normal_repo():
+    return proper_repo()
+
+
+@pytest.fixture
+def main_repo():
+    return proper_repo('main')
 
 
 @pytest.fixture
@@ -313,3 +321,45 @@ def test_check_for_expired_metrics(expired_repo):
         # Everything goes here
         'glean-team@mozilla.com'
     ])
+
+
+def test_repo_default_main_branch(main_repo):
+    runner.main(cache_dir, out_dir, None, None, False, True, repositories_file,
+                True, None, None, None, None, 'dev')
+
+    path = os.path.join(out_dir, "glean", normal_repo_name, "metrics")
+
+    with open(path, 'r') as data:
+        metrics = json.load(data)
+
+    # there are 2 metrics
+    assert len(metrics) == 2
+
+    duration = 'example.duration'
+    os_metric = 'example.os'
+
+    # duration has 2 definitions
+    assert len(metrics[duration][HISTORY_KEY]) == 2
+
+    # os has 3 definitions
+    assert len(metrics[os_metric][HISTORY_KEY]) == 3
+
+    # duration same begin/end commits for first history entry
+    assert len(set(metrics[duration][HISTORY_KEY][0][COMMITS_KEY].values())) == 1
+
+    # duration same begin/end commits for first history entry
+    assert len(set(metrics[duration][HISTORY_KEY][1][COMMITS_KEY].values())) == 2
+
+    # os was in 1 commit
+    assert len(set(metrics[os_metric][HISTORY_KEY][0][COMMITS_KEY].values())) == 1
+
+    # There should have been no errors
+    assert not Path(EMAIL_FILE).exists()
+
+    path = os.path.join(out_dir, "glean", normal_repo_name, "dependencies")
+
+    with open(path, 'r') as data:
+        dependencies = json.load(data)
+
+    assert len(dependencies) == 2
+

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -95,6 +95,7 @@ def get_repo(repo_name, branch='master'):
 
     return directory
 
+
 def proper_repo(branch='master'):
     location = get_repo(normal_repo_name, branch)
     repositories_info = {
@@ -362,4 +363,3 @@ def test_repo_default_main_branch(main_repo):
         dependencies = json.load(data)
 
     assert len(dependencies) == 2
-


### PR DESCRIPTION
We just ran into a failure yesterday on https://github.com/MozillaReality/FirefoxReality, which just moved to `main` from `master`.

This adds `main` as the fallback; once everyone is switched over we can make `master` the fallback (and hopefully deprecate it).