### PR TITLE
Remove mozbuild metrics from mach

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -424,7 +424,6 @@ mach:
     - mhentges@mozilla.com
   metrics_files:
     - python/mach/metrics.yaml
-    - python/mozbuild/metrics.yaml
   ping_files:
     - python/mach/pings.yaml
 glean-js-tmp:


### PR DESCRIPTION
This was what was failing last night. These are missing from that repo.