### PR TITLE
org-mozilla-firefox-beta is not deprecated

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -288,7 +288,6 @@ firefox-android-beta:
   app_id: org-mozilla-firefox-beta
   description: Firefox for Android
   channel: beta
-  deprecated: true
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com


### PR DESCRIPTION
This was just a mistake I made when working on #220, made more obvious by the glean dictionary.

See also: https://docs.google.com/spreadsheets/d/18PzkzZxdpFl23__-CIO735NumYDqu7jHpqllo0sBbPA/edit#gid=0