### PR TITLE
added black and isort linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ clean-pyc:
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .
 	docker-compose run app yamllint repositories.yaml .circleci
+	docker-compose run app python -m black .
+	docker-compose run app python -m isort .
 
 test: build
 	docker-compose run app pytest tests/ --run-web-tests

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 format: 
-	python3 -m black probe_scraper tests setup.py
-	python3 -m isort probe_scraper tests setup.py
+	python3 -m black probe_scraper tests ./*.py
+	python3 -m isort probe_scraper tests ./*.py
 
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .
 	docker-compose run app yamllint repositories.yaml .circleci
-	docker-compose run app python -m black --check probe_scraper tests setup.py
-	docker-compose run app python -m isort --check-only probe_scraper tests setup.py
+	docker-compose run app python -m black --check probe_scraper tests ./*.py
+	docker-compose run app python -m isort --check-only probe_scraper tests ./*.py
 
 test: build
 	docker-compose run app pytest tests/ --run-web-tests

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 help:
 	@echo "  clean                  Remove build artifacts"
 	@echo "  lint                   Check style with flake8"
+	@echo "  format                 Format code with black and isort"
 	@echo "  test                   Run tests quickly with the default Python"
 	@echo "  build                  Builds the docker images for the docker-compose setup"
 	@echo "  docker-rm              Stops and removes all docker containers"
@@ -21,6 +22,10 @@ clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
+
+format: 
+	python3 -m black .
+	python3 -m isort .
 
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ clean-pyc:
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .
 	docker-compose run app yamllint repositories.yaml .circleci
-	docker-compose run app python -m black .
-	docker-compose run app python -m isort .
+	docker-compose run app python -m black --check .
+	docker-compose run app python -m isort --check-only .
 
 test: build
 	docker-compose run app pytest tests/ --run-web-tests

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 format: 
-	python3 -m black .
-	python3 -m isort .
+	python3 -m black probe_scraper tests setup.py
+	python3 -m isort probe_scraper tests setup.py
 
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .
 	docker-compose run app yamllint repositories.yaml .circleci
-	docker-compose run app python -m black --check .
-	docker-compose run app python -m isort --check-only .
+	docker-compose run app python -m black --check probe_scraper tests setup.py
+	docker-compose run app python -m isort --check-only probe_scraper tests setup.py
 
 test: build
 	docker-compose run app pytest tests/ --run-web-tests

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
         "--run-web-tests",
         action="store_true",
         default=False,
-        help="Run tests that require a web connection"
+        help="Run tests that require a web connection",
     )
 
 

--- a/probe_scraper/emailer.py
+++ b/probe_scraper/emailer.py
@@ -2,23 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import boto3
-import yaml
-
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+import boto3
+import yaml
 
 EMAIL_FILE = "emails.txt"
 
 
-def send_ses(fromaddr,
-             subject,
-             body,
-             recipients,
-             filename='',
-             dryrun=True):
+def send_ses(fromaddr, subject, body, recipients, filename="", dryrun=True):
     """Send an email via the Amazon SES service. Can specify a single or list of
        recipients.
 
@@ -38,23 +32,23 @@ def send_ses(fromaddr,
     if isinstance(recipients, list):
         recipients = ",".join(recipients)
 
-    email_data = [{
-        "from": fromaddr,
-        "to": subject,
-        "body": body,
-        "recipients": recipients
-    }]
+    email_data = [
+        {"from": fromaddr, "to": subject, "body": body, "recipients": recipients}
+    ]
 
     with open(EMAIL_FILE, "a") as f:
         f.write(yaml.dump(email_data, default_flow_style=False))
 
     if dryrun:
-        email_txt = "\n".join([
-            "New Email",
-            "    From: " + fromaddr,
-            "    To: " + recipients,
-            "    Subject: " + subject,
-            "    Body: " + body])
+        email_txt = "\n".join(
+            [
+                "New Email",
+                "    From: " + fromaddr,
+                "    To: " + recipients,
+                "    Subject: " + subject,
+                "    Body: " + body,
+            ]
+        )
         print(email_txt)
         return
 
@@ -71,9 +65,7 @@ def send_ses(fromaddr,
         msg.attach(part)
 
     ses = boto3.client("ses", region_name="us-west-2")
-    result = ses.send_raw_email(
-        RawMessage={"Data": msg.as_string()}
-    )
+    result = ses.send_raw_email(RawMessage={"Data": msg.as_string()})
 
     if "ErrorResponse" in result:
         raise RuntimeError("Error sending email: " + result)

--- a/probe_scraper/parsers/events.py
+++ b/probe_scraper/parsers/events.py
@@ -3,20 +3,18 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from .third_party import parse_events
-from .utils import set_in_nested_dict, get_major_version
+from .utils import get_major_version, set_in_nested_dict
 
 
 def extract_events_data(e):
     props = {
         # source_field: target_field
-
         # TODO: extract description.
         "description": "description",
         "expiry_version": "expiry_version",
         "expiry_day": "expiry_day",
         "cpp_guard": "cpp_guard",
         "bug_numbers": "bug_numbers",
-
         "methods": "details/methods",
         "objects": "details/objects",
         "record_in_processes": "details/record_in_processes",
@@ -33,9 +31,7 @@ def extract_events_data(e):
         "bug_numbers": [],
     }
 
-    data = {
-        "details": {}
-    }
+    data = {"details": {}}
 
     for source_field, target_field in props.items():
         value = getattr(e, source_field, e._definition.get(source_field, None))
@@ -44,7 +40,7 @@ def extract_events_data(e):
         set_in_nested_dict(data, target_field, value)
 
     # We only care about opt-out or opt-in really.
-    optout = getattr(e, "dataset", "").endswith('_OPTOUT')
+    optout = getattr(e, "dataset", "").endswith("_OPTOUT")
     data["optout"] = optout
 
     # Normalize some field values.
@@ -61,12 +57,15 @@ class EventsParser:
         # We don't have important event usage yet, so lets skip
         # backwards compatibility for now.
         if (version and channel) and (
-          ((channel != "nightly" and version < 53)
-           or (channel == "nightly" and version < 54))):
+            (
+                (channel != "nightly" and version < 53)
+                or (channel == "nightly" and version < 54)
+            )
+        ):
             return {}
 
         if len(filenames) > 1:
-            raise Exception('We don\'t support loading from more than one file.')
+            raise Exception("We don't support loading from more than one file.")
 
         events = parse_events.load_events(filenames[0], strict_type_checks=False)
 

--- a/probe_scraper/parsers/histograms.py
+++ b/probe_scraper/parsers/histograms.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from .third_party import histogram_tools
-from .utils import set_in_nested_dict, get_major_version
+from .utils import get_major_version, set_in_nested_dict
 
 
 def extract_histogram_data(histogram, version):
@@ -14,7 +14,6 @@ def extract_histogram_data(histogram, version):
         "expiration": "expiry_version",
         "bug_numbers": "bug_numbers",
         "alert_emails": "notification_emails",
-
         "n_buckets": "details/n_buckets",
         "low": "details/low",
         "high": "details/high",
@@ -32,9 +31,7 @@ def extract_histogram_data(histogram, version):
         "alert_emails": [],
     }
 
-    data = {
-        "details": {}
-    }
+    data = {"details": {}}
 
     for source_field, target_field in props.items():
         value = None
@@ -53,7 +50,7 @@ def extract_histogram_data(histogram, version):
     # We only care about opt-out or opt-in really.
     optout = False
     if hasattr(histogram, "dataset"):
-        optout = getattr(histogram, "dataset")().endswith('_OPTOUT')
+        optout = getattr(histogram, "dataset")().endswith("_OPTOUT")
 
     # Use Counters are shipped on release since 65.
     # If the parsers would set this flag, we couldn't differentiate between versions.
@@ -80,7 +77,9 @@ def extract_histogram_data(histogram, version):
 
 
 def transform_probe_info(probes, version):
-    return dict((probe.name(), extract_histogram_data(probe, version)) for probe in probes)
+    return dict(
+        (probe.name(), extract_histogram_data(probe, version)) for probe in probes
+    )
 
 
 class HistogramsParser:

--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -2,10 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from glean_parser.parser import parse_objects
-from .pings import normalize_ping_name
-
 from pathlib import Path
+
+from glean_parser.parser import parse_objects
+
+from .pings import normalize_ping_name
 
 
 class GleanMetricsParser:
@@ -31,7 +32,6 @@ class GleanMetricsParser:
         }
 
         for i, v in metrics.items():
-            v['send_in_pings'] = [normalize_ping_name(p)
-                                  for p in v['send_in_pings']]
+            v["send_in_pings"] = [normalize_ping_name(p) for p in v["send_in_pings"]]
 
         return metrics, errors

--- a/probe_scraper/parsers/pings.py
+++ b/probe_scraper/parsers/pings.py
@@ -2,14 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from glean_parser.parser import parse_objects
 from pathlib import Path
 
+from glean_parser.parser import parse_objects
+
 PING_NAME_NORMALIZATION = {
-    'deletion_request': 'deletion-request',
-    'bookmarks_sync': 'bookmarks-sync',
-    'history_sync': 'history-sync',
-    'session_end': 'session-end',
+    "deletion_request": "deletion-request",
+    "bookmarks_sync": "bookmarks-sync",
+    "history_sync": "history-sync",
+    "session_end": "session-end",
 }
 
 
@@ -37,5 +38,5 @@ class GleanPingsParser:
                 for category, pings in results.value.items()
                 for ping_name, ping_data in pings.items()
             },
-            errors
+            errors,
         )

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -3,9 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+
 import jsonschema
 import yaml
-
 
 REPOSITORIES_FILENAME = "repositories.yaml"
 REPOSITORIES_SCHEMA = "schemas/repositories.json"
@@ -15,6 +15,7 @@ class Repository(object):
     """
     A class representing a repository, read in from `repositories.yaml`
     """
+
     default_branch = "master"
 
     def __init__(self, name, definition):
@@ -63,7 +64,7 @@ class RepositoriesParser(object):
         if filename is None:
             filename = REPOSITORIES_FILENAME
 
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             repos = yaml.load(f, Loader=yaml.SafeLoader)
 
         return repos
@@ -71,7 +72,7 @@ class RepositoriesParser(object):
     def validate(self, filename=None):
         repos = self._get_repos(filename)
 
-        with open(REPOSITORIES_SCHEMA, 'r') as f:
+        with open(REPOSITORIES_SCHEMA, "r") as f:
             schema = json.load(f)
 
         jsonschema.validate(repos, schema)
@@ -87,9 +88,7 @@ class RepositoriesParser(object):
         repos = self._get_repos(filename)
 
         repos = [
-            Repository(name, definition)
-            for name, definition
-            in list(repos.items())
+            Repository(name, definition) for name, definition in list(repos.items())
         ]
 
         return self.filter_repos(repos, glean_repo)

--- a/probe_scraper/parsers/scalars.py
+++ b/probe_scraper/parsers/scalars.py
@@ -10,9 +10,9 @@ def extract_scalar_data(s):
 
     # External scalars.yaml files have release/prerelease, not opt-in/opt-out
     try:
-        optout = s.dataset.endswith('_OPTOUT')
+        optout = s.dataset.endswith("_OPTOUT")
     except KeyError:
-        optout = s._definition.get('collect_on_channels', 'prerelease') == 'release'
+        optout = s._definition.get("collect_on_channels", "prerelease") == "release"
 
     return {
         "description": s.description,
@@ -25,8 +25,8 @@ def extract_scalar_data(s):
             "keyed": s.keyed,
             "kind": s.kind,
             "record_in_processes": s.record_in_processes,
-            "record_into_store": s.record_into_store
-        }
+            "record_into_store": s.record_into_store,
+        },
     }
 
 
@@ -37,7 +37,7 @@ def transform_scalar_info(probes):
 class ScalarsParser:
     def parse(self, filenames, version=None, channel=None):
         if len(filenames) > 1:
-            raise Exception('We don\'t support loading from more than one file.')
+            raise Exception("We don't support loading from more than one file.")
 
         scalars = parse_scalars.load_scalars(filenames[0], strict_type_checks=False)
 

--- a/probe_scraper/parsers/third_party/parse_events.py
+++ b/probe_scraper/parsers/third_party/parse_events.py
@@ -2,11 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-import yaml
-import itertools
 import datetime
+import itertools
+import re
 import string
+
+import yaml
+
 from . import shared_telemetry_utils as utils
 
 MAX_CATEGORY_NAME_LENGTH = 30
@@ -15,8 +17,8 @@ MAX_OBJECT_NAME_LENGTH = 20
 MAX_EXTRA_KEYS_COUNT = 10
 MAX_EXTRA_KEY_NAME_LENGTH = 15
 
-IDENTIFIER_PATTERN = r'^[a-zA-Z][a-zA-Z0-9_.]*[a-zA-Z0-9]$'
-DATE_PATTERN = r'^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+IDENTIFIER_PATTERN = r"^[a-zA-Z][a-zA-Z0-9_.]*[a-zA-Z0-9]$"
+DATE_PATTERN = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
 
 
 def nice_type_name(t):
@@ -34,11 +36,13 @@ class OneOf:
     It signals that the checked value should match one of the following arguments
     passed to the TypeChecker constructor.
     """
+
     pass
 
 
 class TypeChecker:
     """This implements a convenience type TypeChecker to make the validation code more readable."""
+
     def __init__(self, kind, *args):
         """This takes 1-3 arguments, specifying the value type to check for.
         It supports:
@@ -52,65 +56,98 @@ class TypeChecker:
     def check(self, identifier, key, value):
         # Check fields that can be one of two different types.
         if self._kind is OneOf:
-            if not isinstance(value, self._args[0]) and not isinstance(value, self._args[1]):
-                raise ValueError("%s: failed type check for %s - expected %s or %s, got %s" %\
-                                  (identifier, key,
-                                   nice_type_name(self._args[0]),
-                                   nice_type_name(self._args[1]),
-                                   nice_type_name(type(value))))
+            if not isinstance(value, self._args[0]) and not isinstance(
+                value, self._args[1]
+            ):
+                raise ValueError(
+                    "%s: failed type check for %s - expected %s or %s, got %s"
+                    % (
+                        identifier,
+                        key,
+                        nice_type_name(self._args[0]),
+                        nice_type_name(self._args[1]),
+                        nice_type_name(type(value)),
+                    )
+                )
             return
 
         # Check basic type of value.
         if not isinstance(value, self._kind):
-            raise ValueError("%s: failed type check for %s - expected %s, got %s" %\
-                              (identifier, key,
-                               nice_type_name(self._kind),
-                               nice_type_name(type(value))))
+            raise ValueError(
+                "%s: failed type check for %s - expected %s, got %s"
+                % (
+                    identifier,
+                    key,
+                    nice_type_name(self._kind),
+                    nice_type_name(type(value)),
+                )
+            )
 
         # Check types of values in lists.
         if self._kind is list:
             if len(value) < 1:
-                raise ValueError("%s: failed check for %s - list should not be empty" % (identifier, key))
+                raise ValueError(
+                    "%s: failed check for %s - list should not be empty"
+                    % (identifier, key)
+                )
             for x in value:
                 if not isinstance(x, self._args[0]):
-                    raise ValueError("%s: failed type check for %s - expected list value type %s, got %s" %\
-                                      (identifier, key,
-                                       nice_type_name(self._args[0]),
-                                       nice_type_name(type(x))))
+                    raise ValueError(
+                        "%s: failed type check for %s - expected list value type %s, got %s"
+                        % (
+                            identifier,
+                            key,
+                            nice_type_name(self._args[0]),
+                            nice_type_name(type(x)),
+                        )
+                    )
 
         # Check types of keys and values in dictionaries.
         elif self._kind is dict:
             if len(list(value.keys())) < 1:
-                    raise ValueError("%s: failed check for %s - dict should not be empty" % (identifier, key))
+                raise ValueError(
+                    "%s: failed check for %s - dict should not be empty"
+                    % (identifier, key)
+                )
             for x in value.keys():
                 if not isinstance(x, self._args[0]):
-                    raise ValueError("%s: failed dict type check for %s - expected key type %s, got %s" %\
-                                      (identifier, key,
-                                       nice_type_name(self._args[0]),
-                                       nice_type_name(type(x))))
+                    raise ValueError(
+                        "%s: failed dict type check for %s - expected key type %s, got %s"
+                        % (
+                            identifier,
+                            key,
+                            nice_type_name(self._args[0]),
+                            nice_type_name(type(x)),
+                        )
+                    )
             for k, v in value.items():
                 if not isinstance(x, self._args[1]):
-                    raise ValueError("%s: failed dict type check for %s - expected value type %s for key %s, got %s" %\
-                                      (identifier, key,
-                                       nice_type_name(self._args[1]),
-                                       k,
-                                       nice_type_name(type(x))))
+                    raise ValueError(
+                        "%s: failed dict type check for %s - expected value type %s for key %s, got %s"
+                        % (
+                            identifier,
+                            key,
+                            nice_type_name(self._args[1]),
+                            k,
+                            nice_type_name(type(x)),
+                        )
+                    )
 
 
 def type_check_event_fields(identifier, name, definition, strict):
     """Perform a type/schema check on the event definition."""
     REQUIRED_FIELDS = {
-        'objects': TypeChecker(list, str),
-        'bug_numbers': TypeChecker(list, int),
-        'notification_emails': TypeChecker(list, str),
-        'description': TypeChecker(str),
+        "objects": TypeChecker(list, str),
+        "bug_numbers": TypeChecker(list, int),
+        "notification_emails": TypeChecker(list, str),
+        "description": TypeChecker(str),
     }
     OPTIONAL_FIELDS = {
-        'methods': TypeChecker(list, str),
-        'release_channel_collection': TypeChecker(str),
-        'expiry_date': TypeChecker(OneOf, str, datetime.date),
-        'expiry_version': TypeChecker(str),
-        'extra_keys': TypeChecker(dict, str, str),
+        "methods": TypeChecker(list, str),
+        "release_channel_collection": TypeChecker(str),
+        "expiry_date": TypeChecker(OneOf, str, datetime.date),
+        "expiry_version": TypeChecker(str),
+        "extra_keys": TypeChecker(dict, str, str),
     }
 
     # Some fields were added later, so we can't be strict about it unless this
@@ -118,7 +155,7 @@ def type_check_event_fields(identifier, name, definition, strict):
     changed_fields = REQUIRED_FIELDS
     if not strict:
         changed_fields = OPTIONAL_FIELDS
-    changed_fields['record_in_processes'] = TypeChecker(list, str)
+    changed_fields["record_in_processes"] = TypeChecker(list, str)
 
     ALL_FIELDS = REQUIRED_FIELDS.copy()
     ALL_FIELDS.update(OPTIONAL_FIELDS)
@@ -126,13 +163,17 @@ def type_check_event_fields(identifier, name, definition, strict):
     # Check that all the required fields are available.
     missing_fields = [f for f in REQUIRED_FIELDS.keys() if f not in definition]
     if len(missing_fields) > 0:
-        raise KeyError(identifier + ' - missing required fields: ' + ', '.join(missing_fields))
+        raise KeyError(
+            identifier + " - missing required fields: " + ", ".join(missing_fields)
+        )
 
     # Are there any unknown field?
     if strict:
         unknown_fields = [f for f in definition.keys() if f not in ALL_FIELDS]
         if len(unknown_fields) > 0:
-            raise KeyError(identifier + ' - unknown fields: ' + ', '.join(unknown_fields))
+            raise KeyError(
+                identifier + " - unknown fields: " + ", ".join(unknown_fields)
+            )
 
     # Type-check fields.
     for k, v in definition.items():
@@ -143,15 +184,21 @@ def type_check_event_fields(identifier, name, definition, strict):
 def string_check(identifier, field, value, min_length=1, max_length=None, regex=None):
     # Length check.
     if len(value) < min_length:
-        raise ValueError("%s: value '%s' for field %s is less than minimum length of %d" %
-                         (identifier, value, field, min_length))
+        raise ValueError(
+            "%s: value '%s' for field %s is less than minimum length of %d"
+            % (identifier, value, field, min_length)
+        )
     if max_length and len(value) > max_length:
-        raise ValueError("%s: value '%s' for field %s is greater than maximum length of %d" %
-                         (identifier, value, field, max_length))
+        raise ValueError(
+            "%s: value '%s' for field %s is greater than maximum length of %d"
+            % (identifier, value, field, max_length)
+        )
     # Regex check.
     if regex and not re.match(regex, value):
-        raise ValueError('%s: string value "%s" for %s is not matching pattern "%s"' % \
-                          (identifier, value, field, regex))
+        raise ValueError(
+            '%s: string value "%s" for %s is not matching pattern "%s"'
+            % (identifier, value, field, regex)
+        )
 
 
 class EventData:
@@ -168,53 +215,82 @@ class EventData:
         # Check method & object string patterns.
         if strict_type_checks:
             for method in self.methods:
-                string_check(self.identifier, field='methods', value=method,
-                             min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
-                             regex=IDENTIFIER_PATTERN)
+                string_check(
+                    self.identifier,
+                    field="methods",
+                    value=method,
+                    min_length=1,
+                    max_length=MAX_METHOD_NAME_LENGTH,
+                    regex=IDENTIFIER_PATTERN,
+                )
             for obj in self.objects:
-                string_check(self.identifier, field='objects', value=obj,
-                             min_length=1, max_length=MAX_OBJECT_NAME_LENGTH,
-                             regex=IDENTIFIER_PATTERN)
+                string_check(
+                    self.identifier,
+                    field="objects",
+                    value=obj,
+                    min_length=1,
+                    max_length=MAX_OBJECT_NAME_LENGTH,
+                    regex=IDENTIFIER_PATTERN,
+                )
 
         # Check release_channel_collection
-        rcc_key = 'release_channel_collection'
-        rcc = definition.get(rcc_key, 'opt-in')
+        rcc_key = "release_channel_collection"
+        rcc = definition.get(rcc_key, "opt-in")
         allowed_rcc = ["opt-in", "opt-out"]
         if not rcc in allowed_rcc:
-            raise ValueError("%s: value for %s should be one of: %s" %\
-                              (self.identifier, rcc_key, ", ".join(allowed_rcc)))
+            raise ValueError(
+                "%s: value for %s should be one of: %s"
+                % (self.identifier, rcc_key, ", ".join(allowed_rcc))
+            )
 
         # Check record_in_processes.
-        record_in_processes = definition.get('record_in_processes', ['main'])
+        record_in_processes = definition.get("record_in_processes", ["main"])
         for proc in record_in_processes:
             if not utils.is_valid_process_name(proc):
-                raise ValueError(self.identifier + ': unknown value in record_in_processes: ' + proc)
+                raise ValueError(
+                    self.identifier + ": unknown value in record_in_processes: " + proc
+                )
 
         # Check extra_keys.
-        extra_keys = definition.get('extra_keys', {})
+        extra_keys = definition.get("extra_keys", {})
         if len(extra_keys.keys()) > MAX_EXTRA_KEYS_COUNT:
-            raise ValueError("%s: number of extra_keys exceeds limit %d" %\
-                              (self.identifier, MAX_EXTRA_KEYS_COUNT))
+            raise ValueError(
+                "%s: number of extra_keys exceeds limit %d"
+                % (self.identifier, MAX_EXTRA_KEYS_COUNT)
+            )
         if strict_type_checks:
             for key in extra_keys.keys():
-                string_check(self.identifier, field='extra_keys', value=key,
-                             min_length=1, max_length=MAX_EXTRA_KEY_NAME_LENGTH,
-                             regex=IDENTIFIER_PATTERN)
+                string_check(
+                    self.identifier,
+                    field="extra_keys",
+                    value=key,
+                    min_length=1,
+                    max_length=MAX_EXTRA_KEY_NAME_LENGTH,
+                    regex=IDENTIFIER_PATTERN,
+                )
 
         # Check expiry.
-        if not 'expiry_version' in definition and not 'expiry_date' in definition:
-            raise KeyError("%s: event is missing an expiration - either expiry_version or expiry_date is required" %\
-                            (self.identifier))
-        expiry_date = definition.get('expiry_date')
-        if expiry_date and isinstance(expiry_date, str) and expiry_date != 'never':
+        if not "expiry_version" in definition and not "expiry_date" in definition:
+            raise KeyError(
+                "%s: event is missing an expiration - either expiry_version or expiry_date is required"
+                % (self.identifier)
+            )
+        expiry_date = definition.get("expiry_date")
+        if expiry_date and isinstance(expiry_date, str) and expiry_date != "never":
             if not re.match(DATE_PATTERN, expiry_date):
-                raise ValueError("%s: event has invalid expiry_date, it should be either 'never' or match this format: %s" %\
-                                  (self.identifier, DATE_PATTERN))
+                raise ValueError(
+                    "%s: event has invalid expiry_date, it should be either 'never' or match this format: %s"
+                    % (self.identifier, DATE_PATTERN)
+                )
             # Parse into date.
-            definition['expiry_date'] = datetime.datetime.strptime(expiry_date, '%Y-%m-%d')
+            definition["expiry_date"] = datetime.datetime.strptime(
+                expiry_date, "%Y-%m-%d"
+            )
 
         # Finish setup.
-        definition['expiry_version'] = utils.add_expiration_postfix(definition.get('expiry_version', 'never'))
+        definition["expiry_version"] = utils.add_expiration_postfix(
+            definition.get("expiry_version", "never")
+        )
 
     @property
     def category(self):
@@ -227,7 +303,7 @@ class EventData:
 
     @property
     def description(self):
-        return self._definition.get('description')
+        return self._definition.get("description")
 
     @property
     def name(self):
@@ -239,15 +315,15 @@ class EventData:
 
     @property
     def methods(self):
-        return self._definition.get('methods', [self.name])
+        return self._definition.get("methods", [self.name])
 
     @property
     def objects(self):
-        return self._definition.get('objects')
+        return self._definition.get("objects")
 
     @property
     def record_in_processes(self):
-        return self._definition.get('record_in_processes', ['main'])
+        return self._definition.get("record_in_processes", ["main"])
 
     @property
     def record_in_processes_enum(self):
@@ -256,14 +332,14 @@ class EventData:
 
     @property
     def expiry_version(self):
-        return self._definition.get('expiry_version')
+        return self._definition.get("expiry_version")
 
     @property
     def expiry_day(self):
-        date = self._definition.get('expiry_date')
+        date = self._definition.get("expiry_date")
         if not date:
             return 0
-        if isinstance(date, str) and date == 'never':
+        if isinstance(date, str) and date == "never":
             return 0
 
         # Convert date to days since UNIX epoch.
@@ -273,30 +349,30 @@ class EventData:
 
     @property
     def cpp_guard(self):
-        return self._definition.get('cpp_guard')
+        return self._definition.get("cpp_guard")
 
     @property
     def enum_labels(self):
         def enum(method_name, object_name):
             m = convert_to_cpp_identifier(method_name, "_")
             o = convert_to_cpp_identifier(object_name, "_")
-            return m + '_' + o
+            return m + "_" + o
+
         combinations = itertools.product(self.methods, self.objects)
         return [enum(t[0], t[1]) for t in combinations]
 
     @property
     def dataset(self):
-        """Get the nsITelemetry constant equivalent for release_channel_collection.
-        """
-        rcc = self._definition.get('release_channel_collection', 'opt-in')
-        if rcc == 'opt-out':
-            return 'nsITelemetry::DATASET_RELEASE_CHANNEL_OPTOUT'
+        """Get the nsITelemetry constant equivalent for release_channel_collection."""
+        rcc = self._definition.get("release_channel_collection", "opt-in")
+        if rcc == "opt-out":
+            return "nsITelemetry::DATASET_RELEASE_CHANNEL_OPTOUT"
         else:
-            return 'nsITelemetry::DATASET_RELEASE_CHANNEL_OPTIN'
+            return "nsITelemetry::DATASET_RELEASE_CHANNEL_OPTIN"
 
     @property
     def extra_keys(self):
-        return list(self._definition.get('extra_keys', {}).keys())
+        return list(self._definition.get("extra_keys", {}).keys())
 
 
 def load_events(filename, strict_type_checks=True):
@@ -309,12 +385,12 @@ def load_events(filename, strict_type_checks=True):
     # Parse the event definitions from the YAML file.
     events = None
     try:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             events = yaml.safe_load(f)
     except IOError as e:
-        raise Exception('Error opening ' + filename + ': ' + e.message)
+        raise Exception("Error opening " + filename + ": " + e.message)
     except ValueError as e:
-        raise Exception('Error parsing events in ' + filename + ': ' + e.message)
+        raise Exception("Error parsing events in " + filename + ": " + e.message)
 
     event_list = []
 
@@ -327,21 +403,34 @@ def load_events(filename, strict_type_checks=True):
     #      ...
     #   ...
     for category_name, category in events.items():
-        if(strict_type_checks):
-            string_check("top level structure", field='category', value=category_name,
-                         min_length=1, max_length=MAX_CATEGORY_NAME_LENGTH,
-                         regex=IDENTIFIER_PATTERN)
+        if strict_type_checks:
+            string_check(
+                "top level structure",
+                field="category",
+                value=category_name,
+                min_length=1,
+                max_length=MAX_CATEGORY_NAME_LENGTH,
+                regex=IDENTIFIER_PATTERN,
+            )
 
         # Make sure that the category has at least one entry in it.
         if strict_type_checks and not category or len(category) == 0:
-            raise ValueError(category_name + ' must contain at least one entry')
+            raise ValueError(category_name + " must contain at least one entry")
 
         for name, entry in category.items():
-            if(strict_type_checks):
-                string_check(category_name, field='event name', value=name,
-                             min_length=1, max_length=MAX_METHOD_NAME_LENGTH,
-                             regex=IDENTIFIER_PATTERN)
-            event_list.append(EventData(category_name, name, entry,
-                                        strict_type_checks=strict_type_checks))
+            if strict_type_checks:
+                string_check(
+                    category_name,
+                    field="event name",
+                    value=name,
+                    min_length=1,
+                    max_length=MAX_METHOD_NAME_LENGTH,
+                    regex=IDENTIFIER_PATTERN,
+                )
+            event_list.append(
+                EventData(
+                    category_name, name, entry, strict_type_checks=strict_type_checks
+                )
+            )
 
     return event_list

--- a/probe_scraper/parsers/third_party/shared_telemetry_utils.py
+++ b/probe_scraper/parsers/third_party/shared_telemetry_utils.py
@@ -6,21 +6,21 @@
 # scripts.
 
 
-
 import re
-import yaml
 import sys
+
+import yaml
 
 # This is a list of flags that determine which process a measurement is allowed
 # to record from.
 KNOWN_PROCESS_FLAGS = {
-    'all': 'All',
-    'all_children': 'AllChildren',
-    'main': 'Main',
-    'content': 'Content',
-    'gpu': 'Gpu',
+    "all": "All",
+    "all_children": "AllChildren",
+    "main": "Main",
+    "content": "Content",
+    "gpu": "Gpu",
     # Historical Values
-    'all_childs': 'AllChildren', # Supporting files from before bug 1363725
+    "all_childs": "AllChildren",  # Supporting files from before bug 1363725
 }
 
 PROCESS_ENUM_PREFIX = "mozilla::Telemetry::Common::RecordedProcessType::"
@@ -56,7 +56,7 @@ class ParserError(Exception):
 
 
 def is_valid_process_name(name):
-    return (name in KNOWN_PROCESS_FLAGS)
+    return name in KNOWN_PROCESS_FLAGS
 
 
 def process_name_to_enum(name):
@@ -90,7 +90,7 @@ class StringTable:
             return result
 
     def stringIndexes(self, strings):
-        """ Returns a list of indexes for the provided list of strings.
+        """Returns a list of indexes for the provided list of strings.
         Adds the strings to the table if they are not in it yet.
         :param strings: list of strings to put into the table.
         """
@@ -118,18 +118,23 @@ class StringTable:
                     return "'\\''"
                 else:
                     return "'%s'" % s
+
             return ", ".join(map(toCChar, string))
 
         f.write("const char %s[] = {\n" % name)
         for (string, offset) in entries:
             if "*/" in string:
