### PR TITLE
Add a temporary app id for testing glean.js

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -416,3 +416,15 @@ firefox-reality-pc:
     - Source/FirefoxRealityUnity/pings.yaml
   dependencies:
     - glean-core
+glean-js-tmp:
+  app_id: glean-js-tmp
+  description: Temporary app id to experiment with Glean.js
+  url: https://github.com/brizental/gleanjs
+  notification_emails:
+    - brizental@mozilla.com
+    - aplacitelli@mozilla.com
+    - mdroettboom@mozilla.com
+  metrics_files:
+    - metrics.yaml
+  dependencies:
+    - glean-core


### PR DESCRIPTION
During the Glean.js workweek (and probably subsequent weeks for early
development), it would be useful to have a real table to send data to.

Eventually, we will delete this and its associated table (which I assume is
possible).

This will be *very* low volume.