### PR TITLE
Link back to metric and ping definitions in source control

### DIFF
--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from glean_parser.parser import parse_objects
 
 from .pings import normalize_ping_name
-from .utils import add_source_url
+from .utils import get_source_url
 
 
 class GleanMetricsParser:
@@ -34,9 +34,11 @@ class GleanMetricsParser:
 
         for v in metrics.values():
             v["send_in_pings"] = [normalize_ping_name(p) for p in v["send_in_pings"]]
-            v = (
-                add_source_url(v, repo_url, commit_hash)
+            v["source_url"] = (
+                get_source_url(v["defined_in"], repo_url, commit_hash)
                 if repo_url and commit_hash
                 else v
             )
+            # the 'defined_in' structure is no longer needed
+            del v["defined_in"]
         return metrics, errors

--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -34,11 +34,8 @@ class GleanMetricsParser:
 
         for v in metrics.values():
             v["send_in_pings"] = [normalize_ping_name(p) for p in v["send_in_pings"]]
-            v["source_url"] = (
-                get_source_url(v["defined_in"], repo_url, commit_hash)
-                if repo_url and commit_hash
-                else v
-            )
+            if repo_url and commit_hash:
+                v["source_url"] = get_source_url(v["defined_in"], repo_url, commit_hash)
             # the 'defined_in' structure is no longer needed
             del v["defined_in"]
         return metrics, errors

--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from glean_parser.parser import parse_objects
 
 from .pings import normalize_ping_name
+from .utils import add_source_url
 
 
 class GleanMetricsParser:
@@ -16,7 +17,7 @@ class GleanMetricsParser:
     to parse the metrics.yaml files.
     """
 
-    def parse(self, filenames, config):
+    def parse(self, filenames, config, repo_url=None, commit_hash=None):
         config = config.copy()
         config["do_not_disable_expired"] = True
 
@@ -31,7 +32,11 @@ class GleanMetricsParser:
             for probe_name, metric in probes.items()
         }
 
-        for i, v in metrics.items():
+        for v in metrics.values():
             v["send_in_pings"] = [normalize_ping_name(p) for p in v["send_in_pings"]]
-
+            v = (
+                add_source_url(v, repo_url, commit_hash)
+                if repo_url and commit_hash
+                else v
+            )
         return metrics, errors

--- a/probe_scraper/parsers/pings.py
+++ b/probe_scraper/parsers/pings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from glean_parser.parser import parse_objects
 
-from .utils import add_source_url
+from .utils import get_source_url
 
 PING_NAME_NORMALIZATION = {
     "deletion_request": "deletion-request",
@@ -42,6 +42,7 @@ class GleanPingsParser:
 
         if repo_url and commit_hash:
             for v in pings.values():
-                v = add_source_url(v, repo_url, commit_hash)
-
+                v["source_url"] = get_source_url(v["defined_in"], repo_url, commit_hash)
+                # the 'defined_in' structure is no longer needed
+                del v["defined_in"]
         return pings, errors

--- a/probe_scraper/parsers/utils.py
+++ b/probe_scraper/parsers/utils.py
@@ -26,10 +26,10 @@ def get_major_version(version):
     return version.split(".")[0]
 
 
-def get_source_url(defined_in, repo_url, commit_hash):
+def get_source_url(glean_definition, repo_url, commit_hash):
     """Add source URL where metrics and pings are defined."""
-    line_number = defined_in["line"]
-    file_path = defined_in["filepath"][
-        defined_in["filepath"].find(commit_hash) :  # noqa: E203
+    line_number = glean_definition["line"]
+    file_path = glean_definition["filepath"][
+        glean_definition["filepath"].find(commit_hash) :  # noqa: E203
     ]
     return f"{repo_url}/blob/{file_path}#L{line_number}"

--- a/probe_scraper/parsers/utils.py
+++ b/probe_scraper/parsers/utils.py
@@ -24,3 +24,15 @@ def get_major_version(version):
     :return: a string containing the leftmost number before the first dot
     """
     return version.split(".")[0]
+
+
+def add_source_url(v, repo_url, commit_hash):
+    """Add source URL where metrics and pings are defined."""
+    file_path = v["defined_in"]["filepath"][
+        v["defined_in"]["filepath"].find(commit_hash) :  # noqa: E203
+    ]
+    line_number = v["defined_in"]["line"]
+    v["source_url"] = f"{repo_url}/blob/{file_path}#L{line_number}"
+    # the 'defined_in' structure is no longer needed
+    del v["defined_in"]
+    return v

--- a/probe_scraper/parsers/utils.py
+++ b/probe_scraper/parsers/utils.py
@@ -26,13 +26,10 @@ def get_major_version(version):
     return version.split(".")[0]
 
 
-def add_source_url(v, repo_url, commit_hash):
+def get_source_url(defined_in, repo_url, commit_hash):
     """Add source URL where metrics and pings are defined."""
-    file_path = v["defined_in"]["filepath"][
-        v["defined_in"]["filepath"].find(commit_hash) :  # noqa: E203
+    line_number = defined_in["line"]
+    file_path = defined_in["filepath"][
+        defined_in["filepath"].find(commit_hash) :  # noqa: E203
     ]
-    line_number = v["defined_in"]["line"]
-    v["source_url"] = f"{repo_url}/blob/{file_path}#L{line_number}"
-    # the 'defined_in' structure is no longer needed
-    del v["defined_in"]
-    return v
+    return f"{repo_url}/blob/{file_path}#L{line_number}"

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -262,8 +262,9 @@ def add_source_url(results, url, commit_hash):
     for result in results:
         defined_in = results[result]["defined_in"]
         line_number = defined_in["line"]
-        file_path = defined_in["filepath"][defined_in["filepath"]
-                                           .find(commit_hash) :]  # noqa: E203
+        file_path = defined_in["filepath"][
+            defined_in["filepath"].find(commit_hash) :  # noqa: E203
+        ]
         results[result]["source_url"] = f"{url}/blob/{file_path}#L{line_number}"
         # the 'defined_in' structure is no longer needed
         del results[result]["defined_in"]

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -268,25 +268,20 @@ def add_source_url(results, url, filepath):
 
 def get_file_path_with_hash(path, commit_hash):
     """
-    Get the relative file path with commit hash included
-    from disk path (to be used with GitHub repo link to
-    create a source url)
+    Get the relative file path with commit hash included.
 
     The structure of disk path is "base_path / _hash / rel_path"
     We want to extract _hash and rel_path from this string.
 
     Example input:
-    '/var/folders/yf/q5zg5fjx2kz2lc2sbfdht4bm0000gn/T/tmpt9x11our/glean-android/
-    530a5128526fcf133d57ec3d188590c600895fa1/glean-core/metrics.yaml'
+    ['/var/folders/yf/q5zg5fjx2kz2lc2sbfdht4bm0000gn/T/tmpt9x11our/glean-android/
+    530a5128526fcf133d57ec3d188590c600895fa1/glean-core/metrics.yaml']
 
     Output:
     '530a5128526fcf133d57ec3d188590c600895fa1/glean-core/metrics.yaml'
     """
-    split_path = "".join(path).split("/")
-    for i, word in enumerate(split_path):
-        if word == commit_hash:
-            file_path = "/".join(split_path[i:])
-    return file_path
+    file_path = "".join(path).split(commit_hash)[-1]
+    return "".join([commit_hash, file_path])
 
 
 def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run, glean_repo):

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -257,31 +257,17 @@ def load_moz_central_probes(
     write_moz_central_probe_data(probes_by_channel_with_dates, revision_dates, out_dir)
 
 
-def add_source_url(results, url, filepath):
+def add_source_url(results, url, commit_hash):
+    """Add source URL where metrics and pings are defined."""
     for result in results:
-        line_number = results[result]["defined_in"]["line"]
-        results[result]["source_url"] = f"{url}/blob/{filepath}#L{line_number}"
+        defined_in = results[result]["defined_in"]
+        line_number = defined_in["line"]
+        file_path = defined_in["filepath"][defined_in["filepath"]
+                                           .find(commit_hash) :]  # noqa: E203
+        results[result]["source_url"] = f"{url}/blob/{file_path}#L{line_number}"
         # the 'defined_in' structure is no longer needed
         del results[result]["defined_in"]
     return results
-
-
-def get_file_path_with_hash(path, commit_hash):
-    """
-    Get the relative file path with commit hash included.
-
-    The structure of disk path is "base_path / _hash / rel_path"
-    We want to extract _hash and rel_path from this string.
-
-    Example input:
-    ['/var/folders/yf/q5zg5fjx2kz2lc2sbfdht4bm0000gn/T/tmpt9x11our/glean-android/
-    530a5128526fcf133d57ec3d188590c600895fa1/glean-core/metrics.yaml']
-
-    Output:
-    '530a5128526fcf133d57ec3d188590c600895fa1/glean-core/metrics.yaml'
-    """
-    file_path = "".join(path).split(commit_hash)[-1]
-    return "".join([commit_hash, file_path])
 
 
 def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run, glean_repo):
@@ -315,19 +301,12 @@ def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run, glean_rep
                 if metrics_files:
                     results, errs = GLEAN_PARSER.parse(metrics_files, config)
                     metrics[repo_name][commit_hash] = results
-                    results = add_source_url(
-                        results,
-                        repo["url"],
-                        get_file_path_with_hash(metrics_files, commit_hash),
-                    )
+                    results = add_source_url(results, repo["url"], commit_hash)
+
                 if pings_files:
                     results, errs = GLEAN_PINGS_PARSER.parse(pings_files, config)
                     pings[repo_name][commit_hash] = results
-                    results = add_source_url(
-                        results,
-                        repo["url"],
-                        get_file_path_with_hash(pings_files, commit_hash),
-                    )
+                    results = add_source_url(results, repo["url"], commit_hash)
             except Exception:
                 files = metrics_files + pings_files
                 msg = "Improper file in {}\n{}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ awscli==1.16.263
 beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.9.250
-glean_parser==2.1.0
+glean_parser==2.4.0
 jsonschema==3.1.1
 python-dateutil==2.8.0
 PyYAML==5.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ awscli==1.16.263
 beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.9.250
-glean_parser==1.29.0
+glean_parser==2.1.0
 jsonschema==3.1.1
 python-dateutil==2.8.0
 PyYAML==5.1.2

--- a/tests/test_metrics_parser.py
+++ b/tests/test_metrics_parser.py
@@ -1,5 +1,6 @@
-from probe_scraper.parsers.metrics import GleanMetricsParser
 import pytest
+
+from probe_scraper.parsers.metrics import GleanMetricsParser
 
 
 def is_string(s):

--- a/tests/test_metrics_parser.py
+++ b/tests/test_metrics_parser.py
@@ -1,4 +1,5 @@
 from probe_scraper.parsers.metrics import GleanMetricsParser
+import pytest
 
 
 def is_string(s):
@@ -21,3 +22,21 @@ def test_metrics_parser():
 
     # Check that ping names are normalized
     assert "session-end" in parsed_metrics["example.os"]["send_in_pings"]
+
+
+def test_source_url():
+    parser = GleanMetricsParser()
+    parsed_metrics, errs = parser.parse(
+        ["tests/resources/metrics.yaml"], {}, "test.com/foo", "tests"
+    )
+
+    assert (
+        parsed_metrics["example.duration"]["source_url"]
+        == "test.com/foo/blob/tests/resources/metrics.yaml#L4"
+    )
+    assert (
+        parsed_metrics["example.os"]["source_url"]
+        == "test.com/foo/blob/tests/resources/metrics.yaml#L19"
+    )
+    with pytest.raises(KeyError):
+        parsed_metrics["example.os"]["defined_in"]

--- a/tests/test_metrics_parser.py
+++ b/tests/test_metrics_parser.py
@@ -28,16 +28,16 @@ def test_metrics_parser():
 def test_source_url():
     parser = GleanMetricsParser()
     parsed_metrics, errs = parser.parse(
-        ["tests/resources/metrics.yaml"], {}, "test.com/foo", "tests"
+        ["tests/resources/metrics.yaml"], {}, "https://www.test.com/foo", "tests"
     )
 
     assert (
         parsed_metrics["example.duration"]["source_url"]
-        == "test.com/foo/blob/tests/resources/metrics.yaml#L4"
+        == "https://www.test.com/foo/blob/tests/resources/metrics.yaml#L4"
     )
     assert (
         parsed_metrics["example.os"]["source_url"]
-        == "test.com/foo/blob/tests/resources/metrics.yaml#L19"
+        == "https://www.test.com/foo/blob/tests/resources/metrics.yaml#L19"
     )
     with pytest.raises(KeyError):
         parsed_metrics["example.os"]["defined_in"]


### PR DESCRIPTION
Add a link back to where a metric/ping is originally defined in source control, as the second step of https://github.com/mozilla/glean-dictionary/issues/223. 

@wlach Could you review if this looks ok so far? Thanks!