-                raise ValueError("String in string table contains unexpected sequence '*/': %s" %
-                                 string)
+                raise ValueError(
+                    "String in string table contains unexpected sequence '*/': %s"
+                    % string
+                )
 
             e = explodeToCharArray(string)
             if e:
-                f.write("  /* %5d - \"%s\" */ %s, '\\0',\n"
-                        % (offset, string, explodeToCharArray(string)))
+                f.write(
+                    "  /* %5d - \"%s\" */ %s, '\\0',\n"
+                    % (offset, string, explodeToCharArray(string))
+                )
             else:
                 f.write("  /* %5d - \"%s\" */ '\\0',\n" % (offset, string))
         f.write("};\n\n")
@@ -142,11 +147,11 @@ def static_assert(output, expression, message):
     :param message: the string literal that will appear if the expression evaluates to
         false.
     """
-    print("static_assert(%s, \"%s\");" % (expression, message), file=output)
+    print('static_assert(%s, "%s");' % (expression, message), file=output)
 
 
 def validate_expiration_version(expiration):
-    """ Makes sure the expiration version has the expected format.
+    """Makes sure the expiration version has the expected format.
 
     Allowed examples: "1.0", "20", "300.0a1", "60.0a1", "30.5a1", "never"
     Disallowed examples: "Never", "asd", "4000000", "60a1"
@@ -154,22 +159,22 @@ def validate_expiration_version(expiration):
     :param expiration: the expiration version string.
     :return: True if the expiration validates correctly, False otherwise.
     """
