### PR TITLE
Implement nested repositories.yaml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,8 @@ A list of available repositories is at [`/glean/repositories`](https://probeinfo
 
 ## Using the v2 Glean API
 
+> **⚠** The v2 API is in-development and subject to change without notice. **Do not** depend on it in production!
+
 We are incrementally building a v2 API for Glean applications that will
 provide views of underlying probe scraper data that are more directly
 usable by consuming applications. The general direction is discussed in

--- a/probe_scraper/check_repositories.py
+++ b/probe_scraper/check_repositories.py
@@ -11,15 +11,16 @@ REPOSITORIES = os.path.join(
 )
 validation_errors = []
 with open(REPOSITORIES) as data:
-    repos = yaml.load(data, Loader=yaml.SafeLoader)
+    repos_data = yaml.load(data, Loader=yaml.SafeLoader)
+    repos = repos_data["libraries"] + repos_data["application_families"]
     for repo in repos:
-        repo_url = repos[repo]["url"]
+        repo_url = repo["url"]
         branch = "master"
-        if "branch" in repos[repo]:
-            branch = repos[repo]["branch"]
+        if "branch" in repo:
+            branch = repo["branch"]
         metrics_files = []
-        if "metrics_files" in repos[repo]:
-            metrics_files = repos[repo]["metrics_files"]
+        if "metrics_files" in repo:
+            metrics_files = repo["metrics_files"]
         if metrics_files:
             temp_url = (
                 GITHUB_RAW_URL
@@ -38,7 +39,7 @@ with open(REPOSITORIES) as data:
                 [Path("./temp-metrics.yaml")], yaml_lint_errors, {}
             )
             if temp_erros:
-                if "prototype" in repos[repo] and not repos[repo]["prototype"]:
+                if not repo.get("prototype", None):
                     validation_errors.append({"repo": repo, "errors": temp_erros})
     os.remove("temp-metrics.yaml")
     os.remove("yaml-lint-errors.txt")

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
-
 import jsonschema
 import yaml
 

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -112,13 +112,13 @@ class RepositoriesParser(object):
         for family in repos["application_families"]:
             apps = family.pop("apps")
             for app in apps:
-                dependencies = family.get("dependencies", []) + app.get("dependencies", [])
+                dependencies = family.get("dependencies", []) + app.get(
+                    "dependencies", []
+                )
                 app = {**family, **app}
                 app["dependencies"] = dependencies
                 v2_apps.append(app)
         repos = [
             Repository.from_v2_library(definition) for definition in repos["libraries"]
-        ] + [
-            Repository.from_v2_repo(app) for app in v2_apps
-        ]
+        ] + [Repository.from_v2_repo(app) for app in v2_apps]
         return self.filter_repos(repos, glean_repo)

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -129,6 +129,11 @@ def write_repositories_data(repos, out_dir):
     dump_json(json_data, os.path.join(out_dir, "glean"), "repositories")
 
 
