### PR TITLE
Mention the correct make target

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flake8 --max-line-length 100 .
 
 To render API documentation locally to `index.html`:
 ```
-make doc
+make apidoc
 ```
 
 ### Developing using the container


### PR DESCRIPTION
woops, initially I called it `doc`, but then changed it in the makefile, but didn't update the readme.