-    if expiration != 'never' and not re.match(r'^\d{1,3}(\.\d|\.\da1)?$', expiration):
+    if expiration != "never" and not re.match(r"^\d{1,3}(\.\d|\.\da1)?$", expiration):
         return False
 
     return True
 
 
 def add_expiration_postfix(expiration):
-    """ Formats the expiration version and adds a version postfix if needed.
+    """Formats the expiration version and adds a version postfix if needed.
 
     :param expiration: the expiration version string.
     :return: the modified expiration string.
     """
-    if re.match(r'^[1-9][0-9]*$', expiration):
+    if re.match(r"^[1-9][0-9]*$", expiration):
         return expiration + ".0a1"
 
-    if re.match(r'^[1-9][0-9]*\.0$', expiration):
+    if re.match(r"^[1-9][0-9]*\.0$", expiration):
         return expiration + "a1"
 
     return expiration
@@ -178,10 +183,11 @@ def add_expiration_postfix(expiration):
 def load_yaml_file(filename):
     """ Load a YAML file from disk, throw a ParserError on failure."""
     try:
-        with open(filename, 'r') as f:
+        with open(filename, "r") as f:
             return yaml.safe_load(f)
     except IOError as e:
-        raise ParserError('Error opening ' + filename + ': ' + e.message)
+        raise ParserError("Error opening " + filename + ": " + e.message)
     except ValueError as e:
-        raise ParserError('Error parsing processes in {}: {}'
-                          .format(filename, e.message))
+        raise ParserError(
+            "Error parsing processes in {}: {}".format(filename, e.message)
+        )

--- a/probe_scraper/parsers/third_party/usecounters.py
+++ b/probe_scraper/parsers/third_party/usecounters.py
@@ -6,73 +6,84 @@ import collections
 import re
 import sys
 
+
 def read_conf(conf_filename):
     # Can't read/write from a single StringIO, so make a new one for reading.
-    stream = open(conf_filename, 'rU')
+    stream = open(conf_filename, "rU")
 
     def parse_counters(stream):
         for line_num, line in enumerate(stream):
-            line = line.rstrip('\n')
-            if not line or line.startswith('//'):
+            line = line.rstrip("\n")
+            if not line or line.startswith("//"):
                 # empty line or comment
                 continue
-            m = re.match(r'method ([A-Za-z0-9]+)\.([A-Za-z0-9]+)$', line)
+            m = re.match(r"method ([A-Za-z0-9]+)\.([A-Za-z0-9]+)$", line)
             if m:
                 interface_name, method_name = m.groups()
-                yield { 'type': 'method',
-                        'interface_name': interface_name,
-                        'method_name': method_name }
+                yield {
+                    "type": "method",
+                    "interface_name": interface_name,
+                    "method_name": method_name,
+                }
                 continue
-            m = re.match(r'attribute ([A-Za-z0-9]+)\.([A-Za-z0-9]+)$', line)
+            m = re.match(r"attribute ([A-Za-z0-9]+)\.([A-Za-z0-9]+)$", line)
             if m:
                 interface_name, attribute_name = m.groups()
-                yield { 'type': 'attribute',
-                        'interface_name': interface_name,
-                        'attribute_name': attribute_name }
+                yield {
+                    "type": "attribute",
+                    "interface_name": interface_name,
+                    "attribute_name": attribute_name,
+                }
                 continue
-            m = re.match(r'property ([A-Za-z0-9]+)$', line)
+            m = re.match(r"property ([A-Za-z0-9]+)$", line)
             if m:
                 property_name = m.group(1)
-                yield { 'type': 'property',
-                        'property_name': property_name }
+                yield {"type": "property", "property_name": property_name}
                 continue
-            m = re.match(r'custom ([A-Za-z0-9_]+) (.*)$', line)
+            m = re.match(r"custom ([A-Za-z0-9_]+) (.*)$", line)
             if m:
                 name, desc = m.groups()
-                yield { 'type': 'custom',
-                        'name': name,
-                        'desc': desc }
+                yield {"type": "custom", "name": name, "desc": desc}
                 continue
-            raise ValueError('error parsing %s at line %d' % (conf_filename, line_num))
+            raise ValueError("error parsing %s at line %d" % (conf_filename, line_num))
 
     return parse_counters(stream)
+
 
 def generate_histograms(filename):
     # The mapping for use counters to telemetry histograms depends on the
     # ordering of items in the dictionary.
     items = collections.OrderedDict()
     for counter in read_conf(filename):
+
         def append_counter(name, desc):
-            items[name] = { 'expires_in_version': 'never',
-                            'kind' : 'boolean',
-                            'description': desc }
+            items[name] = {
+                "expires_in_version": "never",
+                "kind": "boolean",
+                "description": desc,
+            }
 
         def append_counters(name, desc):
-            append_counter('USE_COUNTER2_%s_DOCUMENT' % name, 'Whether a document %s' % desc)
-            append_counter('USE_COUNTER2_%s_PAGE' % name, 'Whether a page %s' % desc)
+            append_counter(
+                "USE_COUNTER2_%s_DOCUMENT" % name, "Whether a document %s" % desc
+            )
+            append_counter("USE_COUNTER2_%s_PAGE" % name, "Whether a page %s" % desc)
 
-        if counter['type'] == 'method':
-            method = '%s.%s' % (counter['interface_name'], counter['method_name'])
-            append_counters(method.replace('.', '_').upper(), 'called %s' % method)
-        elif counter['type'] == 'attribute':
-            attr = '%s.%s' % (counter['interface_name'], counter['attribute_name'])
-            counter_name = attr.replace('.', '_').upper()
-            append_counters('%s_getter' % counter_name, 'got %s' % attr)
-            append_counters('%s_setter' % counter_name, 'set %s' % attr)
-        elif counter['type'] == 'property':
-            prop = counter['property_name']
-            append_counters('PROPERTY_%s' % prop.replace('-', '_').upper(), "used the '%s' property" % prop)
-        elif counter['type'] == 'custom':
-            append_counters(counter['name'].upper(), counter['desc'])
+        if counter["type"] == "method":
+            method = "%s.%s" % (counter["interface_name"], counter["method_name"])
+            append_counters(method.replace(".", "_").upper(), "called %s" % method)
+        elif counter["type"] == "attribute":
+            attr = "%s.%s" % (counter["interface_name"], counter["attribute_name"])
+            counter_name = attr.replace(".", "_").upper()
+            append_counters("%s_getter" % counter_name, "got %s" % attr)
+            append_counters("%s_setter" % counter_name, "set %s" % attr)
+        elif counter["type"] == "property":
+            prop = counter["property_name"]
+            append_counters(
+                "PROPERTY_%s" % prop.replace("-", "_").upper(),
+                "used the '%s' property" % prop,
+            )
+        elif counter["type"] == "custom":
+            append_counters(counter["name"].upper(), counter["desc"])
 
     return items

--- a/probe_scraper/parsers/utils.py
+++ b/probe_scraper/parsers/utils.py
@@ -11,16 +11,16 @@ def set_in_nested_dict(dictionary, path, value):
     is equivalent to:
       d["a"]["b"]["c"] = 1
     """
