### PR TITLE
Fix glean-js table

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -436,5 +436,4 @@ glean-js:
     - mdroettboom@mozilla.com
   metrics_files:
     - metrics.yaml
-  dependencies:
-    - glean-core
+  dependencies: []


### PR DESCRIPTION
Both glean-js itself and glean-core define the same core metrics.  Since
glean-js is actually standalone, it probably shouldn't have glean-core as a
dependency.

Unblocks the following alert e-mail:

```
Glean has detected duplicated metric identifiers coming from the product 'glean-js'.

- 'os' defined more than once in glean-core, glean-js
- 'os_version' defined more than once in glean-core, glean-js
- 'device_manufacturer' defined more than once in glean-core, glean-js
- 'device_model' defined more than once in glean-core, glean-js
- 'architecture' defined more than once in glean-core, glean-js
- 'client_id' defined more than once in glean-core, glean-js
- 'app_build' defined more than once in glean-core, glean-js
- 'app_display_version' defined more than once in glean-core, glean-js
- 'app_channel' defined more than once in glean-core, glean-js
- 'first_run_date' defined more than once in glean-core, glean-js
- 'locale' defined more than once in glean-core, glean-js
- 'ping_reason' defined more than once in glean-core, glean-js
```