### PR TITLE
Upgrade to glean_parser v1.29.0

### DIFF
--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -20,7 +20,7 @@ class GleanMetricsParser:
         config["do_not_disable_expired"] = True
 
         paths = [Path(fname) for fname in filenames]
-        paths = [path for path in filenames if path.is_file()]
+        paths = [path for path in paths if path.is_file()]
         results = parse_objects(paths, config)
         errors = [err for err in results]
 

--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -20,6 +20,7 @@ class GleanMetricsParser:
         config["do_not_disable_expired"] = True
 
         paths = [Path(fname) for fname in filenames]
+        paths = [path for path in filenames if path.is_file()]
         results = parse_objects(paths, config)
         errors = [err for err in results]
 

--- a/probe_scraper/parsers/pings.py
+++ b/probe_scraper/parsers/pings.py
@@ -27,6 +27,7 @@ class GleanPingsParser:
     def parse(self, filenames, config):
         config = config.copy()
         paths = [Path(fname) for fname in filenames]
+        paths = [path for path in filenames if path.is_file()]
         results = parse_objects(paths, config)
         errors = [err for err in results]
 

--- a/probe_scraper/parsers/pings.py
+++ b/probe_scraper/parsers/pings.py
@@ -27,7 +27,7 @@ class GleanPingsParser:
     def parse(self, filenames, config):
         config = config.copy()
         paths = [Path(fname) for fname in filenames]
-        paths = [path for path in filenames if path.is_file()]
+        paths = [path for path in paths if path.is_file()]
         results = parse_objects(paths, config)
         errors = [err for err in results]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ awscli==1.16.263
 beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.9.250
-glean_parser==1.28.3
+glean_parser==1.29.0
 jsonschema==3.1.1
 python-dateutil==2.8.0
 PyYAML==5.1.2


### PR DESCRIPTION
* **Breaking change:** `glean_parser` will now return an error code when any of the input files do not exist (unless the `--allow-missing-files` flag is passed).
* Generated code now includes a comment next to each metric containing the name of the metric in its original `snake_case` form.
* When metrics don't provide a `unit` parameter, it is not included in the output (as provided by probe-scraper).