-    keys = path.split('/')
+    keys = path.split("/")
     for k in keys[:-1]:
         dictionary = dictionary[k]
     dictionary[keys[-1]] = value
 
 
 def get_major_version(version):
-    """ Extracts the major (leftmost) version of a version string.
+    """Extracts the major (leftmost) version of a version string.
 
     :param version: the version string (e.g. "53.1")
     :return: a string containing the leftmost number before the first dot
     """
-    return version.split('.')[0]
+    return version.split(".")[0]

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -2,14 +2,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from collections import defaultdict
-import git
 import os
 import shutil
 import tempfile
 import traceback
+from collections import defaultdict
 from datetime import datetime, timedelta
 
+import git
 
 # WARNING!
 # Changing these dates can cause files that had metrics to
@@ -35,8 +35,8 @@ MIN_DATES = {
 def get_commits(repo, filename):
     sep = ":"
     log_format = '--format="%H{}%ct"'.format(sep)
-    change_commits = enumerate(repo.git.log(log_format, filename).split('\n'))
-    most_recent_commit = enumerate(repo.git.log('-n', '1', log_format).split('\n'))
+    change_commits = enumerate(repo.git.log(log_format, filename).split("\n"))
+    most_recent_commit = enumerate(repo.git.log("-n", "1", log_format).split("\n"))
     commits = set(change_commits) | set(most_recent_commit)
 
     # Store the index in the ref-log as well as the timestamp, so that the
@@ -85,7 +85,7 @@ def retrieve_files(repo_info, cache_dir):
         for rel_path in repo_info.get_change_files():
             hashes = get_commits(repo, rel_path)
             for _hash, (ts, index) in hashes.items():
-                if (min_date and ts < min_date):
+                if min_date and ts < min_date:
                     continue
 
                 disk_path = os.path.join(base_path, _hash, rel_path)
@@ -95,7 +95,7 @@ def retrieve_files(repo_info, cache_dir):
                     dir = os.path.split(disk_path)[0]
                     if not os.path.exists(dir):
                         os.makedirs(dir)
-                    with open(disk_path, 'wb') as f:
+                    with open(disk_path, "wb") as f:
                         f.write(contents.encode("UTF-8"))
 
                 results[_hash].append(disk_path)
@@ -142,7 +142,10 @@ def scrape(folder=None, repos=None):
         print("Getting commits for repository " + repo_info.name)
 
         results[repo_info.name] = {}
-        emails[repo_info.name] = {"addresses": repo_info.notification_emails, "emails": []}
+        emails[repo_info.name] = {
+            "addresses": repo_info.notification_emails,
+            "emails": [],
+        }
 
         try:
             ts, commits = retrieve_files(repo_info, folder)
@@ -151,9 +154,11 @@ def scrape(folder=None, repos=None):
             timestamps[repo_info.name] = ts
         except Exception:
             raise
-            emails[repo_info.name]["emails"].append({
-                "subject": "Probe Scraper: Failed Probe Import",
-                "message": traceback.format_exc()
-            })
+            emails[repo_info.name]["emails"].append(
+                {
+                    "subject": "Probe Scraper: Failed Probe Import",
+                    "message": traceback.format_exc(),
+                }
+            )
 
     return timestamps, results, emails

--- a/probe_scraper/scrapers/moz_central_scraper.py
+++ b/probe_scraper/scrapers/moz_central_scraper.py
@@ -2,58 +2,59 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-import os
 import json
-import requests
-from .buildhub import Buildhub
-
+import os
+import re
 from collections import defaultdict
 
-BASE_URI = 'https://hg.mozilla.org'
+import requests
+
+from .buildhub import Buildhub
+
+BASE_URI = "https://hg.mozilla.org"
 
 REGISTRY_FILES = {
-    'histogram': [
-        'toolkit/components/telemetry/Histograms.json',
-        'dom/base/UseCounters.conf',
-        'dom/base/nsDeprecatedOperationList.h',
-        'servo/components/style/properties/counted_unknown_properties.py',
-        'devtools/shared/css/generated/properties-db.js',
+    "histogram": [
+        "toolkit/components/telemetry/Histograms.json",
+        "dom/base/UseCounters.conf",
+        "dom/base/nsDeprecatedOperationList.h",
+        "servo/components/style/properties/counted_unknown_properties.py",
+        "devtools/shared/css/generated/properties-db.js",
     ],
-    'scalar': [
-        'toolkit/components/telemetry/Scalars.yaml',
+    "scalar": [
+        "toolkit/components/telemetry/Scalars.yaml",
     ],
-    'event': [
-        'toolkit/components/telemetry/Events.yaml',
+    "event": [
+        "toolkit/components/telemetry/Events.yaml",
     ],
 }
 
 
 CHANNELS = {
-    'nightly': {
-        'base_uri': f'{BASE_URI}/mozilla-central',
-        'tag_regex': '^FIREFOX_(AURORA|BETA)_[0-9]+_BASE$',
-        'artificial_tags': [
+    "nightly": {
+        "base_uri": f"{BASE_URI}/mozilla-central",
+        "tag_regex": "^FIREFOX_(AURORA|BETA)_[0-9]+_BASE$",
+        "artificial_tags": [
             {
-                'date': [1567362726.0, 0],
-                'node': 'fd2934cca1ae7b492f29a4d240915aa9ec5b4977',
-                'tag': 'FIREFOX_BETA_71_BASE',
+                "date": [1567362726.0, 0],
+                "node": "fd2934cca1ae7b492f29a4d240915aa9ec5b4977",
+                "tag": "FIREFOX_BETA_71_BASE",
             }
-        ]
+        ],
     },
-    'beta': {
-        'base_uri': f'{BASE_URI}/releases/mozilla-beta',
-        'tag_regex': '^FIREFOX_BETA_[0-9]+_BASE$',
+    "beta": {
+        "base_uri": f"{BASE_URI}/releases/mozilla-beta",
+        "tag_regex": "^FIREFOX_BETA_[0-9]+_BASE$",
     },
-    'release': {
-        'base_uri': f'{BASE_URI}/releases/mozilla-release',
-        'tag_regex': '^FIREFOX_[0-9]+_0_RELEASE$',
+    "release": {
+        "base_uri": f"{BASE_URI}/releases/mozilla-release",
+        "tag_regex": "^FIREFOX_[0-9]+_0_RELEASE$",
     },
 }
 
 MIN_FIREFOX_VERSION = 30
-ERROR_CACHE_FILENAME = 'probe_scraper_errors_cache.json'
-ARTIFICIAL_TAG = 'artificial'
+ERROR_CACHE_FILENAME = "probe_scraper_errors_cache.json"
+ARTIFICIAL_TAG = "artificial"
 
 
 def extract_major_version(version_str):
@@ -71,8 +72,10 @@ def extract_major_version(version_str):
 def relative_path_is_in_version(rel_path, version):
     # The devtools file exists in a bunch of versions, but we only care for it
     # since firefox 71 (bug 1578661).
-    if rel_path == 'devtools/shared/css/generated/properties-db.js' or \
-       rel_path == 'servo/components/style/properties/counted_unknown_properties.py':
+    if (
+        rel_path == "devtools/shared/css/generated/properties-db.js"
+        or rel_path == "servo/components/style/properties/counted_unknown_properties.py"
+    ):
         return version >= 71
     return True
 
@@ -80,16 +83,16 @@ def relative_path_is_in_version(rel_path, version):
 def download_files(channel, node, temp_dir, error_cache, version, tree=None):
 
     if tree is None:
-        uri = CHANNELS[channel]['base_uri']
+        uri = CHANNELS[channel]["base_uri"]
     else:
         # mozilla-release and mozilla-beta need to be prefixed with "release/"
         # sometimes they aren't from buildhub, add them if they are missing
         if not tree.startswith("releases/") and tree != "mozilla-central":
             tree = f"releases/{tree}"
-        uri = f'{BASE_URI}/{tree}'
+        uri = f"{BASE_URI}/{tree}"
 
-    base_uri = f'{uri}/raw-file/{node}/'
-    node_path = os.path.join(temp_dir, 'hg', node)
+    base_uri = f"{uri}/raw-file/{node}/"
+    node_path = os.path.join(temp_dir, "hg", node)
 
     results = {}
 
@@ -116,8 +119,10 @@ def download_files(channel, node, temp_dir, error_cache, version, tree=None):
 
         req = requests.get(uri)
         if req.status_code != requests.codes.ok:
-            if os.path.basename(rel_path) == 'Histograms.json':
-                raise Exception("Request returned status " + str(req.status_code) + " for " + uri)
+            if os.path.basename(rel_path) == "Histograms.json":
+                raise Exception(
+                    "Request returned status " + str(req.status_code) + " for " + uri
+                )
             else:
                 error_cache[uri] = req.status_code
                 continue
@@ -125,7 +130,7 @@ def download_files(channel, node, temp_dir, error_cache, version, tree=None):
         dir = os.path.split(disk_path)[0]
         if not os.path.exists(dir):
             os.makedirs(dir)
-        with open(disk_path, 'wb') as f:
+        with open(disk_path, "wb") as f:
             for chunk in req.iter_content(chunk_size=128):
                 f.write(chunk)
 
@@ -138,17 +143,19 @@ def load_error_cache(folder):
     path = os.path.join(folder, ERROR_CACHE_FILENAME)
     if not os.path.exists(path):
         return {}
-    with open(path, 'r') as f:
+    with open(path, "r") as f:
         return json.load(f)
 
 
 def save_error_cache(folder, error_cache):
     path = os.path.join(folder, ERROR_CACHE_FILENAME)
-    with open(path, 'w') as f:
-        json.dump(error_cache, f, sort_keys=True, indent=2, separators=(',', ': '))
+    with open(path, "w") as f:
+        json.dump(error_cache, f, sort_keys=True, indent=2, separators=(",", ": "))
 
 
-def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=None, channels=None):
+def scrape_channel_revisions(
+    folder=None, min_fx_version=None, max_fx_version=None, channels=None
+):
     """
     Returns data in the format:
     {
@@ -180,7 +187,9 @@ def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=No
 
         print("\nRetreiving Buildhub results for channel " + channel)
 
-        revision_dates = bh.get_revision_dates(channel, min_fx_version, max_version=max_fx_version)
+        revision_dates = bh.get_revision_dates(
+            channel, min_fx_version, max_version=max_fx_version
+        )
         num_revisions = len(revision_dates)
 
         print("  " + str(num_revisions) + " revisions found")
@@ -188,15 +197,21 @@ def scrape_channel_revisions(folder=None, min_fx_version=None, max_fx_version=No
         for i, rd in enumerate(revision_dates):
             revision = rd["revision"]
 
-            print((f"  Downloading files for revision number {str(i+1)}/{str(num_revisions)}"
-                   f" - revision: {revision}, tree: {rd['tree']}, version: {str(rd['version'])}"))
+            print(
+                (
+                    f"  Downloading files for revision number {str(i+1)}/{str(num_revisions)}"
+                    f" - revision: {revision}, tree: {rd['tree']}, version: {str(rd['version'])}"
+                )
+            )
             version = extract_major_version(rd["version"])
-            files = download_files(channel, revision, folder, error_cache, version, tree=rd["tree"])
+            files = download_files(
+                channel, revision, folder, error_cache, version, tree=rd["tree"]
+            )
 
             results[channel][revision] = {
-                'date': rd['date'],
-                'version': version,
-                'registries': files
+                "date": rd["date"],
+                "version": version,
+                "registries": files,
             }
             save_error_cache(folder, error_cache)
 

--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -15,17 +15,17 @@ REFLOG_KEY = "reflog-index"
 
 
 def is_test_probe(probe_type, name):
-    if probe_type == 'histogram':
+    if probe_type == "histogram":
         # These are test-only probes and never sent out.
         return name.startswith("TELEMETRY_TEST_")
-    elif probe_type in ['scalar', 'event']:
+    elif probe_type in ["scalar", "event"]:
         return name.startswith("telemetry.test.")
 
     return False
 
 
 def get_from_nested_dict(dictionary, path, default=None):
-    keys = path.split('/')
+    keys = path.split("/")
     for k in keys[:-1]:
         dictionary = dictionary[k]
     return dictionary.get(keys[-1], default)
@@ -63,9 +63,10 @@ def probes_equal(probe1, probe2):
     return True
 
 
-def extract_node_data(node_id, channel, probe_type, probe_data, result_data,
-                      version, break_by_channel):
-    """ Extract the probe data and group it by channel.
+def extract_node_data(
+    node_id, channel, probe_type, probe_data, result_data, version, break_by_channel
+):
+    """Extract the probe data and group it by channel.
 
     :param node_id: the revision the probe data comes from, with th
     :param channel: the channel the probe was found in.
@@ -157,10 +158,12 @@ def sorted_node_lists_by_channel(node_data):
     channels = defaultdict(list)
     for channel, nodes in node_data.items():
         for node_id, data in nodes.items():
-            channels[channel].append({
-                'node_id': node_id,
-                'version': data['version'],
-            })
+            channels[channel].append(
+                {
+                    "node_id": node_id,
+                    "version": data["version"],
+                }
+            )
 
     for channel, data in channels.items():
         channels[channel] = sorted(data, key=lambda n: int(n["version"]), reverse=True)
@@ -175,19 +178,23 @@ def sorted_node_lists_by_date(node_data, revision_dates):
     channels = defaultdict(list)
     for channel, nodes in node_data.items():
         for node_id, data in nodes.items():
-            channels[channel].append({
-                'node_id': node_id,
-                'version': data['version'],
-            })
+            channels[channel].append(
+                {
+                    "node_id": node_id,
+                    "version": data["version"],
+                }
+            )
 
     for channel, data in channels.items():
-        channels[channel] = sorted(data, key=lambda x: get_date(x["node_id"]), reverse=True)
+        channels[channel] = sorted(
+            data, key=lambda x: get_date(x["node_id"]), reverse=True
+        )
 
     return channels
 
 
 def transform(probe_data, node_data, break_by_channel, revision_dates=None):
-    """ Transform the probe data into the final format.
+    """Transform the probe data into the final format.
 
     :param probe_data: the preprocessed probe data.
     :param node_data: the raw probe data.
@@ -205,28 +212,36 @@ def transform(probe_data, node_data, break_by_channel, revision_dates=None):
     for channel, channel_data in channels.items():
         print("\n" + channel + " - transforming probe data:")
         for entry in channel_data:
-            node_id = entry['node_id']
+            node_id = entry["node_id"]
 
             readable_version = str(entry["version"])
             print("  from: " + str({"node": node_id, "version": readable_version}))
             for probe_type, probes in probe_data[channel][node_id].items():
                 # Group the probes by the release channel, if requested
-                extract_node_data(node_id, channel, probe_type, probes, result_data,
-                                  readable_version, break_by_channel)
+                extract_node_data(
+                    node_id,
+                    channel,
+                    probe_type,
+                    probes,
+                    result_data,
+                    readable_version,
+                    break_by_channel,
+                )
 
     return result_data
 
 
 def get_minimum_date(probe_data, revision_data, revision_dates):
-    probe_histories = transform(probe_data, revision_data, break_by_channel=True,
-                                revision_dates=revision_dates)
+    probe_histories = transform(
+        probe_data, revision_data, break_by_channel=True, revision_dates=revision_dates
+    )
     min_dates = defaultdict(lambda: defaultdict(str))
 
     for channel, probes in probe_histories.items():
         for probe_id, entry in probes.items():
             dates = []
-            for history in entry['history'][channel]:
-                revision = history['revisions']['first']
+            for history in entry["history"][channel]:
+                revision = history["revisions"]["first"]
                 dates.append(revision_dates[channel][revision]["date"])
             min_dates[probe_id][channel] = min(dates)
 
@@ -234,23 +249,20 @@ def get_minimum_date(probe_data, revision_data, revision_dates):
 
 
 def pretty_ts(ts):
-    return datetime.utcfromtimestamp(ts).isoformat(' ')
+    return datetime.utcfromtimestamp(ts).isoformat(" ")
 
 
 def make_item_defn(definition, commit, commit_timestamps):
     if COMMITS_KEY not in definition:
         # This is the first time we've seen this definition
-        definition[COMMITS_KEY] = {
-            "first": commit,
-            "last": commit
-        }
+        definition[COMMITS_KEY] = {"first": commit, "last": commit}
         definition[DATES_KEY] = {
             "first": pretty_ts(commit_timestamps[commit][0]),
-            "last": pretty_ts(commit_timestamps[commit][0])
+            "last": pretty_ts(commit_timestamps[commit][0]),
         }
         definition[REFLOG_KEY] = {
             "first": commit_timestamps[commit][1],
-            "last": commit_timestamps[commit][1]
+            "last": commit_timestamps[commit][1],
         }
     else:
         # we've seen this definition, update the `last` commit
@@ -262,23 +274,25 @@ def make_item_defn(definition, commit, commit_timestamps):
 
 
 def metrics_equal(def1, def2):
-    return all((
-        def1.get(l) == def2.get(l)
-        for l in {
-            'bugs',
-            'data_reviews',
-            'description',
-            'disabled',
-            'labeled',
-            'labels',
-            'lifetime',
-            'notification_emails',
-            'send_in_pings',
-            'time_unit',
-            'type',
-            'version',
-        }
-     ))
+    return all(
+        (
+            def1.get(l) == def2.get(l)
+            for l in {
+                "bugs",
+                "data_reviews",
+                "description",
+                "disabled",
+                "labeled",
+                "labels",
+                "lifetime",
+                "notification_emails",
+                "send_in_pings",
+                "time_unit",
+                "type",
+                "version",
+            }
+        )
+    )
 
 
 def ping_equal(def1, def2):
@@ -286,34 +300,27 @@ def ping_equal(def1, def2):
     ignored_keys = set([DATES_KEY, COMMITS_KEY, HISTORY_KEY, REFLOG_KEY])
     all_keys = set(def1.keys()).union(def2.keys()).difference(ignored_keys)
 
-    return all((
-        def1.get(l) == def2.get(l)
-        for l in all_keys
-    ))
+    return all((def1.get(l) == def2.get(l) for l in all_keys))
 
 
 def metric_constructor(defn, metric):
-    return {
-        TYPE_KEY: defn[TYPE_KEY],
-        NAME_KEY: metric,
-        HISTORY_KEY: [defn]
-    }
+    return {TYPE_KEY: defn[TYPE_KEY], NAME_KEY: metric, HISTORY_KEY: [defn]}
 
 
 def ping_constructor(defn, metric):
-    return {
-        NAME_KEY: metric,
-        HISTORY_KEY: [defn]
-    }
+    return {NAME_KEY: metric, HISTORY_KEY: [defn]}
 
 
-def update_or_add_item(repo_items, commit_hash, item, definition, commit_timestamps,
-                       equal_fn, type_ctor):
+def update_or_add_item(
+    repo_items, commit_hash, item, definition, commit_timestamps, equal_fn, type_ctor
+):
     # If we've seen this item before, check previous definitions
     if item in repo_items:
         prev_defns = repo_items[item][HISTORY_KEY]
-        max_defn_i = max(range(len(prev_defns)),
-                         key=lambda i: datetime.fromisoformat(prev_defns[i][DATES_KEY]["last"]))
+        max_defn_i = max(
+            range(len(prev_defns)),
+            key=lambda i: datetime.fromisoformat(prev_defns[i][DATES_KEY]["last"]),
+        )
         max_defn = prev_defns[max_defn_i]
 
         # If equal to previous commit, update date and commit on existing definition
@@ -387,18 +394,20 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
         # iterate through commits, sorted by timestamp of the commit
         sorted_commits = sorted(
             iter(commits.items()),
-            key=lambda x_y: timestamp_sorter(commit_timestamps[repo_name][x_y[0]])
+            key=lambda x_y: timestamp_sorter(commit_timestamps[repo_name][x_y[0]]),
         )
 
         for commit_hash, items in sorted_commits:
             for item, definition in items.items():
-                repo_items = update_or_add_item(repo_items,
-                                                commit_hash,
-                                                item,
-                                                definition,
-                                                commit_timestamps[repo_name],
-                                                equal_fn,
-                                                type_ctor)
+                repo_items = update_or_add_item(
+                    repo_items,
+                    commit_hash,
+                    item,
+                    definition,
+                    commit_timestamps[repo_name],
+                    equal_fn,
+                    type_ctor,
+                )
 
         all_items[repo_name] = repo_items
 
@@ -406,7 +415,9 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
 
 
 def transform_metrics_by_hash(commit_timestamps, metric_data):
-    return transform_by_hash(commit_timestamps, metric_data, metrics_equal, metric_constructor)
+    return transform_by_hash(
+        commit_timestamps, metric_data, metrics_equal, metric_constructor
+    )
 
 
 def transform_pings_by_hash(commit_timestamps, ping_data):

--- a/probe_scraper/transform_revisions.py
+++ b/probe_scraper/transform_revisions.py
@@ -10,8 +10,8 @@ def transform(node_data):
     for channel, nodes in node_data.items():
         for node_id, details in nodes.items():
             results[channel][node_id] = {
-                'version': details.get('version'),
-                'date': details.get('date')
+                "version": details.get("version"),
+                "date": details.get("date"),
             }
 
     return results

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@
 
 from setuptools import setup
 
-setup(name='probe-scraper',
-      version='0.1',
-      description='Scrape probe data from Firefox repositories.',
-      author='Georg Fritzsche (gfritzsche)',
-      author_email='gfritzsche@mozilla.com',
-      url='https://github.com/georgf/probe-scraper/',
-      packages=['probe_scraper'],
-      license='MPL 2.0',
-      )
+setup(
+    name="probe-scraper",
+    version="0.1",
+    description="Scrape probe data from Firefox repositories.",
+    author="Georg Fritzsche (gfritzsche)",
+    author_email="gfritzsche@mozilla.com",
+    url="https://github.com/georgf/probe-scraper/",
+    packages=["probe_scraper"],
+    license="MPL 2.0",
+)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,6 @@
 flake8==3.7.8
 pytest>=3.0
 responses==0.10.6
+black==20.8b1
+isort==5.6.4
+

--- a/tests/test_buildhub.py
+++ b/tests/test_buildhub.py
@@ -1,13 +1,14 @@
+from datetime import datetime
 
 import pytest
+
 from probe_scraper.scrapers.buildhub import Buildhub, NoDataFoundException
-from datetime import datetime
 
 FX_RELEASE_62_0_3 = {
     "revision": "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b",
     "date": datetime(2018, 10, 1, 18, 40, 35),
     "version": "62.0.3rc1",
-    "tree": "releases/mozilla-release"
+    "tree": "releases/mozilla-release",
 }
 
 VERBOSE = True
@@ -16,16 +17,20 @@ VERBOSE = True
 @pytest.fixture
 def records():
     return [
-        {"_source": {
-            "download": {"date": "2019-01-28T23:49:22.717388+00:00"},
-            "source": {"revision": "abc", "tree": "releases/mozilla-release"},
-            "target": {"version": "1"}
-        }},
-        {"_source": {
-            "download": {"date": "2019-01-29T23:49:22Z"},
-            "source": {"revision": "def", "tree": "releases/mozilla-release"},
-            "target": {"version": "2"}
-        }}
+        {
+            "_source": {
+                "download": {"date": "2019-01-28T23:49:22.717388+00:00"},
+                "source": {"revision": "abc", "tree": "releases/mozilla-release"},
+                "target": {"version": "1"},
+            }
+        },
+        {
+            "_source": {
+                "download": {"date": "2019-01-29T23:49:22Z"},
+                "source": {"revision": "def", "tree": "releases/mozilla-release"},
+                "target": {"version": "2"},
+            }
+        },
     ]
 
 
@@ -34,7 +39,9 @@ def test_nightly_count():
     channel, min_version, max_version = "nightly", 62, 62
 
     bh = Buildhub()
-    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    releases = bh.get_revision_dates(
+        channel, min_version, max_version=max_version, verbose=VERBOSE
+    )
     assert len(releases) == 97
 
 
@@ -43,8 +50,9 @@ def test_pagination():
     channel, min_version, max_version = "nightly", 62, 62
 
     bh = Buildhub()
-    releases = bh.get_revision_dates(channel, min_version, max_version=max_version,
-                                     verbose=VERBOSE, window=10)
+    releases = bh.get_revision_dates(
+        channel, min_version, max_version=max_version, verbose=VERBOSE, window=10
+    )
     assert len(releases) == 97
 
 
@@ -53,7 +61,9 @@ def test_duplicate_revisions():
     channel, min_version, max_version = "nightly", 67, 67
 
     bh = Buildhub()
-    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    releases = bh.get_revision_dates(
+        channel, min_version, max_version=max_version, verbose=VERBOSE
+    )
     assert len({r["revision"] for r in releases}) == len(releases)
 
 
@@ -62,7 +72,9 @@ def test_release():
     channel, min_version, max_version = "release", 62, 62
 
     bh = Buildhub()
-    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    releases = bh.get_revision_dates(
+        channel, min_version, max_version=max_version, verbose=VERBOSE
+    )
 
     assert FX_RELEASE_62_0_3 in releases
 
@@ -72,7 +84,9 @@ def test_min_release():
     channel, min_version, max_version = "release", 63, 63
 
     bh = Buildhub()
-    releases = bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+    releases = bh.get_revision_dates(
+        channel, min_version, max_version=max_version, verbose=VERBOSE
+    )
 
     assert FX_RELEASE_62_0_3 not in releases
 
@@ -83,7 +97,9 @@ def test_no_min_max_version_overlap():
     bh = Buildhub()
 
     with pytest.raises(NoDataFoundException):
-        bh.get_revision_dates(channel, min_version, max_version=max_version, verbose=VERBOSE)
+        bh.get_revision_dates(
+            channel, min_version, max_version=max_version, verbose=VERBOSE
+        )
 
 
 @pytest.mark.web_dependency
@@ -107,14 +123,18 @@ def test_cleaned_dates(records):
     bh = Buildhub()
 
     expected = [
-        {"revision": "abc",
-         "date": datetime(2019, 1, 28, 23, 49, 22, 717388),
-         "version": "1",
-         "tree": "releases/mozilla-release"},
-        {"revision": "def",
-         "date": datetime(2019, 1, 29, 23, 49, 22),
-         "version": "2",
-         "tree": "releases/mozilla-release"}
+        {
+            "revision": "abc",
+            "date": datetime(2019, 1, 28, 23, 49, 22, 717388),
+            "version": "1",
+            "tree": "releases/mozilla-release",
+        },
+        {
+            "revision": "def",
+            "date": datetime(2019, 1, 29, 23, 49, 22),
+            "version": "2",
+            "tree": "releases/mozilla-release",
+        },
     ]
 
     assert bh._distinct_and_clean(records) == expected
@@ -128,10 +148,12 @@ def test_unique_sorted(records):
     records[1]["_source"]["download"]["date"] = "2019-01-22T23:49:22Z"
 
     expected = [
-        {"revision": "abc",
-         "date": datetime(2019, 1, 22, 23, 49, 22),
-         "version": "2",
-         "tree": "releases/mozilla-release"},
+        {
+            "revision": "abc",
+            "date": datetime(2019, 1, 22, 23, 49, 22),
+            "version": "2",
+            "tree": "releases/mozilla-release",
+        },
     ]
 
     assert bh._distinct_and_clean(records) == expected

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -15,11 +15,14 @@ def test_event_parser():
 
     # Make sure each of them contains all the required fields and details.
     REQUIRED_FIELDS = [
-      "cpp_guard", "description", "details", "expiry_version", "optout", "bug_numbers"
+        "cpp_guard",
+        "description",
+        "details",
+        "expiry_version",
+        "optout",
+        "bug_numbers",
     ]
-    REQUIRED_DETAILS = [
-      "methods", "objects", "extra_keys", "record_in_processes"
-    ]
+    REQUIRED_DETAILS = ["methods", "objects", "extra_keys", "record_in_processes"]
 
     for name, data in parsed_events.items():
         assert is_string(name)

--- a/tests/test_histogram_parser.py
+++ b/tests/test_histogram_parser.py
@@ -68,11 +68,22 @@ def histogram_parser(version, usecounter_optout):
 
     # Make sure each of them contains all the required fields and details.
     REQUIRED_FIELDS = [
-        "cpp_guard", "description", "details", "expiry_version", "optout", "bug_numbers"
+        "cpp_guard",
+        "description",
+        "details",
+        "expiry_version",
+        "optout",
+        "bug_numbers",
     ]
 
     REQUIRED_DETAILS = [
-        "low", "high", "keyed", "kind", "n_buckets", "record_in_processes", "record_into_store"
+        "low",
+        "high",
+        "keyed",
+        "kind",
+        "n_buckets",
+        "record_in_processes",
+        "record_into_store",
     ]
 
     for name, data in parsed_histograms.items():
@@ -84,22 +95,22 @@ def histogram_parser(version, usecounter_optout):
 
         # Check that we have all the needed details.
         for field in REQUIRED_DETAILS:
-            assert field in data['details']
+            assert field in data["details"]
 
         # If multiple stores set, they should be both listed
         if name == "HISTOGRAM_WITH_MULTISTORE":
-            assert ["main", "store2"] == data['details']['record_into_store']
+            assert ["main", "store2"] == data["details"]["record_into_store"]
         else:
             # Default multistore if unspecified is just "main"
-            assert ["main"] == data['details']['record_into_store']
+            assert ["main"] == data["details"]["record_into_store"]
 
         # Categorical histograms should have a non-empty `details["labels"]`.
-        if data['details']['kind'] == 'categorical':
-            assert ('labels' in data['details'].keys() and isinstance(
-                data['details']['labels'], list
-            ))
+        if data["details"]["kind"] == "categorical":
+            assert "labels" in data["details"].keys() and isinstance(
+                data["details"]["labels"], list
+            )
         else:
-            assert 'labels' not in data['details'].keys()
+            assert "labels" not in data["details"].keys()
 
         if name.startswith("USE_COUNTER2_"):
             assert data["optout"] == usecounter_optout

--- a/tests/test_metrics_parser.py
+++ b/tests/test_metrics_parser.py
@@ -20,4 +20,4 @@ def test_metrics_parser():
         assert is_string(name)
 
     # Check that ping names are normalized
-    assert 'session-end' in parsed_metrics['example.os']['send_in_pings']
+    assert "session-end" in parsed_metrics["example.os"]["send_in_pings"]

--- a/tests/test_moz_central_scraper.py
+++ b/tests/test_moz_central_scraper.py
@@ -1,7 +1,9 @@
-from probe_scraper.scrapers import moz_central_scraper
-from datetime import datetime
-import pytest
 import os
+from datetime import datetime
+
+import pytest
+
+from probe_scraper.scrapers import moz_central_scraper
 
 
 def test_extract_major_version():
@@ -23,21 +25,23 @@ def test_channel_revisions():
     channel = "release"
     revision = "c9ed11ae5c79df3dcb69075e1c9da0317d1ecb1b"
 
-    res = moz_central_scraper.scrape_channel_revisions(tmp_dir, min_fx_version,
-                                                       max_fx_version=max_fx_version,
-                                                       channels=[channel])
+    res = moz_central_scraper.scrape_channel_revisions(
+        tmp_dir, min_fx_version, max_fx_version=max_fx_version, channels=[channel]
+    )
 
     registries = {
         probe_type: [
             os.path.join(tmp_dir, "hg", revision, path)
-            for path in paths if path_is_in_version(path, 62)
-        ] for probe_type, paths in moz_central_scraper.REGISTRY_FILES.items()
+            for path in paths
+            if path_is_in_version(path, 62)
+        ]
+        for probe_type, paths in moz_central_scraper.REGISTRY_FILES.items()
     }
 
     record = {
         "date": datetime(2018, 10, 1, 18, 40, 35),
         "version": 62,
-        "registries": registries
+        "registries": registries,
     }
 
     assert res[channel][revision] == record

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -17,18 +17,19 @@ class ResponseWrapper:
 
 
 def test_bugzilla_prod_urls():
-    assert probe_expiry_alert.BUGZILLA_BUG_URL.startswith("https://bugzilla.mozilla.org/")
-    assert probe_expiry_alert.BUGZILLA_USER_URL.startswith("https://bugzilla.mozilla.org/")
+    assert probe_expiry_alert.BUGZILLA_BUG_URL.startswith(
+        "https://bugzilla.mozilla.org/"
+    )
+    assert probe_expiry_alert.BUGZILLA_USER_URL.startswith(
+        "https://bugzilla.mozilla.org/"
+    )
     assert probe_expiry_alert.BUGZILLA_BUG_LINK_TEMPLATE.startswith(
-        "https://bugzilla.mozilla.org/")
+        "https://bugzilla.mozilla.org/"
+    )
 
 
 def test_find_expiring_probes_no_expiring():