+def write_v2_applications_data(repos, out_dir):
+    json_data = [r.to_v2_dict() for r in repos if r.app_id]
+    dump_json(json_data, os.path.join(out_dir, "v2", "glean"), "applications")
+
+
 def parse_moz_central_probes(scraped_data):
     """
     Parse probe data from files into the form:
@@ -310,8 +315,10 @@ def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run, glean_rep
 
     write_glean_metric_data(metrics_by_repo, dependencies_by_repo, out_dir)
     write_glean_ping_data(pings_by_repo, out_dir)
-    write_repositories_data(repositories, out_dir)
     write_general_data(out_dir)
+
+    write_repositories_data(repositories, out_dir)
+    write_v2_applications_data(repositories, out_dir)
 
     for repo_name, email_info in list(emails.items()):
         addresses = email_info["addresses"] + [DEFAULT_TO_EMAIL]

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,460 +1,460 @@
 ---
 
 libraries:
-- library_id: glean-core
-  description: Modern cross-platform telemetry (core library)
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla/glean
-  branch: main
-  metrics_files:
-    - glean-core/metrics.yaml
-  ping_files:
-    - glean-core/pings.yaml
-  library_names:
-    - glean-core
-- library_id: glean-android
-  description: Modern cross-platform telemetry (Android-specific)
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla/glean
-  branch: main
-  metrics_files:
-    - glean-core/android/metrics.yaml
-    - glean-core/metrics.yaml
-  ping_files:
-    - glean-core/pings.yaml
-  library_names:
-    - org.mozilla.components:service-glean
-- library_id: glean
-  description: Modern cross-platform telemetry (old)
-  deprecated: true
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla/glean
-  branch: main
-  metrics_files:
-    - glean-core/android/metrics.yaml
-    - glean-core/metrics.yaml
-  ping_files:
-    - glean-core/pings.yaml
-- library_id: glean-deprecated
-  description: Modern cross-platform telemetry (old)
-  deprecated: true
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla/glean
-  branch: main
-  metrics_files:
-    - glean-core/android/metrics.yaml
-    - glean-core/metrics.yaml
-  ping_files:
-    - glean-core/pings.yaml
-  library_names:
-    - org.mozilla.deprecated:glean
-- library_id: lib-crash
-  description: >
-    A generic crash reporter component that can report crashes to multiple
-    services
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/lib/crash/metrics.yaml
-  library_names:
-    - org.mozilla.components:lib-crash
-- library_id: sync
-  description: Sync telemetry helper functionality
-  notification_emails:
-    - frank@mozilla.com
-    - lina@mozilla.com
-    - grisha@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/support/sync-telemetry/metrics.yaml
-  ping_files:
-    - components/support/sync-telemetry/pings.yaml
-  library_names:
-    - org.mozilla.components:support-sync-telemetry
-- library_id: engine-gecko
-  description: GeckoView metrics
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  branch: release
-  library_names:
-    - org.mozilla.components:browser-engine-gecko
-- library_id: engine-gecko-beta
-  description: GeckoView metrics
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  branch: beta
-  library_names:
-    - org.mozilla.components:browser-engine-gecko-beta
-- library_id: engine-gecko-nightly
-  description: GeckoView metrics
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  library_names:
-    - org.mozilla.components:browser-engine-gecko-nightly
-- library_id: logins-store
-  description: >
-    A collection of Android libraries to build browsers or browser-like
-    applications
-  notification_emails:
-    - rfkelly@mozilla.com
-    - lina@mozilla.com
-    - sync-team@mozilla.com
-  url: https://github.com/mozilla/application-services
-  metrics_files:
-    - components/logins/android/metrics.yaml
-  branch: main
-  library_names:
-    - org.mozilla.appservices:logins
-- library_id: support-migration
-  description: >
-    Helper code to migrate from a Fennec-based (Firefox for Android) app to
-    an Android Components based app
-  notification_emails:
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/support/migration/metrics.yaml
-  ping_files:
-    - components/support/migration/pings.yaml
-  library_names:
-    - org.mozilla.components:support-migration
-- library_id: android-places
-  description: >
-    A collection of Android libraries to build browsers or browser-like
-    applications
-  notification_emails:
-    - frank@mozilla.com
-    - sync-team@mozilla.com
-  url: https://github.com/mozilla/application-services
-  metrics_files:
-    - components/places/android/metrics.yaml
-  branch: main
-  library_names:
-    - org.mozilla.components:places
+  - library_id: glean-core
+    description: Modern cross-platform telemetry (core library)
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    url: https://github.com/mozilla/glean
+    branch: main
+    metrics_files:
+      - glean-core/metrics.yaml
+    ping_files:
+      - glean-core/pings.yaml
+    library_names:
+      - glean-core
+  - library_id: glean-android
+    description: Modern cross-platform telemetry (Android-specific)
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    url: https://github.com/mozilla/glean
+    branch: main
+    metrics_files:
+      - glean-core/android/metrics.yaml
+      - glean-core/metrics.yaml
+    ping_files:
+      - glean-core/pings.yaml
+    library_names:
+      - org.mozilla.components:service-glean
+  - library_id: glean
+    description: Modern cross-platform telemetry (old)
+    deprecated: true
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    url: https://github.com/mozilla/glean
+    branch: main
+    metrics_files:
+      - glean-core/android/metrics.yaml
+      - glean-core/metrics.yaml
+    ping_files:
+      - glean-core/pings.yaml
+  - library_id: glean-deprecated
+    description: Modern cross-platform telemetry (old)
+    deprecated: true
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    url: https://github.com/mozilla/glean
+    branch: main
+    metrics_files:
+      - glean-core/android/metrics.yaml
+      - glean-core/metrics.yaml
+    ping_files:
+      - glean-core/pings.yaml
+    library_names:
+      - org.mozilla.deprecated:glean
+  - library_id: lib-crash
+    description: >
+      A generic crash reporter component that can report crashes to multiple
+      services
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+      - android-components-team@mozilla.com
+    url: https://github.com/mozilla-mobile/android-components
+    metrics_files:
+      - components/lib/crash/metrics.yaml
+    library_names:
+      - org.mozilla.components:lib-crash
+  - library_id: sync
+    description: Sync telemetry helper functionality
+    notification_emails:
+      - frank@mozilla.com
+      - lina@mozilla.com
+      - grisha@mozilla.com
+    url: https://github.com/mozilla-mobile/android-components
+    metrics_files:
+      - components/support/sync-telemetry/metrics.yaml
+    ping_files:
+      - components/support/sync-telemetry/pings.yaml
+    library_names:
+      - org.mozilla.components:support-sync-telemetry
+  - library_id: engine-gecko
+    description: GeckoView metrics
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+      - android-components-team@mozilla.com
+      - geckoview-team@mozilla.com
+    url: https://github.com/mozilla/gecko-dev
+    metrics_files:
+      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+    branch: release
+    library_names:
+      - org.mozilla.components:browser-engine-gecko
+  - library_id: engine-gecko-beta
+    description: GeckoView metrics
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+      - android-components-team@mozilla.com
+      - geckoview-team@mozilla.com
+    url: https://github.com/mozilla/gecko-dev
+    metrics_files:
+      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+    branch: beta
+    library_names:
+      - org.mozilla.components:browser-engine-gecko-beta
+  - library_id: engine-gecko-nightly
+    description: GeckoView metrics
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+      - android-components-team@mozilla.com
+      - geckoview-team@mozilla.com
+    url: https://github.com/mozilla/gecko-dev
+    metrics_files:
+      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+    library_names:
+      - org.mozilla.components:browser-engine-gecko-nightly
+  - library_id: logins-store
+    description: >
+      A collection of Android libraries to build browsers or browser-like
+      applications
+    notification_emails:
+      - rfkelly@mozilla.com
+      - lina@mozilla.com
+      - sync-team@mozilla.com
+    url: https://github.com/mozilla/application-services
+    metrics_files:
+      - components/logins/android/metrics.yaml
+    branch: main
+    library_names:
+      - org.mozilla.appservices:logins
+  - library_id: support-migration
+    description: >
+      Helper code to migrate from a Fennec-based (Firefox for Android) app to
+      an Android Components based app
+    notification_emails:
+      - frank@mozilla.com
+    url: https://github.com/mozilla-mobile/android-components
+    metrics_files:
+      - components/support/migration/metrics.yaml
+    ping_files:
+      - components/support/migration/pings.yaml
+    library_names:
+      - org.mozilla.components:support-migration
+  - library_id: android-places
+    description: >
+      A collection of Android libraries to build browsers or browser-like
+      applications
+    notification_emails:
+      - frank@mozilla.com
+      - sync-team@mozilla.com
+    url: https://github.com/mozilla/application-services
+    metrics_files:
+      - components/places/android/metrics.yaml
+    branch: main
+    library_names:
+      - org.mozilla.components:places
 application_families:
-- app_name: firefox_desktop
-  description: The desktop version of Firefox
-  url: https://github.com/mozilla/gecko-dev
-  notification_emails:
-    - chutten@mozilla.com
-  metrics_files:
-    - toolkit/components/glean/metrics.yaml
-  ping_files:
-    - toolkit/components/glean/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-  apps:
-    - v1_name: firefox-desktop
-      app_id: firefox-desktop
-- app_name: fenix
-  canonical_app_name: Firefox for Android
-  url: https://github.com/mozilla-mobile/fenix
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-    - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.appservices:logins
-    - org.mozilla.components:support-migration
-    - org.mozilla.components:places
-  apps:
-    - v1_name: firefox-android-release
-      app_id: org.mozilla.firefox
-      app_channel: release
-      dependencies:
-        - org.mozilla.components:browser-engine-gecko-beta
-      description: >
-        Release channel of Firefox for Android.
-    - v1_name: firefox-android-beta
-      app_id: org-mozilla-firefox-beta
-      app_channel: beta
-      dependencies:
-        - org.mozilla.components:browser-engine-gecko-beta
-      description: >
-        Beta channel of Firefox for Android.
-    - v1_name: fenix
-      app_id: org.mozilla.fenix
-      app_channel: nightly
-      dependencies:
-        - org.mozilla.components:browser-engine-gecko-beta
-      description: >
-        Nightly channel of Firefox for Android.
-        Prior to June 2020, this app_id was used for the beta channel
-        of Firefox Preview.
-    - v1_name: fenix-nightly
-      app_id: org.mozilla.fenix.nightly
-      app_channel: nightly
-      deprecated: true
-      dependencies:
-        - org.mozilla.components:browser-engine-gecko-nightly
-      description: >
-        Nightly channel of Firefox Preview.
-    - v1_name: firefox-android-nightly
-      app_id: org.mozilla.fennec.aurora
-      app_channel: nightly
-      deprecated: true
-      dependencies:
-        - org.mozilla.components:browser-engine-gecko-beta
-      description: >
-        Nightly channel of Firefox for Android users migrated to Fenix;
-        delisted in June 2020.
-- app_name: firefox_ios
-  canonical_app_name: Firefox for iOS
-  description: Firefox for iOS
-  notification_emails:
-    - tlong@mozilla.com
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/firefox-ios
-  metrics_files:
-    - Client/metrics.yaml
-  branch: main
-  dependencies:
-    - org.mozilla.deprecated:glean
-  apps:
-    - v1_name: firefox-ios-release
-      app_id: org.mozilla.ios.Firefox
-      app_channel: release
-    - v1_name: firefox-ios-beta
-      app_id: org.mozilla.ios.FirefoxBeta
-      app_channel: beta
-    - v1_name: firefox-ios-dev
-      app_id: org.mozilla.ios.Fennec
-      app_channel: nightly
-- app_name: reference_browser
-  canonical_app_name: Reference Browser
-  description: >
-    A full-featured browser reference implementation using Mozilla Android
-    Components
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla-mobile/reference-browser
-  prototype: true
-  metrics_files:
-    - app/metrics.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-  apps:
-    - v1_name: reference-browser
-      app_id: org-mozilla-reference-browser
-- app_name: firefox_fire_tv
-  canonical_app_name: Firefox for Fire TV
-  description: Firefox for Amazon's Fire TV
-  notification_emails:
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/firefox-tv
-  metrics_files:
-    - app/metrics.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-  apps:
-    - v1_name: firefox-for-fire-tv
-      app_id: org.mozilla.tv.firefox
-- app_name: firefox_reality
-  description: >
-    A fast and secure browser for standalone virtual-reality and
-    augmented-reality headsets
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - dmu@mozilla.com
-  branch: main
-  url: https://github.com/MozillaReality/FirefoxReality
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:support-sync-telemetry
-  apps:
-    - v1_name: firefox-reality
-      app_id: org.mozilla.vrbrowser
-- app_name: lockwise_android
-  canonical_app_name: Lockwise for Android
-  description: >
-    Firefox's Lockwise app for Android
-  notification_emails:
-    - frank@mozilla.com
-    - lockwise-dev@mozilla.com
-  url: https://github.com/mozilla-lockwise/lockwise-android
-  metrics_files:
-    - app/metrics.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:support-sync-telemetry
-  apps:
-    - v1_name: lockwise-android
-      app_id: mozilla-lockbox
-- app_name: lockwise_ios
-  canonical_app_name: Lockwise for iOS
-  description: >
-    Firefox's Lockwise app for iOS
-  notification_emails:
-    - frank@mozilla.com
-    - tlong@mozilla.com
-    - lockwise-dev@mozilla.com
-  url: https://github.com/mozilla-lockwise/lockwise-ios
-  dependencies:
-    - org.mozilla.components:service-glean
-  apps:
-    - v1_name: lockwise-ios
-      app_id: org-mozilla-ios-lockbox
-- app_name: mozregression
-  canonical_app_name: mozregression
-  description: Regression range finder for Mozilla nightly builds
-  notification_emails:
-    - wlachance@mozilla.com
-  url: https://github.com/mozilla/mozregression
-  metrics_files:
-    - mozregression/metrics.yaml
-  ping_files:
-    - mozregression/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-  apps:
-    - v1_name: mozregression
-      app_id: org-mozilla-mozregression
-- app_name: burnham
-  canonical_app_name: Burnham
-  description: Automated end-to-end testing for Mozilla's Glean telemetry
-  notification_emails:
-    - rpierzina@mozilla.com
-  url: https://github.com/mozilla/burnham
-  branch: main
-  metrics_files:
-    - application/src/burnham/config/metrics.yaml
-  ping_files:
-    - application/src/burnham/config/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-  prototype: false
-  apps:
-    - v1_name: burnham
-      app_id: burnham
-- app_name: mozphab
-  description: Phabricator review submission/management tool
-  notification_emails:
-    - pzalewa@mozilla.com
-  url: https://github.com/mozilla-conduit/review
-  metrics_files:
-    - mozphab/metrics.yaml
-  ping_files:
-    - mozphab/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-  apps:
-    - v1_name: mozphab
-      app_id: mozphab
-- app_name: firefox_echo_show
-  description: Firefox for Amazon's Echo Show
-  url: https://github.com/mozilla-mobile/firefox-echo-show
-  notification_emails:
-    - tlong@mozilla.com
-  metrics_files:
-    - app/metrics.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-  apps:
-    - v1_name: firefox-for-echo-show
-      app_id: org.mozilla.connect.firefox
-- app_name: firefox_reality_pc
-  description: Firefox Reality for PC-connected VR platforms
-  url: https://github.com/MozillaReality/FirefoxRealityPC
-  notification_emails:
-    - dmu@mozilla.com
-  metrics_files:
-    - Source/FirefoxRealityUnity/metrics.yaml
-  ping_files:
-    - Source/FirefoxRealityUnity/pings.yaml
-  dependencies:
-    - glean-core
-  apps:
-    - v1_name: firefox-reality-pc
-      app_id: org-mozilla-firefoxreality
-- app_name: mach
-  description: Mach build telemetry
-  url: https://github.com/mozilla/gecko-dev
-  notification_emails:
-    - mhentges@mozilla.com
-  metrics_files:
-    - python/mach/metrics.yaml
-  ping_files:
-    - python/mach/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-  apps:
-    - v1_name: mach
-      app_id: mozilla-mach
-- app_name: glean_js
-  description: Experimentation with Glean.js
-  url: https://github.com/brizental/gleanjs
-  prototype: true
-  notification_emails:
-    - brizental@mozilla.com
-    - aplacitelli@mozilla.com
-    - mdroettboom@mozilla.com
-  branch: main
-  metrics_files:
-    - metrics.yaml
-  dependencies:
-    - glean-core
-  retention_days: 90
-  apps:
-    - v1_name: glean-js
-      app_id: glean-js-tmp
-- url: https://github.com/mozilla-mobile/focus-ios
-  notification_emails:
-    - jboek@mozilla.com
-    - tlong@mozilla.com
-  branch: main
-  metrics_files:
-    - Blockzilla/metrics.yaml
-  dependencies:
-    - glean-core
-  retention_days: 720
-  apps:
-    - v1_name: firefox-focus-ios
-      app_id: org-mozilla-ios-focus
-      app_name: focus_ios
-      description: Firefox Focus on iOS. Klar is the sibling application
-    - v1_name: firefox-klar-ios
-      app_id: org-mozilla-ios-klar
-      app_name: klar_ios
-      description: Firefox Klar on iOS. Focus is the sibling application
+  - app_name: firefox_desktop
+    description: The desktop version of Firefox
+    url: https://github.com/mozilla/gecko-dev
+    notification_emails:
+      - chutten@mozilla.com
+    metrics_files:
+      - toolkit/components/glean/metrics.yaml
+    ping_files:
+      - toolkit/components/glean/pings.yaml
+    dependencies:
+      - org.mozilla.deprecated:glean
+    apps:
+      - v1_name: firefox-desktop
+        app_id: firefox-desktop
+  - app_name: fenix
+    canonical_app_name: Firefox for Android
+    url: https://github.com/mozilla-mobile/fenix
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    metrics_files:
+      - app/metrics.yaml
+    ping_files:
+      - app/pings.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:lib-crash
+      - org.mozilla.components:support-sync-telemetry
+      - org.mozilla.appservices:logins
+      - org.mozilla.components:support-migration
+      - org.mozilla.components:places
+    apps:
+      - v1_name: firefox-android-release
+        app_id: org.mozilla.firefox
+        app_channel: release
+        dependencies:
+          - org.mozilla.components:browser-engine-gecko-beta
+        description: >
+          Release channel of Firefox for Android.
+      - v1_name: firefox-android-beta
+        app_id: org-mozilla-firefox-beta
+        app_channel: beta
+        dependencies:
+          - org.mozilla.components:browser-engine-gecko-beta
+        description: >
+          Beta channel of Firefox for Android.
+      - v1_name: fenix
+        app_id: org.mozilla.fenix
+        app_channel: nightly
+        dependencies:
+          - org.mozilla.components:browser-engine-gecko-beta
+        description: >
+          Nightly channel of Firefox for Android.
+          Prior to June 2020, this app_id was used for the beta channel
+          of Firefox Preview.
+      - v1_name: fenix-nightly
+        app_id: org.mozilla.fenix.nightly
+        app_channel: nightly
+        deprecated: true
+        dependencies:
+          - org.mozilla.components:browser-engine-gecko-nightly
+        description: >
+          Nightly channel of Firefox Preview.
+      - v1_name: firefox-android-nightly
+        app_id: org.mozilla.fennec.aurora
+        app_channel: nightly
+        deprecated: true
+        dependencies:
+          - org.mozilla.components:browser-engine-gecko-beta
+        description: >
+          Nightly channel of Firefox for Android users migrated to Fenix;
+          delisted in June 2020.
+  - app_name: firefox_ios
+    canonical_app_name: Firefox for iOS
+    description: Firefox for iOS
+    notification_emails:
+      - tlong@mozilla.com
+      - frank@mozilla.com
+    url: https://github.com/mozilla-mobile/firefox-ios
+    metrics_files:
+      - Client/metrics.yaml
+    branch: main
+    dependencies:
+      - org.mozilla.deprecated:glean
+    apps:
+      - v1_name: firefox-ios-release
+        app_id: org.mozilla.ios.Firefox
+        app_channel: release
+      - v1_name: firefox-ios-beta
+        app_id: org.mozilla.ios.FirefoxBeta
+        app_channel: beta
+      - v1_name: firefox-ios-dev
+        app_id: org.mozilla.ios.Fennec
+        app_channel: nightly
+  - app_name: reference_browser
+    canonical_app_name: Reference Browser
+    description: >
+      A full-featured browser reference implementation using Mozilla Android
+      Components
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+    url: https://github.com/mozilla-mobile/reference-browser
+    prototype: true
+    metrics_files:
+      - app/metrics.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:lib-crash
+    apps:
+      - v1_name: reference-browser
+        app_id: org-mozilla-reference-browser
+  - app_name: firefox_fire_tv
+    canonical_app_name: Firefox for Fire TV
+    description: Firefox for Amazon's Fire TV
+    notification_emails:
+      - frank@mozilla.com
+    url: https://github.com/mozilla-mobile/firefox-tv
+    metrics_files:
+      - app/metrics.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+    apps:
+      - v1_name: firefox-for-fire-tv
+        app_id: org.mozilla.tv.firefox
+  - app_name: firefox_reality
+    description: >
+      A fast and secure browser for standalone virtual-reality and
+      augmented-reality headsets
+    notification_emails:
+      - frank@mozilla.com
+      - mdroettboom@mozilla.com
+      - dmu@mozilla.com
+    branch: main
+    url: https://github.com/MozillaReality/FirefoxReality
+    metrics_files:
+      - app/metrics.yaml
+    ping_files:
+      - app/pings.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:support-sync-telemetry
+    apps:
+      - v1_name: firefox-reality
+        app_id: org.mozilla.vrbrowser
+  - app_name: lockwise_android
+    canonical_app_name: Lockwise for Android
+    description: >
+      Firefox's Lockwise app for Android
+    notification_emails:
+      - frank@mozilla.com
+      - lockwise-dev@mozilla.com
+    url: https://github.com/mozilla-lockwise/lockwise-android
+    metrics_files:
+      - app/metrics.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:support-sync-telemetry
+    apps:
+      - v1_name: lockwise-android
+        app_id: mozilla-lockbox
+  - app_name: lockwise_ios
+    canonical_app_name: Lockwise for iOS
+    description: >
+      Firefox's Lockwise app for iOS
+    notification_emails:
+      - frank@mozilla.com
+      - tlong@mozilla.com
+      - lockwise-dev@mozilla.com
+    url: https://github.com/mozilla-lockwise/lockwise-ios
+    dependencies:
+      - org.mozilla.components:service-glean
+    apps:
+      - v1_name: lockwise-ios
+        app_id: org-mozilla-ios-lockbox
+  - app_name: mozregression
+    canonical_app_name: mozregression
+    description: Regression range finder for Mozilla nightly builds
+    notification_emails:
+      - wlachance@mozilla.com
+    url: https://github.com/mozilla/mozregression
+    metrics_files:
+      - mozregression/metrics.yaml
+    ping_files:
+      - mozregression/pings.yaml
+    dependencies:
+      - org.mozilla.deprecated:glean
+    apps:
+      - v1_name: mozregression
+        app_id: org-mozilla-mozregression
+  - app_name: burnham
+    canonical_app_name: Burnham
+    description: Automated end-to-end testing for Mozilla's Glean telemetry
+    notification_emails:
+      - rpierzina@mozilla.com
+    url: https://github.com/mozilla/burnham
+    branch: main
+    metrics_files:
+      - application/src/burnham/config/metrics.yaml
+    ping_files:
+      - application/src/burnham/config/pings.yaml
+    dependencies:
+      - org.mozilla.deprecated:glean
+    prototype: false
+    apps:
+      - v1_name: burnham
+        app_id: burnham
+  - app_name: mozphab
+    description: Phabricator review submission/management tool
+    notification_emails:
+      - pzalewa@mozilla.com
+    url: https://github.com/mozilla-conduit/review
+    metrics_files:
+      - mozphab/metrics.yaml
+    ping_files:
+      - mozphab/pings.yaml
+    dependencies:
+      - org.mozilla.deprecated:glean
+    apps:
+      - v1_name: mozphab
+        app_id: mozphab
+  - app_name: firefox_echo_show
+    description: Firefox for Amazon's Echo Show
+    url: https://github.com/mozilla-mobile/firefox-echo-show
+    notification_emails:
+      - tlong@mozilla.com
+    metrics_files:
+      - app/metrics.yaml
+    dependencies:
+      - org.mozilla.components:service-glean
+    apps:
+      - v1_name: firefox-for-echo-show
+        app_id: org.mozilla.connect.firefox
+  - app_name: firefox_reality_pc
+    description: Firefox Reality for PC-connected VR platforms
+    url: https://github.com/MozillaReality/FirefoxRealityPC
+    notification_emails:
+      - dmu@mozilla.com
+    metrics_files:
+      - Source/FirefoxRealityUnity/metrics.yaml
+    ping_files:
+      - Source/FirefoxRealityUnity/pings.yaml
+    dependencies:
+      - glean-core
+    apps:
+      - v1_name: firefox-reality-pc
+        app_id: org-mozilla-firefoxreality
+  - app_name: mach
+    description: Mach build telemetry
+    url: https://github.com/mozilla/gecko-dev
+    notification_emails:
+      - mhentges@mozilla.com
+    metrics_files:
+      - python/mach/metrics.yaml
+    ping_files:
+      - python/mach/pings.yaml
+    dependencies:
+      - org.mozilla.deprecated:glean
+    apps:
+      - v1_name: mach
+        app_id: mozilla-mach
+  - app_name: glean_js
+    description: Experimentation with Glean.js
+    url: https://github.com/brizental/gleanjs
+    prototype: true
+    notification_emails:
+      - brizental@mozilla.com
+      - aplacitelli@mozilla.com
+      - mdroettboom@mozilla.com
+    branch: main
+    metrics_files:
+      - metrics.yaml
+    dependencies:
+      - glean-core
+    retention_days: 90
+    apps:
+      - v1_name: glean-js
+        app_id: glean-js-tmp
+  - url: https://github.com/mozilla-mobile/focus-ios
+    notification_emails:
+      - jboek@mozilla.com
+      - tlong@mozilla.com
+    branch: main
+    metrics_files:
+      - Blockzilla/metrics.yaml
+    dependencies:
+      - glean-core
+    retention_days: 720
+    apps:
+      - v1_name: firefox-focus-ios
+        app_id: org-mozilla-ios-focus
+        app_name: focus_ios
+        description: Firefox Focus on iOS. Klar is the sibling application
+      - v1_name: firefox-klar-ios
+        app_id: org-mozilla-ios-klar
+        app_name: klar_ios
+        description: Firefox Klar on iOS. Focus is the sibling application

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,7 +1,7 @@
 ---
 
 libraries:
-  - library_id: glean-core
+  - v1_name: glean-core
     description: Modern cross-platform telemetry (core library)
     notification_emails:
       - frank@mozilla.com
@@ -14,7 +14,7 @@ libraries:
       - glean-core/pings.yaml
     library_names:
       - glean-core
-  - library_id: glean-android
+  - v1_name: glean-android
     description: Modern cross-platform telemetry (Android-specific)
     notification_emails:
       - frank@mozilla.com
@@ -28,7 +28,7 @@ libraries:
       - glean-core/pings.yaml
     library_names:
       - org.mozilla.components:service-glean
-  - library_id: glean
+  - v1_name: glean
     description: Modern cross-platform telemetry (old)
     deprecated: true
     notification_emails:
@@ -41,7 +41,7 @@ libraries:
       - glean-core/metrics.yaml
     ping_files:
       - glean-core/pings.yaml
-  - library_id: glean-deprecated
+  - v1_name: glean-deprecated
     description: Modern cross-platform telemetry (old)
     deprecated: true
     notification_emails:
@@ -56,7 +56,7 @@ libraries:
       - glean-core/pings.yaml
     library_names:
       - org.mozilla.deprecated:glean
-  - library_id: lib-crash
+  - v1_name: lib-crash
     description: >
       A generic crash reporter component that can report crashes to multiple
       services
@@ -69,7 +69,7 @@ libraries:
       - components/lib/crash/metrics.yaml
     library_names:
       - org.mozilla.components:lib-crash
-  - library_id: sync
+  - v1_name: sync
     description: Sync telemetry helper functionality
     notification_emails:
       - frank@mozilla.com
@@ -82,7 +82,7 @@ libraries:
       - components/support/sync-telemetry/pings.yaml
     library_names:
       - org.mozilla.components:support-sync-telemetry
-  - library_id: engine-gecko
+  - v1_name: engine-gecko
     description: GeckoView metrics
     notification_emails:
       - frank@mozilla.com
@@ -95,7 +95,7 @@ libraries:
     branch: release
     library_names:
       - org.mozilla.components:browser-engine-gecko
-  - library_id: engine-gecko-beta
+  - v1_name: engine-gecko-beta
     description: GeckoView metrics
     notification_emails:
       - frank@mozilla.com
@@ -108,7 +108,7 @@ libraries:
     branch: beta
     library_names:
       - org.mozilla.components:browser-engine-gecko-beta
-  - library_id: engine-gecko-nightly
+  - v1_name: engine-gecko-nightly
     description: GeckoView metrics
     notification_emails:
       - frank@mozilla.com
@@ -120,7 +120,7 @@ libraries:
       - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
     library_names:
       - org.mozilla.components:browser-engine-gecko-nightly
-  - library_id: logins-store
+  - v1_name: logins-store
     description: >
       A collection of Android libraries to build browsers or browser-like
       applications
@@ -134,7 +134,7 @@ libraries:
     branch: main
     library_names:
       - org.mozilla.appservices:logins
-  - library_id: support-migration
+  - v1_name: support-migration
     description: >
       Helper code to migrate from a Fennec-based (Firefox for Android) app to
       an Android Components based app
@@ -147,7 +147,7 @@ libraries:
       - components/support/migration/pings.yaml
     library_names:
       - org.mozilla.components:support-migration
-  - library_id: android-places
+  - v1_name: android-places
     description: >
       A collection of Android libraries to build browsers or browser-like
       applications

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,7 +1,7 @@
 ---
 
-glean-core:
-  app_id: glean-core
+libraries:
+- library_id: glean-core
   description: Modern cross-platform telemetry (core library)
   notification_emails:
     - frank@mozilla.com
@@ -14,8 +14,7 @@ glean-core:
     - glean-core/pings.yaml
   library_names:
     - glean-core
-glean-android:
-  app_id: glean-android
+- library_id: glean-android
   description: Modern cross-platform telemetry (Android-specific)
   notification_emails:
     - frank@mozilla.com
@@ -29,8 +28,7 @@ glean-android:
     - glean-core/pings.yaml
   library_names:
     - org.mozilla.components:service-glean
-glean:
-  app_id: glean
+- library_id: glean
   description: Modern cross-platform telemetry (old)
   deprecated: true
   notification_emails:
@@ -43,8 +41,7 @@ glean:
     - glean-core/metrics.yaml
   ping_files:
     - glean-core/pings.yaml
-glean-deprecated:
-  app_id: glean-deprecated
+- library_id: glean-deprecated
   description: Modern cross-platform telemetry (old)
   deprecated: true
   notification_emails:
@@ -59,14 +56,131 @@ glean-deprecated:
     - glean-core/pings.yaml
   library_names:
     - org.mozilla.deprecated:glean
-fenix:
-  app_id: org-mozilla-fenix
-  description: Firefox for Android
-  channel: nightly
+- library_id: lib-crash
+  description: >
+    A generic crash reporter component that can report crashes to multiple
+    services
   notification_emails:
     - frank@mozilla.com
     - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+  url: https://github.com/mozilla-mobile/android-components
+  metrics_files:
+    - components/lib/crash/metrics.yaml
+  library_names:
+    - org.mozilla.components:lib-crash
+- library_id: sync
+  description: Sync telemetry helper functionality
+  notification_emails:
+    - frank@mozilla.com
+    - lina@mozilla.com
+    - grisha@mozilla.com
+  url: https://github.com/mozilla-mobile/android-components
+  metrics_files:
+    - components/support/sync-telemetry/metrics.yaml
+  ping_files:
+    - components/support/sync-telemetry/pings.yaml
+  library_names:
+    - org.mozilla.components:support-sync-telemetry
+- library_id: engine-gecko
+  description: GeckoView metrics
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
+  url: https://github.com/mozilla/gecko-dev
+  metrics_files:
+    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+  branch: release
+  library_names:
+    - org.mozilla.components:browser-engine-gecko
+- library_id: engine-gecko-beta
+  description: GeckoView metrics
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
+  url: https://github.com/mozilla/gecko-dev
+  metrics_files:
+    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+  branch: beta
+  library_names:
+    - org.mozilla.components:browser-engine-gecko-beta
+- library_id: engine-gecko-nightly
+  description: GeckoView metrics
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
+    - android-components-team@mozilla.com
+    - geckoview-team@mozilla.com
+  url: https://github.com/mozilla/gecko-dev
+  metrics_files:
+    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+  library_names:
+    - org.mozilla.components:browser-engine-gecko-nightly
+- library_id: logins-store
+  description: >
+    A collection of Android libraries to build browsers or browser-like
+    applications
+  notification_emails:
+    - rfkelly@mozilla.com
+    - lina@mozilla.com
+    - sync-team@mozilla.com
+  url: https://github.com/mozilla/application-services
+  metrics_files:
+    - components/logins/android/metrics.yaml
+  branch: main
+  library_names:
+    - org.mozilla.appservices:logins
+- library_id: support-migration
+  description: >
+    Helper code to migrate from a Fennec-based (Firefox for Android) app to
+    an Android Components based app
+  notification_emails:
+    - frank@mozilla.com
+  url: https://github.com/mozilla-mobile/android-components
+  metrics_files:
+    - components/support/migration/metrics.yaml
+  ping_files:
+    - components/support/migration/pings.yaml
+  library_names:
+    - org.mozilla.components:support-migration
+- library_id: android-places
+  description: >
+    A collection of Android libraries to build browsers or browser-like
+    applications
+  notification_emails:
+    - frank@mozilla.com
+    - sync-team@mozilla.com
+  url: https://github.com/mozilla/application-services
+  metrics_files:
+    - components/places/android/metrics.yaml
+  branch: main
+  library_names:
+    - org.mozilla.components:places
+application_families:
+- app_name: firefox_desktop
+  description: The desktop version of Firefox
+  url: https://github.com/mozilla/gecko-dev
+  notification_emails:
+    - chutten@mozilla.com
+  metrics_files:
+    - toolkit/components/glean/metrics.yaml
+  ping_files:
+    - toolkit/components/glean/pings.yaml
+  dependencies:
+    - org.mozilla.deprecated:glean
+  apps:
+    - v1_name: firefox-desktop
+      app_id: firefox-desktop
+- app_name: fenix
+  canonical_app_name: Firefox for Android
   url: https://github.com/mozilla-mobile/fenix
+  notification_emails:
+    - frank@mozilla.com
+    - mdroettboom@mozilla.com
   metrics_files:
     - app/metrics.yaml
   ping_files:
@@ -75,12 +189,74 @@ fenix:
     - org.mozilla.components:service-glean
     - org.mozilla.components:lib-crash
     - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.components:browser-engine-gecko-beta
     - org.mozilla.appservices:logins
     - org.mozilla.components:support-migration
     - org.mozilla.components:places
-reference-browser:
-  app_id: org-mozilla-reference-browser
+  apps:
+    - v1_name: firefox-android-release
+      app_id: org.mozilla.firefox
+      app_channel: release
+      dependencies:
+        - org.mozilla.components:browser-engine-gecko-beta
+      description: >
+        Release channel of Firefox for Android.
+    - v1_name: firefox-android-beta
+      app_id: org-mozilla-firefox-beta
+      app_channel: beta
+      dependencies:
+        - org.mozilla.components:browser-engine-gecko-beta
+      description: >
+        Beta channel of Firefox for Android.
+    - v1_name: fenix
+      app_id: org.mozilla.fenix
+      app_channel: nightly
+      dependencies:
+        - org.mozilla.components:browser-engine-gecko-beta
+      description: >
+        Nightly channel of Firefox for Android.
+        Prior to June 2020, this app_id was used for the beta channel
+        of Firefox Preview.
+    - v1_name: fenix-nightly
+      app_id: org.mozilla.fenix.nightly
+      app_channel: nightly
+      deprecated: true
+      dependencies:
+        - org.mozilla.components:browser-engine-gecko-nightly
+      description: >
+        Nightly channel of Firefox Preview.
+    - v1_name: firefox-android-nightly
+      app_id: org.mozilla.fennec.aurora
+      app_channel: nightly
+      deprecated: true
+      dependencies:
+        - org.mozilla.components:browser-engine-gecko-beta
+      description: >
+        Nightly channel of Firefox for Android users migrated to Fenix;
+        delisted in June 2020.
+- app_name: firefox_ios
+  canonical_app_name: Firefox for iOS
+  description: Firefox for iOS
+  notification_emails:
+    - tlong@mozilla.com
+    - frank@mozilla.com
+  url: https://github.com/mozilla-mobile/firefox-ios
+  metrics_files:
+    - Client/metrics.yaml
+  branch: main
+  dependencies:
+    - org.mozilla.deprecated:glean
+  apps:
+    - v1_name: firefox-ios-release
+      app_id: org.mozilla.ios.Firefox
+      app_channel: release
+    - v1_name: firefox-ios-beta
+      app_id: org.mozilla.ios.FirefoxBeta
+      app_channel: beta
+    - v1_name: firefox-ios-dev
+      app_id: org.mozilla.ios.Fennec
+      app_channel: nightly
+- app_name: reference_browser
+  canonical_app_name: Reference Browser
   description: >
     A full-featured browser reference implementation using Mozilla Android
     Components
@@ -94,28 +270,11 @@ reference-browser:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:lib-crash
-fenix-nightly:
-  app_id: org-mozilla-fenix-nightly
-  description: Firefox for Android
-  channel: nightly
-  deprecated: true
-  notification_emails:
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/fenix
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-    - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.components:browser-engine-gecko-nightly
-    - org.mozilla.appservices:logins
-    - org.mozilla.components:support-migration
-    - org.mozilla.components:places
-firefox-for-fire-tv:
-  app_id: org-mozilla-tv-firefox
+  apps:
+    - v1_name: reference-browser
+      app_id: org-mozilla-reference-browser
+- app_name: firefox_fire_tv
+  canonical_app_name: Firefox for Fire TV
   description: Firefox for Amazon's Fire TV
   notification_emails:
     - frank@mozilla.com
@@ -124,78 +283,10 @@ firefox-for-fire-tv:
     - app/metrics.yaml
   dependencies:
     - org.mozilla.components:service-glean
-lib-crash:
-  app_id: lib-crash
-  description: >
-    A generic crash reporter component that can report crashes to multiple
-    services
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/lib/crash/metrics.yaml
-  library_names:
-    - org.mozilla.components:lib-crash
-sync:
-  app_id: sync
-  description: Sync telemetry helper functionality
-  notification_emails:
-    - frank@mozilla.com
-    - lina@mozilla.com
-    - grisha@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/support/sync-telemetry/metrics.yaml
-  ping_files:
-    - components/support/sync-telemetry/pings.yaml
-  library_names:
-    - org.mozilla.components:support-sync-telemetry
-engine-gecko:
-  app_id: engine-gecko
-  description: GeckoView metrics
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  branch: release
-  library_names:
-    - org.mozilla.components:browser-engine-gecko
-engine-gecko-beta:
-  app_id: engine-gecko-beta
-  description: GeckoView metrics
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  branch: beta
-  library_names:
-    - org.mozilla.components:browser-engine-gecko-beta
-engine-gecko-nightly:
-  app_id: engine-gecko-nightly
-  description: GeckoView metrics
-  channel: nightly
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-    - android-components-team@mozilla.com
-    - geckoview-team@mozilla.com
-  url: https://github.com/mozilla/gecko-dev
-  metrics_files:
-    - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-  library_names:
-    - org.mozilla.components:browser-engine-gecko-nightly
-firefox-reality:
-  app_id: org-mozilla-vrbrowser
+  apps:
+    - v1_name: firefox-for-fire-tv
+      app_id: org.mozilla.tv.firefox
+- app_name: firefox_reality
   description: >
     A fast and secure browser for standalone virtual-reality and
     augmented-reality headsets
@@ -212,9 +303,13 @@ firefox-reality:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:support-sync-telemetry
-lockwise-android:
-  app_id: mozilla-lockbox
-  description: Firefox's Lockwise app for Android
+  apps:
+    - v1_name: firefox-reality
+      app_id: org.mozilla.vrbrowser
+- app_name: lockwise_android
+  canonical_app_name: Lockwise for Android
+  description: >
+    Firefox's Lockwise app for Android
   notification_emails:
     - frank@mozilla.com
     - lockwise-dev@mozilla.com
@@ -224,9 +319,13 @@ lockwise-android:
   dependencies:
     - org.mozilla.components:service-glean
     - org.mozilla.components:support-sync-telemetry
-lockwise-ios:
-  app_id: org-mozilla-ios-lockbox
-  description: Firefox's Lockwise app for iOS
+  apps:
+    - v1_name: lockwise-android
+      app_id: mozilla-lockbox
+- app_name: lockwise_ios
+  canonical_app_name: Lockwise for iOS
+  description: >
+    Firefox's Lockwise app for iOS
   notification_emails:
     - frank@mozilla.com
     - tlong@mozilla.com
@@ -234,98 +333,11 @@ lockwise-ios:
   url: https://github.com/mozilla-lockwise/lockwise-ios
   dependencies:
     - org.mozilla.components:service-glean
-logins-store:
-  app_id: logins-store
-  description: >
-    A collection of Android libraries to build browsers or browser-like
-    applications
-  notification_emails:
-    - rfkelly@mozilla.com
-    - lina@mozilla.com
-    - sync-team@mozilla.com
-  url: https://github.com/mozilla/application-services
-  metrics_files:
-    - components/logins/android/metrics.yaml
-  branch: main
-  library_names:
-    - org.mozilla.appservices:logins
-support-migration:
-  app_id: support-migration
-  description: >
-    Helper code to migrate from a Fennec-based (Firefox for Android) app to
-    an Android Components based app
-  notification_emails:
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/android-components
-  metrics_files:
-    - components/support/migration/metrics.yaml
-  ping_files:
-    - components/support/migration/pings.yaml
-  library_names:
-    - org.mozilla.components:support-migration
-firefox-android-nightly:
-  app_id: org-mozilla-fennec-aurora
-  description: Firefox for Android
-  channel: nightly
-  deprecated: true
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla-mobile/fenix
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-    - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.components:browser-engine-gecko-beta
-    - org.mozilla.appservices:logins
-    - org.mozilla.components:support-migration
-    - org.mozilla.components:places
-firefox-android-beta:
-  app_id: org-mozilla-firefox-beta
-  description: Firefox for Android
-  channel: beta
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla-mobile/fenix
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-    - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.components:browser-engine-gecko-beta
-    - org.mozilla.appservices:logins
-    - org.mozilla.components:support-migration
-    - org.mozilla.components:places
-firefox-android-release:
-  app_id: org-mozilla-firefox
-  description: Firefox for Android
-  channel: release
-  notification_emails:
-    - frank@mozilla.com
-    - mdroettboom@mozilla.com
-  url: https://github.com/mozilla-mobile/fenix
-  metrics_files:
-    - app/metrics.yaml
-  ping_files:
-    - app/pings.yaml
-  dependencies:
-    - org.mozilla.components:service-glean
-    - org.mozilla.components:lib-crash
-    - org.mozilla.components:support-sync-telemetry
-    - org.mozilla.components:browser-engine-gecko-beta
-    - org.mozilla.appservices:logins
-    - org.mozilla.components:support-migration
-    - org.mozilla.components:places
-mozregression:
-  app_id: org-mozilla-mozregression
+  apps:
+    - v1_name: lockwise-ios
+      app_id: org-mozilla-ios-lockbox
+- app_name: mozregression
+  canonical_app_name: mozregression
   description: Regression range finder for Mozilla nightly builds
   notification_emails:
     - wlachance@mozilla.com
@@ -336,46 +348,11 @@ mozregression:
     - mozregression/pings.yaml
   dependencies:
     - org.mozilla.deprecated:glean
-firefox-ios-dev:
-  app_id: org-mozilla-ios-fennec
-  description: Firefox for iOS
-  notification_emails:
-    - tlong@mozilla.com
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/firefox-ios
-  metrics_files:
-    - Client/metrics.yaml
-  branch: main
-  dependencies:
-    - org.mozilla.deprecated:glean
-firefox-ios-beta:
-  app_id: org-mozilla-ios-firefoxbeta
-  description: Firefox for iOS
-  channel: beta
-  notification_emails:
-    - tlong@mozilla.com
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/firefox-ios
-  metrics_files:
-    - Client/metrics.yaml
-  branch: main
-  dependencies:
-    - org.mozilla.deprecated:glean
-firefox-ios-release:
-  app_id: org-mozilla-ios-firefox
-  description: Firefox for iOS
-  channel: release
-  notification_emails:
-    - tlong@mozilla.com
-    - frank@mozilla.com
-  url: https://github.com/mozilla-mobile/firefox-ios
-  metrics_files:
-    - Client/metrics.yaml
-  branch: main
-  dependencies:
-    - org.mozilla.deprecated:glean
-burnham:
-  app_id: burnham
+  apps:
+    - v1_name: mozregression
+      app_id: org-mozilla-mozregression
+- app_name: burnham
+  canonical_app_name: Burnham
   description: Automated end-to-end testing for Mozilla's Glean telemetry
   notification_emails:
     - rpierzina@mozilla.com
@@ -387,22 +364,11 @@ burnham:
     - application/src/burnham/config/pings.yaml
   dependencies:
     - org.mozilla.deprecated:glean
-android-places:
-  app_id: android-places
-  description: >
-    A collection of Android libraries to build browsers or browser-like
-    applications
-  notification_emails:
-    - frank@mozilla.com
-    - sync-team@mozilla.com
-  url: https://github.com/mozilla/application-services
-  metrics_files:
-    - components/places/android/metrics.yaml
-  branch: main
-  library_names:
-    - org.mozilla.components:places
-mozphab:
-  app_id: mozphab
+  prototype: false
+  apps:
+    - v1_name: burnham
+      app_id: burnham
+- app_name: mozphab
   description: Phabricator review submission/management tool
   notification_emails:
     - pzalewa@mozilla.com
@@ -413,20 +379,10 @@ mozphab:
     - mozphab/pings.yaml
   dependencies:
     - org.mozilla.deprecated:glean
-firefox-desktop:
-  app_id: firefox-desktop
-  description: The desktop version of Firefox
-  url: https://github.com/mozilla/gecko-dev
-  notification_emails:
-    - chutten@mozilla.com
-  metrics_files:
-    - toolkit/components/glean/metrics.yaml
-  ping_files:
-    - toolkit/components/glean/pings.yaml
-  dependencies:
-    - org.mozilla.deprecated:glean
-firefox-for-echo-show:
-  app_id: org-mozilla-connect-firefox
+  apps:
+    - v1_name: mozphab
+      app_id: mozphab
+- app_name: firefox_echo_show
   description: Firefox for Amazon's Echo Show
   url: https://github.com/mozilla-mobile/firefox-echo-show
   notification_emails:
@@ -435,8 +391,10 @@ firefox-for-echo-show:
     - app/metrics.yaml
   dependencies:
     - org.mozilla.components:service-glean
-firefox-reality-pc:
-  app_id: org-mozilla-firefoxreality
+  apps:
+    - v1_name: firefox-for-echo-show
+      app_id: org.mozilla.connect.firefox
+- app_name: firefox_reality_pc
   description: Firefox Reality for PC-connected VR platforms
   url: https://github.com/MozillaReality/FirefoxRealityPC
   notification_emails:
@@ -447,8 +405,10 @@ firefox-reality-pc:
     - Source/FirefoxRealityUnity/pings.yaml
   dependencies:
     - glean-core
-mach:
-  app_id: mozilla-mach
+  apps:
+    - v1_name: firefox-reality-pc
+      app_id: org-mozilla-firefoxreality
+- app_name: mach
   description: Mach build telemetry
   url: https://github.com/mozilla/gecko-dev
   notification_emails:
@@ -459,8 +419,10 @@ mach:
     - python/mach/pings.yaml
   dependencies:
     - org.mozilla.deprecated:glean
-glean-js:
-  app_id: glean-js-tmp
+  apps:
+    - v1_name: mach
+      app_id: mozilla-mach
+- app_name: glean_js
   description: Experimentation with Glean.js
   url: https://github.com/brizental/gleanjs
   prototype: true
@@ -474,10 +436,10 @@ glean-js:
   dependencies:
     - glean-core
   retention_days: 90
-firefox-focus-ios:
-  app_id: org-mozilla-ios-focus
-  description: Firefox Focus on iOS. Klar is the sibling application
-  url: https://github.com/mozilla-mobile/focus-ios
+  apps:
+    - v1_name: glean-js
+      app_id: glean-js-tmp
+- url: https://github.com/mozilla-mobile/focus-ios
   notification_emails:
     - jboek@mozilla.com
     - tlong@mozilla.com
@@ -487,16 +449,12 @@ firefox-focus-ios:
   dependencies:
     - glean-core
   retention_days: 720
-firefox-klar-ios:
-  app_id: org-mozilla-ios-klar
-  description: Firefox Klar on iOS. Focus is the sibling application
-  url: https://github.com/mozilla-mobile/focus-ios
-  notification_emails:
-    - jboek@mozilla.com
-    - tlong@mozilla.com
-  branch: main
-  metrics_files:
-    - Blockzilla/metrics.yaml
-  dependencies:
-    - glean-core
-  retention_days: 720
+  apps:
+    - v1_name: firefox-focus-ios
+      app_id: org-mozilla-ios-focus
+      app_name: focus_ios
+      description: Firefox Focus on iOS. Klar is the sibling application
+    - v1_name: firefox-klar-ios
+      app_id: org-mozilla-ios-klar
+      app_name: klar_ios
+      description: Firefox Klar on iOS. Focus is the sibling application

--- a/schemas/repositories_v2.yaml
+++ b/schemas/repositories_v2.yaml
@@ -9,11 +9,11 @@ properties:
       type: object
       additionalProperties: false
       required:
-        - library_id
+        - v1_name
         - notification_emails
         - url
       properties:
-        library_id:
+        v1_name:
           type: string
           pattern: "^[a-z][a-z-]{0,1023}$"
         description:

--- a/schemas/repositories_v2.yaml
+++ b/schemas/repositories_v2.yaml
@@ -1,0 +1,152 @@
+---
+$schema: http://json-schema.org/schema#
+type: object
+additionalProperties: false
+properties:
+  libraries:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - library_id
+        - notification_emails
+        - url
+      properties:
+        library_id:
+          type: string
+          pattern: "^[a-z][a-z-]{0,1023}$"
+        description:
+          type: string
+        notification_emails:
+          type: array
+          items:
+            type: string
+            format: email
+        url:
+          type: string
+          format: uri
+        branch:
+          type: string
+          default: master
+        metrics_files:
+          type: array
+          items:
+            type: string
+            pattern: metrics\.yaml$
+        ping_files:
+          type: array
+          items:
+            type: string
+            pattern: pings\.yaml$
+        library_names:
+          type: array
+          items:
+            type: string
+        prototype:
+          type: boolean
+          default: false
+        deprecated:
+          type: boolean
+          default: false
+        app_channel:
+          type: string
+          enum:
+            - release
+            - beta
+            - nightly
+            - esr
+  application_families:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - apps
+        - notification_emails
+        - url
+      properties:
+        app_name:
+          type: string
+          pattern: "^[a-z][a-z_]{0,29}$"
+        canonical_app_name:
+          type: string
+        description:
+          type: string
+        notification_emails:
+          type: array
+          items:
+            type: string
+            format: email
+        url:
+          type: string
+          format: uri
+        branch:
+          type: string
+          default: master
+        metrics_files:
+          type: array
+          items:
+            type: string
+            pattern: metrics\.yaml$
+        ping_files:
+          type: array
+          items:
+            type: string
+            pattern: pings\.yaml$
+        dependencies:
+          type: array
+          item:
+            type: string
+        prototype:
+          type: boolean
+          default: false
+        deprecated:
+          type: boolean
+          default: false
+        retention_days:
+          type: integer
+        apps:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required:
+              - v1_name
+              - app_id
+            properties:
+              v1_name:
+                type: string
+                pattern: "^[a-z][a-z-]{0,29}$"
+              app_id:
+                type: string
+                pattern: "^[a-zA-Z][a-zA-Z-_.]{0,1023}$"
+              app_name:
+                type: string
+                pattern: "^[a-z][a-z_]{0,29}$"
+              canonical_app_name:
+                type: string
+              description:
+                type: string
+              app_channel:
+                type: string
+                enum:
+                  - release
+                  - beta
+                  - nightly
+                  - esr
+              notification_emails:
+                type: array
+                items:
+                  type: string
+                  format: email
+              dependencies:
+                type: array
+                item:
+                  type: string
+              prototype:
+                type: boolean
+                default: false
+              deprecated:
+                type: boolean
+                default: false

--- a/schemas/repository_v1.yaml
+++ b/schemas/repository_v1.yaml
@@ -1,0 +1,61 @@
+---
+"$schema": http://json-schema.org/schema#
+type: object
+required:
+  - app_id
+  - description
+  - url
+  - notification_emails
+properties:
+  app_id:
+    type: string
+    pattern: "^[a-z][a-z-]{0,1023}$"
+  description:
+    type: string
+  channel:
+    type: string
+    enum:
+    - release
+    - beta
+    - nightly
+    - esr
+  deprecated:
+    type: boolean
+    default: false
+  notification_emails:
+    type: array
+    items:
+      type: string
+      format: email
+  url:
+    type: string
+    format: uri
+  branch:
+    type: string
+  metrics_files:
+    type: array
+    items:
+      type: string
+      pattern: metrics\.yaml$
+  ping_files:
+    type: array
+    items:
+      type: string
+      pattern: pings\.yaml$
+  dependencies:
+    type: array
+    item:
+      type: string
+  dependencies_files:
+    type: array
+    item:
+      type: string
+  library_names:
+    type: array
+    item:
+      type: string
+  prototype:
+    type: boolean
+    default: false
+  retention_days:
+    type: integer

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -97,31 +97,42 @@ def get_repo(repo_name, branch="master"):
 def proper_repo(branch="master"):
     location = get_repo(normal_repo_name, branch)
     repositories_info = {
-        normal_repo_name: {
-            "app_id": "normal-app-name",
-            "description": "foo",
-            "notification_emails": ["frank@mozilla.com"],
-            "url": location,
-            "metrics_files": ["metrics.yaml"],
-            "dependencies": [
-                "org.mozilla.components:service-glean",
-                "org.mozilla.components:lib-crash",
-            ],
-        },
-        "glean": {
-            "app_id": "glean",
-            "description": "foo",
-            "notification_emails": ["frank@mozilla.com"],
-            "url": location,
-            "library_names": ["org.mozilla.components:service-glean"],
-        },
-        "lib-crash": {
-            "app_id": "lib-crash",
-            "description": "foo",
-            "notification_emails": ["frank@mozilla.com"],
-            "url": location,
-            "library_names": ["org.mozilla.components:lib-crash"],
-        },
+        "libraries": [
+            {
+                "library_id": "glean",
+                "description": "foo",
+                "notification_emails": ["frank@mozilla.com"],
+                "url": location,
+                "library_names": ["org.mozilla.components:service-glean"],
+            },
+            {
+                "library_id": "lib-crash",
+                "description": "foo",
+                "notification_emails": ["frank@mozilla.com"],
+                "url": location,
+                "library_names": ["org.mozilla.components:lib-crash"],
+            },
+        ],
+        "application_families": [
+            {
+                "app_name": "proper_repo_example",
+                "description": "foo",
+                "url": location,
+                "notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "dependencies": [
+                    "org.mozilla.components:service-glean",
+                    "org.mozilla.components:lib-crash",
+                ],
+                "apps": [
+                    {
+                        "v1_name": normal_repo_name,
+                        "app_id": "normal-app-name",
+                        "app_channel": "release",
+                    }
+                ],
+            }
+        ],
     }
 
     with open(repositories_file, "w") as f:
@@ -144,13 +155,23 @@ def main_repo():
 def improper_metrics_repo():
     location = get_repo(improper_repo_name)
     repositories_info = {
-        improper_repo_name: {
-            "app_id": "improper-app-name",
-            "description": "foo",
-            "notification_emails": ["frank@mozilla.com"],
-            "url": location,
-            "metrics_files": ["metrics.yaml"],
-        }
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "mobile_metrics_example",
+                "description": "foo",
+                "url": location,
+                "notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": improper_repo_name,
+                        "app_id": "improper-app-name",
+                        "app_channel": "release",
+                    }
+                ],
+            }
+        ],
     }
 
     with open(repositories_file, "w") as f:
@@ -256,22 +277,35 @@ def duplicate_repo():
 
 def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
     repositories_info = {
-        normal_repo_name: {
-            "app_id": "normal-app-name",
-            "description": "foo",
-            "notification_emails": ["repo_alice@example.com"],
-            "url": normal_duplicate_repo,
-            "metrics_files": ["metrics.yaml"],
-            "dependencies": ["duplicate_library"],
-        },
-        duplicate_repo_name: {
-            "app_id": "duplicate-library-name",
-            "description": "foo",
-            "notification_emails": ["repo_bob@example.com"],
-            "url": duplicate_repo,
-            "metrics_files": ["metrics.yaml"],
-            "library_names": ["duplicate_library"],
-        },
+        "libraries": [
+            {
+                "library_id": "mylib",
+                "description": "foo",
+                "notification_emails": ["repo_alice@example.com"],
+                "url": normal_duplicate_repo,
+                "metrics_files": ["metrics.yaml"],
+                "library_names": ["duplicate_library"],
+            },
+        ],
+        "application_families": [
+            {
+                "app_name": "duplicate_metrics_example",
+                "description": "foo",
+                "url": duplicate_repo,
+                "notification_emails": ["repo_bob@example.com"],
+                "metrics_files": ["metrics.yaml"],
+                "dependencies": [
+                    "duplicate_library",
+                ],
+                "apps": [
+                    {
+                        "v1_name": normal_repo_name,
+                        "app_id": "normal-app-name",
+                        "app_channel": "release",
+                    }
+                ],
+            }
+        ],
     }
 
     with open(repositories_file, "w") as f:
@@ -329,13 +363,23 @@ def expired_repo():
 
 def test_check_for_expired_metrics(expired_repo):
     repositories_info = {
-        expired_repo_name: {
-            "app_id": "expired-app-name",
-            "description": "foo",
-            "notification_emails": ["repo_alice@example.com"],
-            "url": expired_repo,
-            "metrics_files": ["metrics.yaml"],
-        },
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "expired_metrics_example",
+                "description": "foo",
+                "url": expired_repo,
+                "notification_emails": ["repo_alice@example.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": expired_repo_name,
+                        "app_id": "expired-app-name",
+                        "app_channel": "release",
+                    }
+                ],
+            }
+        ],
     }
 
     with open(repositories_file, "w") as f:

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -99,14 +99,14 @@ def proper_repo(branch="master"):
     repositories_info = {
         "libraries": [
             {
-                "library_id": "glean",
+                "v1_name": "glean",
                 "description": "foo",
                 "notification_emails": ["frank@mozilla.com"],
                 "url": location,
                 "library_names": ["org.mozilla.components:service-glean"],
             },
             {
-                "library_id": "lib-crash",
+                "v1_name": "boollib",
                 "description": "foo",
                 "notification_emails": ["frank@mozilla.com"],
                 "url": location,
@@ -233,6 +233,18 @@ def test_normal_repo(normal_repo):
 
     assert len(dependencies) == 2
 
+    path = os.path.join(out_dir, "v2", "glean", "applications")
+
+    with open(path, "r") as data:
+        applications = json.load(data)
+
+    # /v2/glean/applications excludes libraries
+    assert len(applications) == 1
+
+    # /v2/glean/applications includes derived fields
+    assert applications[0]["document_namespace"] == "normal-app-name"
+    assert applications[0]["bq_dataset_family"] == "normal_app_name"
+
 
 def test_improper_metrics_repo(improper_metrics_repo):
     runner.main(
@@ -279,7 +291,7 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
     repositories_info = {
         "libraries": [
             {
-                "library_id": "mylib",
+                "v1_name": "mylib",
                 "description": "foo",
                 "notification_emails": ["repo_alice@example.com"],
                 "url": normal_duplicate_repo,

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -7,6 +7,7 @@ import yaml
 
 from probe_scraper.parsers.repositories import RepositoriesParser
 
+
 def write_to_temp_file(data):
     fd, path = tempfile.mkstemp()
     with os.fdopen(fd, "w") as tmp:
@@ -53,7 +54,7 @@ def incorrect_repos_file():
                 "app_name": "mobile-metrics-example",
                 "description": "foo",
                 "url": "www.github.com/fbertsch/mobile-metrics-example",
-                #"notification_emails": ["frank@mozilla.com"],
+                # "notification_emails": ["frank@mozilla.com"],
                 "metrics_files": ["metrics.yaml"],
                 "apps": [
                     {

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -7,7 +7,6 @@ import yaml
 
 from probe_scraper.parsers.repositories import RepositoriesParser
 
-
 def write_to_temp_file(data):
     fd, path = tempfile.mkstemp()
     with os.fdopen(fd, "w") as tmp:
@@ -21,31 +20,50 @@ def parser():
 
 
 @pytest.fixture
-def incorrect_repos_file():
+def correct_repos_file():
     data = {
-        "some-repo": {
-            # missing `notification_emails`
-            "app_id": "mobile-metrics-example",
-            "description": "foo",
-            "url": "www.github.com/fbertsch/mobile-metrics-example",
-            "metrics_files": ["metrics.yaml"],
-        }
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "mobile_metrics_example",
+                "description": "foo",
+                "url": "www.github.com/fbertsch/mobile-metrics-example",
+                "notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": "test-repo",
+                        "app_id": "mobile_metrics_example",
+                        "app_channel": "release"
+                    }
+                ]
+            }
+        ]
     }
 
     return write_to_temp_file(data)
 
 
 @pytest.fixture
-def correct_repos_file():
+def incorrect_repos_file():
     data = {
-        "test-repo": {
-            "app_id": "mobile-metrics-example",
-            "description": "foo",
-            "channel": "release",
-            "url": "www.github.com/fbertsch/mobile-metrics-example",
-            "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"],
-        }
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "mobile-metrics-example",
+                "description": "foo",
+                "url": "www.github.com/fbertsch/mobile-metrics-example",
+                #"notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": "test-repo",
+                        "app_id": "mobile_metrics_example",
+                        "app_channel": "release"
+                    }
+                ]
+            }
+        ]
     }
 
     return write_to_temp_file(data)
@@ -54,13 +72,23 @@ def correct_repos_file():
 @pytest.fixture
 def not_kebab_case_repos_file():
     data = {
-        "some_repo": {
-            "app_id": "mobile-metrics-example",
-            "description": "foo",
-            "url": "www.github.com/fbertsch/mobile-metrics-example",
-            "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"],
-        }
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "mobile_metrics_example",
+                "description": "foo",
+                "url": "www.github.com/fbertsch/mobile-metrics-example",
+                "notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": "test_repo",
+                        "app_id": "mobile_metrics_example",
+                        "app_channel": "release"
+                    }
+                ]
+            }
+        ]
     }
 
     return write_to_temp_file(data)
@@ -69,14 +97,23 @@ def not_kebab_case_repos_file():
 @pytest.fixture
 def invalid_release_channel_file():
     data = {
-        "test-repo": {
-            "app_id": "mobile-metrics-example",
-            "description": "foo",
-            "channel": "releaze",
-            "url": "www.github.com/fbertsch/mobile-metrics-example",
-            "notification_emails": ["frank@mozilla.com"],
-            "metrics_files": ["metrics.yaml"],
-        }
+        "libraries": [],
+        "application_families": [
+            {
+                "app_name": "mobile_metrics_example",
+                "description": "foo",
+                "url": "www.github.com/fbertsch/mobile-metrics-example",
+                "notification_emails": ["frank@mozilla.com"],
+                "metrics_files": ["metrics.yaml"],
+                "apps": [
+                    {
+                        "v1_name": "test-repo",
+                        "app_id": "mobile_metrics_example",
+                        "app_channel": "semiquarterly"
+                    }
+                ]
+            }
+        ]
     }
 
     return write_to_temp_file(data)

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -35,11 +35,11 @@ def correct_repos_file():
                     {
                         "v1_name": "test-repo",
                         "app_id": "mobile_metrics_example",
-                        "app_channel": "release"
+                        "app_channel": "release",
                     }
-                ]
+                ],
             }
-        ]
+        ],
     }
 
     return write_to_temp_file(data)
@@ -60,11 +60,11 @@ def incorrect_repos_file():
                     {
                         "v1_name": "test-repo",
                         "app_id": "mobile_metrics_example",
-                        "app_channel": "release"
+                        "app_channel": "release",
                     }
-                ]
+                ],
             }
-        ]
+        ],
     }
 
     return write_to_temp_file(data)
@@ -85,11 +85,11 @@ def not_kebab_case_repos_file():
                     {
                         "v1_name": "test_repo",
                         "app_id": "mobile_metrics_example",
-                        "app_channel": "release"
+                        "app_channel": "release",
                     }
-                ]
+                ],
             }
-        ]
+        ],
     }
 
     return write_to_temp_file(data)
@@ -110,11 +110,11 @@ def invalid_release_channel_file():
                     {
                         "v1_name": "test-repo",
                         "app_id": "mobile_metrics_example",
-                        "app_channel": "semiquarterly"
+                        "app_channel": "semiquarterly",
                     }
-                ]
+                ],
             }
-        ]
+        ],
     }
 
     return write_to_temp_file(data)


### PR DESCRIPTION
Implements the new structure defined in
https://docs.google.com/document/d/1_zx0cxBnnFOhct1cCb_QnXntV-HN9sjqfGfiBwEBL-8/edit?usp=sharing 
but ensures that we maintain the current output format.

This PR also introduces a `/v2/glean/applications` endpoint. Further work will be required to implement v2 metrics and pings endpoints, especially if we want to include dependency resolution there.

The most important piece for review here is about the new `repositories.yaml` format. There are some additional specifics that differ a bit from the proposal, including introducing top-level `libraries` and `application_families` organization. Now is the time to suggest any final refinements.