-    probes = {
-        "p1": {
-            "expiry_version": "never"
-        }
-    }
+    probes = {"p1": {"expiry_version": "never"}}
     expiring_probes = probe_expiry_alert.find_expiring_probes(
         probes,
         "75",
@@ -100,9 +101,15 @@ def test_find_expiring_probes_expiring(mock_get_bug_component):
 @mock.patch("probe_scraper.probe_expiry_alert.get_latest_nightly_version")
 @mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
 @mock.patch("probe_scraper.probe_expiry_alert.send_emails")
-def test_not_dryrun_only_once_per_week(mock_send_emails, mock_file_bugs, mock_get_version,
-                                       mock_download_file, mock_scalars_parser,
-                                       mock_histograms_parser, mock_events_parser):
+def test_not_dryrun_only_once_per_week(
+    mock_send_emails,
+    mock_file_bugs,
+    mock_get_version,
+    mock_download_file,
+    mock_scalars_parser,
+    mock_histograms_parser,
+    mock_events_parser,
+):
     mock_file_bugs.return_value = {}
     mock_events_parser.return_value = {}
     mock_histograms_parser.return_value = {}
@@ -112,13 +119,17 @@ def test_not_dryrun_only_once_per_week(mock_send_emails, mock_file_bugs, mock_ge
         base_date = datetime.date(2020, 1, 1)
         probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), False, "")
 
-    mock_file_bugs.assert_has_calls([mock.call([], "76", "", dryrun=False)] +
-                                    [mock.call([], "76", "", dryrun=True)] * 6,
-                                    any_order=True)
+    mock_file_bugs.assert_has_calls(
+        [mock.call([], "76", "", dryrun=False)]
+        + [mock.call([], "76", "", dryrun=True)] * 6,
+        any_order=True,
+    )
     assert mock_file_bugs.call_count == 7
-    mock_send_emails.assert_has_calls([mock.call({}, {}, "76", dryrun=False)] +
-                                      [mock.call({}, {}, "76", dryrun=True)] * 6,
-                                      any_order=True)
+    mock_send_emails.assert_has_calls(
+        [mock.call({}, {}, "76", dryrun=False)]
+        + [mock.call({}, {}, "76", dryrun=True)] * 6,
+        any_order=True,
+    )
     assert mock_send_emails.call_count == 7
 
 
@@ -128,7 +139,7 @@ def test_no_bugs_created_on_dryrun(mock_create_bug, mock_find_bugs):
     mock_find_bugs.return_value = set()
     expiring_probes = [
         ProbeDetails("p1", "", "", [], 1),
-        ProbeDetails("p2", "", "", ['a@test.com'], 1),
+        ProbeDetails("p2", "", "", ["a@test.com"], 1),
     ]
 
     probe_expiry_alert.file_bugs(expiring_probes, "76", "", dryrun=True)
@@ -142,7 +153,7 @@ def test_bugs_created_not_dryrun(mock_create_bug, mock_find_bugs):
     mock_find_bugs.return_value = []
     expiring_probes = [
         ProbeDetails("p1", "1", "2", [], 1),
-        ProbeDetails("p2", "3", "4", ['a@test.com'], 1),
+        ProbeDetails("p2", "3", "4", ["a@test.com"], 1),
     ]
 
     probe_expiry_alert.file_bugs(expiring_probes, "76", "", dryrun=False)
@@ -194,9 +205,16 @@ def test_send_email_not_dryrun(mock_boto_client):
 @mock.patch("probe_scraper.probe_expiry_alert.check_bugzilla_user_exists")
 @mock.patch("probe_scraper.probe_expiry_alert.file_bugs")
 @mock.patch("probe_scraper.probe_expiry_alert.send_emails")
-def test_main_run(mock_send_emails, mock_file_bugs, mock_user_exists,
-                  mock_get_version, mock_download_file, mock_scalars_parser,
-                  mock_histograms_parser, mock_events_parser):
+def test_main_run(
+    mock_send_emails,
+    mock_file_bugs,
+    mock_user_exists,
+    mock_get_version,
+    mock_download_file,
+    mock_scalars_parser,
+    mock_histograms_parser,
+    mock_events_parser,
+):
     mock_user_exists.return_value = False
     mock_events_parser.return_value = {
         "p1": {
@@ -223,10 +241,10 @@ def test_main_run(mock_send_emails, mock_file_bugs, mock_user_exists,
 
     probe_expiry_alert.main(datetime.date(2020, 1, 8), False, "")
 
-    expected_expiring_probes = [
-        ProbeDetails("p1", "Firefox", "General", [], None)
-    ]
-    mock_file_bugs.assert_called_once_with(expected_expiring_probes, "76", "", dryrun=False)
+    expected_expiring_probes = [ProbeDetails("p1", "Firefox", "General", [], None)]
+    mock_file_bugs.assert_called_once_with(
+        expected_expiring_probes, "76", "", dryrun=False
+    )
 
 
 @mock.patch("probe_scraper.probe_expiry_alert.find_existing_bugs")
@@ -242,10 +260,13 @@ def test_bugs_created_only_for_new_probes(mock_create_bugs, mock_find_bugs):
     probe_expiry_alert.file_bugs(probes, "1", "", dryrun=False)
 
     assert mock_create_bugs.call_count == 2
-    mock_create_bugs.has_calls([
-        mock.call(ProbeDetails("p1", "", "", ["email1"], 1), "1", mock.ANY),
-        mock.call(ProbeDetails("p4", "", "", ["email2"], 1), "1", mock.ANY),
-    ], any_order=True)
+    mock_create_bugs.has_calls(
+        [
+            mock.call(ProbeDetails("p1", "", "", ["email1"], 1), "1", mock.ANY),
+            mock.call(ProbeDetails("p4", "", "", ["email2"], 1), "1", mock.ANY),
+        ],
+        any_order=True,
+    )
 
 
 @mock.patch("requests.post")
@@ -275,17 +296,20 @@ def test_bug_description_parser(mock_get):
             {
                 "summary": "",
                 "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
-                    version="76", probes="\np1\np2 \n", notes=""),
+                    version="76", probes="\np1\np2 \n", notes=""
+                ),
             },
             {
                 "summary": "",
                 "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
-                    version="77", probes="\n p3 p4", notes=""),
+                    version="77", probes="\n p3 p4", notes=""
+                ),
             },
             {
                 "summary": "",
                 "description": probe_expiry_alert.BUG_DESCRIPTION_TEMPLATE.format(
-                    version="76", probes="\np5 p6\n", notes=""),
+                    version="76", probes="\np5 p6\n", notes=""
+                ),
             },
         ]
     }
@@ -331,12 +355,14 @@ def test_check_bugzilla_user_account_not_found(mock_get):
 def test_check_bugzilla_user_account_not_found_200(mock_get):
     mock_response = mock.MagicMock()
     mock_response.status_code = 200
-    mock_response.json = mock.MagicMock(return_value={
-        "message": None,
-        "code": 100500,
-        "documentation": "https://bmo.readthedocs.io/en/latest/api/",
-        "error": True,
-    })
+    mock_response.json = mock.MagicMock(
+        return_value={
+            "message": None,
+            "code": 100500,
+            "documentation": "https://bmo.readthedocs.io/en/latest/api/",
+            "error": True,
+        }
+    )
 
     mock_get.return_value = mock_response
 

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -1,14 +1,16 @@
-from probe_scraper.parsers.repositories import RepositoriesParser
-import pytest
-import jsonschema
-import yaml
-import tempfile
 import os
+import tempfile
+
+import jsonschema
+import pytest
+import yaml
+
+from probe_scraper.parsers.repositories import RepositoriesParser
 
 
 def write_to_temp_file(data):
     fd, path = tempfile.mkstemp()
-    with os.fdopen(fd, 'w') as tmp:
+    with os.fdopen(fd, "w") as tmp:
         tmp.write(yaml.dump(data))
     return path
 
@@ -26,7 +28,7 @@ def incorrect_repos_file():
             "app_id": "mobile-metrics-example",
             "description": "foo",
             "url": "www.github.com/fbertsch/mobile-metrics-example",
-            "metrics_files": ["metrics.yaml"]
+            "metrics_files": ["metrics.yaml"],
         }
     }
 
@@ -42,7 +44,7 @@ def correct_repos_file():
             "channel": "release",
             "url": "www.github.com/fbertsch/mobile-metrics-example",
             "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"]
+            "metrics_files": ["metrics.yaml"],
         }
     }
 
@@ -57,7 +59,7 @@ def not_kebab_case_repos_file():
             "description": "foo",
             "url": "www.github.com/fbertsch/mobile-metrics-example",
             "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"]
+            "metrics_files": ["metrics.yaml"],
         }
     }
 
@@ -73,7 +75,7 @@ def invalid_release_channel_file():
             "channel": "releaze",
             "url": "www.github.com/fbertsch/mobile-metrics-example",
             "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"]
+            "metrics_files": ["metrics.yaml"],
         }
     }
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,7 +1,8 @@
-from probe_scraper import runner
+import os
 from copy import deepcopy
 from datetime import datetime
-import os
+
+from probe_scraper import runner
 
 
 def test_add_first_appeared_dates():
@@ -9,58 +10,38 @@ def test_add_first_appeared_dates():
         "all": {
             "histogram/test_int_histogram": {
                 "history": {
-                    "nightly": {
-                        "revisions": {
-                            "first": "rev-a",
-                            "last": "rev-b"
-                        }
-                    },
-                    "release": {
-                        "revisions": {
-                            "first": "rev-c",
-                            "last": "rev-d"
-                        }
-                    }
+                    "nightly": {"revisions": {"first": "rev-a", "last": "rev-b"}},
+                    "release": {"revisions": {"first": "rev-c", "last": "rev-d"}},
                 }
             }
         },
         "nightly": {
             "histogram/test_int_histogram": {
                 "history": {
-                    "nightly": {
-                        "revisions": {
-                            "first": "rev-a",
-                            "last": "rev-b"
-                        }
-                    }
+                    "nightly": {"revisions": {"first": "rev-a", "last": "rev-b"}}
                 }
             }
         },
         "release": {
             "histogram/test_int_histogram": {
                 "history": {
-                    "release": {
-                        "revisions": {
-                            "first": "rev-c",
-                            "last": "rev-d"
-                        }
-                    }
+                    "release": {"revisions": {"first": "rev-c", "last": "rev-d"}}
                 }
             }
-        }
+        },
     }
 
     first_appeared_dates = {
         "histogram/test_int_histogram": {
             "release": datetime(2019, 1, 1, 0, 0, 0),
-            "nightly": datetime(2018, 12, 1, 0, 0, 0)
+            "nightly": datetime(2018, 12, 1, 0, 0, 0),
         }
     }
 
     expected = deepcopy(probes_by_channel)
     expected["all"]["histogram/test_int_histogram"]["first_added"] = {
         "release": "2019-01-01 00:00:00",
-        "nightly": "2018-12-01 00:00:00"
+        "nightly": "2018-12-01 00:00:00",
     }
     expected["release"]["histogram/test_int_histogram"]["first_added"] = {
         "release": "2019-01-01 00:00:00",
@@ -69,12 +50,14 @@ def test_add_first_appeared_dates():
         "nightly": "2018-12-01 00:00:00"
     }
 
-    assert runner.add_first_appeared_dates(probes_by_channel, first_appeared_dates) == expected
+    assert (
+        runner.add_first_appeared_dates(probes_by_channel, first_appeared_dates)
+        == expected
+    )
 
 
 def test_trailing_space(tmp_path):
-    '''Test cases to check the output of json.dumps has no trailing spaces
-    '''
+    """Test cases to check the output of json.dumps has no trailing spaces"""
     test_cases = [
         {
             "test1": 12,
@@ -82,16 +65,16 @@ def test_trailing_space(tmp_path):
         }
     ]
 
-    DIR_NAME = tmp_path / 'output_dir'
-    FILE_NAME = 'file_name.txt'
+    DIR_NAME = tmp_path / "output_dir"
+    FILE_NAME = "file_name.txt"
 
     for test_case in test_cases:
-        trailing_spaces = 0     # Counts no of trailing spaces
+        trailing_spaces = 0  # Counts no of trailing spaces
         runner.dump_json(test_case, DIR_NAME, FILE_NAME)
         path = os.path.join(DIR_NAME, FILE_NAME)
-        with open(path, 'r') as file:
+        with open(path, "r") as file:
             for line in file.readline():
-                if line[-1] == ' ':
+                if line[-1] == " ":
                     trailing_spaces += 1
 
         assert not trailing_spaces

--- a/tests/test_scalar_parser.py
+++ b/tests/test_scalar_parser.py
@@ -15,11 +15,14 @@ def test_scalar_parser():
 
     # Make sure each of them contains all the required fields and details.
     REQUIRED_FIELDS = [
-        "cpp_guard", "description", "details", "expiry_version", "optout", "bug_numbers"
+        "cpp_guard",
+        "description",
+        "details",
+        "expiry_version",
+        "optout",
+        "bug_numbers",
     ]
-    REQUIRED_DETAILS = [
-        "keyed", "kind", "record_in_processes", "record_into_store"
-    ]
+    REQUIRED_DETAILS = ["keyed", "kind", "record_in_processes", "record_into_store"]
 
     for name, data in parsed_scalars.items():
         assert is_string(name)
@@ -33,7 +36,7 @@ def test_scalar_parser():
 
         # If multiple stores set, they should be both listed
         if name == "other.test.multistore_probe":
-            assert ["main", "store2"] == data['details']['record_into_store']
+            assert ["main", "store2"] == data["details"]["record_into_store"]
         else:
             # Default multistore if unspecified is just "main"
-            assert ["main"] == data['details']['record_into_store']
+            assert ["main"] == data["details"]["record_into_store"]

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -1,7 +1,7 @@
-import probe_scraper.transform_probes as transform
 import pprint
-
 from datetime import datetime
+
+import probe_scraper.transform_probes as transform
 
 # incoming probe_data is of the form:
 #   node_id -> {
@@ -42,22 +42,10 @@ IN_NODE_DATA = {
 
 REVISION_DATES = {
     channel: {
-        "node_id_1": {
-            "version": "50",
-            "date": datetime(2018, 1, 1, 10, 11, 12)
-        },
-        "node_id_2": {
-            "version": "51",
-            "date": datetime(2018, 2, 2, 10, 11, 12)
-        },
-        "node_id_3": {
-            "version": "52",
-            "date": datetime(2018, 3, 3, 10, 11, 12)
-        },
-        "node_id_4": {
-            "version": "52",
-            "date": datetime(2018, 1, 1, 1, 1, 1)
-        },
+        "node_id_1": {"version": "50", "date": datetime(2018, 1, 1, 10, 11, 12)},
+        "node_id_2": {"version": "51", "date": datetime(2018, 2, 2, 10, 11, 12)},
+        "node_id_3": {"version": "52", "date": datetime(2018, 3, 3, 10, 11, 12)},
+        "node_id_4": {"version": "52", "date": datetime(2018, 1, 1, 1, 1, 1)},
     }
     for channel in CHANNELS
 }
@@ -73,11 +61,15 @@ IN_METRICS_DATA = {
                 "time_unit": "second",
                 "send_in_pings": ["baseline"],
                 "bugs": [1497894, 1519120],
-                "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                "data_reviews": [
+                    "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                ],
+                "notification_emails": ["telemetry-client-dev@mozilla.com"],
             }
-        } for i in range(4)
-    } for repo in REPOS
+        }
+        for i in range(4)
+    }
+    for repo in REPOS
 }
 
 OUT_METRICS_DATA = {
@@ -92,24 +84,21 @@ OUT_METRICS_DATA = {
                     "time_unit": "second",
                     "send_in_pings": ["baseline"],
                     "bugs": [1497894, 1519120],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
                     "notification_emails": ["telemetry-client-dev@mozilla.com"],
-                    "git-commits": {
-                        "first": "3",
-                        "last": "0"
-                    },
+                    "git-commits": {"first": "3", "last": "0"},
                     "dates": {
                         "first": "1969-12-31 23:59:57",
-                        "last": "1970-01-01 00:00:00"
+                        "last": "1970-01-01 00:00:00",
                     },
-                    "reflog-index": {
-                        "first": 3,
-                        "last": 0
-                    }
+                    "reflog-index": {"first": 3, "last": 0},
                 }
-            ]
+            ],
         }
-    } for repo in REPOS
+    }
+    for repo in REPOS
 }
 
 IN_PING_DATA = {
@@ -118,13 +107,17 @@ IN_PING_DATA = {
             "metrics": {
                 "description": "Metrics ping",
                 "bugs": ["https://bugzilla.mozilla.org/1512938"],
-                "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                "data_reviews": [
+                    "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                ],
                 "notification_emails": ["telemetry-client-dev@mozilla.com"],
                 "include_client_id": True,
                 "send_if_empty": False,
             }
-        } for i in range(4)
-    } for repo in REPOS
+        }
+        for i in range(4)
+    }
+    for repo in REPOS
 }
 
 OUT_PING_DATA = {
@@ -135,26 +128,23 @@ OUT_PING_DATA = {
                 {
                     "description": "Metrics ping",
                     "bugs": ["https://bugzilla.mozilla.org/1512938"],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
                     "notification_emails": ["telemetry-client-dev@mozilla.com"],
                     "include_client_id": True,
                     "send_if_empty": False,
-                    "git-commits": {
-                        "first": "3",
-                        "last": "0"
-                    },
+                    "git-commits": {"first": "3", "last": "0"},
                     "dates": {
                         "first": "1969-12-31 23:59:57",
-                        "last": "1970-01-01 00:00:00"
+                        "last": "1970-01-01 00:00:00",
                     },
-                    "reflog-index": {
-                        "first": 3,
-                        "last": 0
-                    }
+                    "reflog-index": {"first": 3, "last": 0},
                 }
-            ]
+            ],
         }
-    } for repo in REPOS
+    }
+    for repo in REPOS
 }
 
 
@@ -163,7 +153,8 @@ def in_probe_data():
     secondary_level_prefix = "node_id_"
 
     secondary_level = {
-        secondary_level_prefix + "1": {
+        secondary_level_prefix
+        + "1": {
             "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
@@ -179,9 +170,10 @@ def in_probe_data():
                         "record_in_processes": ["main", "content"],
                     },
                 }
-             }
+            }
         },
-        secondary_level_prefix + "2": {
+        secondary_level_prefix
+        + "2": {
             "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
@@ -197,9 +189,10 @@ def in_probe_data():
                         "record_in_processes": ["main", "content"],
                     },
                 }
-             }
+            }
         },
-        secondary_level_prefix + "3": {
+        secondary_level_prefix
+        + "3": {
             "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
@@ -217,7 +210,8 @@ def in_probe_data():
                 }
             }
         },
-        secondary_level_prefix + "4": {
+        secondary_level_prefix
+        + "4": {
             "histogram": {
                 "TEST_HISTOGRAM_1": {
                     "cpp_guard": None,
@@ -234,7 +228,7 @@ def in_probe_data():
                     },
                 }
             }
-        }
+        },
     }
 
     return {top_level: secondary_level for top_level in top_levels}
@@ -244,69 +238,62 @@ def out_probe_data(by_channel=False):
 
     probes = [
         {
-            'cpp_guard': None,
-            'description': 'A description.',
-            'details': {
-                'high': 10,
-                'keyed': False,
-                'kind': 'exponential',
-                'low': 1,
-                'n_buckets': 5,
-                'record_in_processes': ['content'],
+            "cpp_guard": None,
+            "description": "A description.",
+            "details": {
+                "high": 10,
+                "keyed": False,
+                "kind": "exponential",
+                "low": 1,
+                "n_buckets": 5,
+                "record_in_processes": ["content"],
             },
-            'expiry_version': '53.0',
-            'optout': True,
-            'revisions': {
-                'first': 'node_id_3',
-                'last': 'node_id_4',
+            "expiry_version": "53.0",
+            "optout": True,
+            "revisions": {
+                "first": "node_id_3",
+                "last": "node_id_4",
             },
-            'versions': {
-                'first': '52',
-                'last': '52'
-            }
-        }, {
-            'cpp_guard': None,
-            'description': 'A description.',
-            'details': {
-                'high': 10,
-                'keyed': False,
-                'kind': 'exponential',
-                'low': 1,
-                'n_buckets': 5,
-                'record_in_processes': ['main', 'content'],
+            "versions": {"first": "52", "last": "52"},
+        },
+        {
+            "cpp_guard": None,
+            "description": "A description.",
+            "details": {
+                "high": 10,
+                "keyed": False,
+                "kind": "exponential",
+                "low": 1,
+                "n_buckets": 5,
+                "record_in_processes": ["main", "content"],
             },
-            'expiry_version': '53.0',
-            'optout': True,
-            'revisions': {
-                'first': 'node_id_2',
-                'last': 'node_id_2',
+            "expiry_version": "53.0",
+            "optout": True,
+            "revisions": {
+                "first": "node_id_2",
+                "last": "node_id_2",
             },
-            'versions': {
-                'first': '51',
-                'last': '51'
-            }
-        }, {
-            'cpp_guard': None,
-            'description': 'A description.',
-            'details': {
-                'high': 10,
-                'keyed': False,
-                'kind': 'exponential',
-                'low': 1,
-                'n_buckets': 5,
-                'record_in_processes': ['main', 'content'],
+            "versions": {"first": "51", "last": "51"},
+        },
+        {
+            "cpp_guard": None,
+            "description": "A description.",
+            "details": {
+                "high": 10,
+                "keyed": False,
+                "kind": "exponential",
+                "low": 1,
+                "n_buckets": 5,
+                "record_in_processes": ["main", "content"],
             },
-            'expiry_version': '53.0',
-            'optout': False,
-            'revisions': {
-                'first': 'node_id_1',
-                'last': 'node_id_1',
+            "expiry_version": "53.0",
+            "optout": False,
+            "revisions": {
+                "first": "node_id_1",
+                "last": "node_id_1",
             },
-            'versions': {
-                'first': '50',
-                'last': '50'
-            }
-        }
+            "versions": {"first": "50", "last": "50"},
+        },
     ]
 
     allowed_channels = CHANNELS
@@ -314,20 +301,20 @@ def out_probe_data(by_channel=False):
     if by_channel:
         return {
             channel: {
-                'histogram/TEST_HISTOGRAM_1': {
-                    'history': {channel: probes},
-                    'name': 'TEST_HISTOGRAM_1',
-                    'type': 'histogram'
+                "histogram/TEST_HISTOGRAM_1": {
+                    "history": {channel: probes},
+                    "name": "TEST_HISTOGRAM_1",
+                    "type": "histogram",
                 }
             }
             for channel in allowed_channels
         }
     else:
         return {
-            'histogram/TEST_HISTOGRAM_1': {
-                'history': {channel: probes for channel in allowed_channels},
-                'name': 'TEST_HISTOGRAM_1',
-                'type': 'histogram'
+            "histogram/TEST_HISTOGRAM_1": {
+                "history": {channel: probes for channel in allowed_channels},
+                "name": "TEST_HISTOGRAM_1",
+                "type": "histogram",
             }
         }
 
@@ -351,11 +338,9 @@ def out_probe_data_by_revision_date(by_channel=False):
                 "first": "node_id_3",
                 "last": "node_id_3",
             },
-            "versions": {
-                "first": "52",
-                "last": "52"
-            }
-        }, {
+            "versions": {"first": "52", "last": "52"},
+        },
+        {
             "cpp_guard": None,
             "description": "A description.",
             "details": {
@@ -372,11 +357,9 @@ def out_probe_data_by_revision_date(by_channel=False):
                 "first": "node_id_2",
                 "last": "node_id_2",
             },
-            "versions": {
-                "first": "51",
-                "last": "51"
-            }
-        }, {
+            "versions": {"first": "51", "last": "51"},
+        },
+        {
             "cpp_guard": None,
             "description": "A description.",
             "details": {
@@ -393,11 +376,9 @@ def out_probe_data_by_revision_date(by_channel=False):
                 "first": "node_id_1",
                 "last": "node_id_1",
             },
-            "versions": {
-                "first": "50",
-                "last": "50"
-            }
-        }, {
+            "versions": {"first": "50", "last": "50"},
+        },
+        {
             "cpp_guard": None,
             "description": "A description.",
             "details": {
@@ -414,11 +395,8 @@ def out_probe_data_by_revision_date(by_channel=False):
                 "first": "node_id_4",
                 "last": "node_id_4",
             },
-            "versions": {
-                "first": "52",
-                "last": "52"
-            }
-        }
+            "versions": {"first": "52", "last": "52"},
+        },
     ]
 
     allowed_channels = CHANNELS
@@ -429,7 +407,7 @@ def out_probe_data_by_revision_date(by_channel=False):
                 "histogram/TEST_HISTOGRAM_1": {
                     "history": {channel: probes},
                     "name": "TEST_HISTOGRAM_1",
-                    "type": "histogram"
+                    "type": "histogram",
                 }
             }
             for channel in allowed_channels
@@ -439,7 +417,7 @@ def out_probe_data_by_revision_date(by_channel=False):
             "histogram/TEST_HISTOGRAM_1": {
                 "history": {channel: probes for channel in allowed_channels},
                 "name": "TEST_HISTOGRAM_1",
-                "type": "histogram"
+                "type": "histogram",
             }
         }
 
@@ -474,7 +452,7 @@ def get_differences(a, b, path="", sep=" / "):
         for k in b_not_a:
             res.append(("B not A", path + sep + k))
 
-        for k in (a_keys & b_keys):
+        for k in a_keys & b_keys:
             res = res + get_differences(a[k], b[k], path + sep + k)
 
     return res
@@ -490,9 +468,9 @@ def print_and_test(expected, result):
     pp.pprint(expected)
 
     print("\nDifferences:")
-    print('\n'.join([' - '.join(v) for v in get_differences(expected, result)]))
+    print("\n".join([" - ".join(v) for v in get_differences(expected, result)]))
 
-    assert(result == expected)
+    assert result == expected
 
 
 def test_probes_equal():
@@ -502,9 +480,9 @@ def test_probes_equal():
     histogram_node3 = DATA["node_id_3"]["histogram"]["TEST_HISTOGRAM_1"]
     histogram_node4 = DATA["node_id_4"]["histogram"]["TEST_HISTOGRAM_1"]
 
-    assert(not transform.probes_equal(histogram_node1, histogram_node2))
-    assert(not transform.probes_equal(histogram_node2, histogram_node3))
-    assert(transform.probes_equal(histogram_node3, histogram_node4))
+    assert not transform.probes_equal(histogram_node1, histogram_node2)
+    assert not transform.probes_equal(histogram_node2, histogram_node3)
+    assert transform.probes_equal(histogram_node3, histogram_node4)
 
 
 def test_transform_monolithic():
@@ -529,11 +507,7 @@ def test_transform_by_revision_date():
 
 
 def test_transform_metrics_by_hash():
-    timestamps = {
-        repo: {
-            str(i): (-i, i) for i in range(4)
-        } for repo in REPOS
-    }
+    timestamps = {repo: {str(i): (-i, i) for i in range(4)} for repo in REPOS}
 
     result = transform.transform_metrics_by_hash(timestamps, IN_METRICS_DATA)
     expected = OUT_METRICS_DATA
@@ -542,11 +516,7 @@ def test_transform_metrics_by_hash():
 
 
 def test_transform_pings_by_hash():
-    timestamps = {
-        repo: {
-            str(i): (-i, i) for i in range(4)
-        } for repo in REPOS
-    }
+    timestamps = {repo: {str(i): (-i, i) for i in range(4)} for repo in REPOS}
 
     result = transform.transform_pings_by_hash(timestamps, IN_PING_DATA)
     expected = OUT_PING_DATA
@@ -558,7 +528,7 @@ def test_get_minimum_date():
     expected = {
         "histogram/TEST_HISTOGRAM_1": {
             "release": datetime(2018, 1, 1, 1, 1, 1),
-            "beta": datetime(2018, 1, 1, 1, 1, 1)
+            "beta": datetime(2018, 1, 1, 1, 1, 1),
         }
     }
 
@@ -578,8 +548,10 @@ def test_sort_ordering():
                     "time_unit": "second",
                     "send_in_pings": ["baseline"],
                     "bugs": [1497894, 1519120],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                    "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
+                    "notification_emails": ["telemetry-client-dev@mozilla.com"],
                 },
             },
             "1": {
@@ -589,8 +561,10 @@ def test_sort_ordering():
                     "time_unit": "second",
                     "send_in_pings": ["custom"],
                     "bugs": [1497894, 1519120],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                    "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
+                    "notification_emails": ["telemetry-client-dev@mozilla.com"],
                 }
             },
             "2": {
@@ -600,8 +574,10 @@ def test_sort_ordering():
                     "time_unit": "second",
                     "send_in_pings": ["all_pings"],
                     "bugs": [1497894, 1519120],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                    "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
+                    "notification_emails": ["telemetry-client-dev@mozilla.com"],
                 },
             },
             "3": {
@@ -611,8 +587,10 @@ def test_sort_ordering():
                     "time_unit": "second",
                     "send_in_pings": ["all_pings"],
                     "bugs": [1497894, 1519120],
-                    "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
-                    "notification_emails": ["telemetry-client-dev@mozilla.com"]
+                    "data_reviews": [
+                        "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                    ],
+                    "notification_emails": ["telemetry-client-dev@mozilla.com"],
                 },
             },
         }
@@ -639,20 +617,16 @@ def test_sort_ordering():
                         "time_unit": "second",
                         "send_in_pings": ["all_pings"],
                         "bugs": [1497894, 1519120],
-                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                        "data_reviews": [
+                            "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                        ],
                         "notification_emails": ["telemetry-client-dev@mozilla.com"],
-                        "git-commits": {
-                            "first": "3",
-                            "last": "2"
-                        },
+                        "git-commits": {"first": "3", "last": "2"},
                         "dates": {
                             "first": "1970-01-01 00:00:00",
-                            "last": "1970-01-02 00:00:00"
+                            "last": "1970-01-02 00:00:00",
                         },
-                        "reflog-index": {
-                            "first": 3,
-                            "last": 2
-                        }
+                        "reflog-index": {"first": 3, "last": 2},
                     },
                     {
                         "type": "timespan",
@@ -660,20 +634,16 @@ def test_sort_ordering():
                         "time_unit": "second",
                         "send_in_pings": ["custom"],
                         "bugs": [1497894, 1519120],
-                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                        "data_reviews": [
+                            "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                        ],
                         "notification_emails": ["telemetry-client-dev@mozilla.com"],
-                        "git-commits": {
-                            "first": "1",
-                            "last": "1"
-                        },
+                        "git-commits": {"first": "1", "last": "1"},
                         "dates": {
                             "first": "1970-01-02 00:00:00",
-                            "last": "1970-01-02 00:00:00"
+                            "last": "1970-01-02 00:00:00",
                         },
-                        "reflog-index": {
-                            "first": 1,
-                            "last": 1
-                        }
+                        "reflog-index": {"first": 1, "last": 1},
                     },
                     {
                         "type": "timespan",
@@ -681,22 +651,18 @@ def test_sort_ordering():
                         "time_unit": "second",
                         "send_in_pings": ["baseline"],
                         "bugs": [1497894, 1519120],
-                        "data_reviews": ["https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"],
+                        "data_reviews": [
+                            "https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3"
+                        ],
                         "notification_emails": ["telemetry-client-dev@mozilla.com"],
-                        "git-commits": {
-                            "first": "0",
-                            "last": "0"
-                        },
+                        "git-commits": {"first": "0", "last": "0"},
                         "dates": {
                             "first": "1970-01-03 00:00:00",
-                            "last": "1970-01-03 00:00:00"
+                            "last": "1970-01-03 00:00:00",
                         },
-                        "reflog-index": {
-                            "first": 0,
-                            "last": 0
-                        }
-                    }
-                ]
+                        "reflog-index": {"first": 0, "last": 0},
+                    },
+                ],
             }
         }
     }


### PR DESCRIPTION
Added black and isort linters to implement more vigorous checking of python.
Fixes : #243 
### Notes
* CircleCI workflow left unchanged since `the lint` step is already included.

```
   steps:
      - checkout
      - run: make build
      - run: make lint
      - run: make test
```
* `black` and `isort` dependencies were installed and simply run in the lint section of the `Makefile`