### PR TITLE
Add a canonical app description field for v2

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -175,8 +175,8 @@ class RepositoriesParser(object):
             app.pop("app_name")
             app.pop("canonical_app_name", None)
             app.pop("bq_dataset_family")
-            app["description"] = app["app_description"]
-            app.pop("app_description", None)
+            app_description = app.pop("app_description", None)
+            app["description"] = app.get("description", app_description)
             namespace = app.pop("document_namespace")
             app["app_id"] = namespace
             repos[v1_name] = app

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -144,6 +144,7 @@ class RepositoriesParser(object):
                     "additional_dependencies", []
                 )
                 listing = {**app, **channel}
+                listing["canonical_app_description"] = app["description"]
                 listing["dependencies"] = dependencies
                 app_id = listing["app_id"]
                 listing["document_namespace"] = (
@@ -174,6 +175,7 @@ class RepositoriesParser(object):
             v1_name = app.pop("v1_name")
             app.pop("app_name")
             app.pop("canonical_app_name", None)
+            app.pop("canonical_app_description", None)
             app.pop("bq_dataset_family")
             namespace = app.pop("document_namespace")
             app["app_id"] = namespace

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -144,7 +144,6 @@ class RepositoriesParser(object):
                     "additional_dependencies", []
                 )
                 listing = {**app, **channel}
-                listing["canonical_app_description"] = app["description"]
                 listing["dependencies"] = dependencies
                 app_id = listing["app_id"]
                 listing["document_namespace"] = (
@@ -175,8 +174,9 @@ class RepositoriesParser(object):
             v1_name = app.pop("v1_name")
             app.pop("app_name")
             app.pop("canonical_app_name", None)
-            app.pop("canonical_app_description", None)
             app.pop("bq_dataset_family")
+            app["description"] = app["app_description"]
+            app.pop("app_description", None)
             namespace = app.pop("document_namespace")
             app["app_id"] = namespace
             repos[v1_name] = app

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -448,6 +448,8 @@ components:
           $ref: "#/components/schemas/AppName"
         canonical_app_name:
           $ref: "#/components/schemas/CanonicalAppName"
+        canonical_app_description:
+          $ref: "#/components/schemas/CanonicalAppDescription"
         v1_name:
           $ref: "#/components/schemas/V1Name"
         app_channel:
@@ -481,7 +483,17 @@ components:
 
     Description:
       type: string
-      description: A brief free-text description of the repository
+      description: A brief free-text description of this application variant.
+
+    CanonicalAppDescription:
+      type: string
+      description: |
+        A brief free-text description of an application, applicable across any variants.
+
+        This should not be materialized in ETL, but rather only made available in user-facing views since it may be verbose
+        and it may change over time.
+
+        example: The desktop version of Firefox
 
     AppName:
       type: string

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -248,7 +248,7 @@ components:
             type: string
             pattern: "^[a-z][a-z-]{0,1023}$"
           description:
-            type: string
+            $ref: "#/components/schemas/AppDescription"
           channel:
             $ref: "#/components/schemas/AppChannel"
           deprecated:
@@ -334,7 +334,7 @@ components:
       required:
         - app_name
         - canonical_app_name
-        - description
+        - app_description
         - url
         - channels
       properties:
@@ -342,8 +342,8 @@ components:
           $ref: "#/components/schemas/AppName"
         canonical_app_name:
           $ref: "#/components/schemas/CanonicalAppName"
-        description:
-          $ref: "#/components/schemas/Description"
+        app_description:
+          $ref: "#/components/schemas/AppDescription"
         notification_emails:
           $ref: "#/components/schemas/NotificationEmails"
         url:
@@ -448,8 +448,8 @@ components:
           $ref: "#/components/schemas/AppName"
         canonical_app_name:
           $ref: "#/components/schemas/CanonicalAppName"
-        canonical_app_description:
-          $ref: "#/components/schemas/CanonicalAppDescription"
+        app_description:
+          $ref: "#/components/schemas/AppDescription"
         v1_name:
           $ref: "#/components/schemas/V1Name"
         app_channel:
@@ -485,7 +485,7 @@ components:
       type: string
       description: A brief free-text description of this application variant.
 
-    CanonicalAppDescription:
+    AppDescription:
       type: string
       description: |
         A brief free-text description of an application, applicable across any variants.

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -182,7 +182,7 @@ libraries:
 applications:
   - app_name: firefox_desktop
     canonical_app_name: Firefox for Desktop
-    description: The desktop version of Firefox
+    app_description: The desktop version of Firefox
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - chutten@mozilla.com
@@ -198,7 +198,7 @@ applications:
 
 
   - app_name: fenix
-    description: Firefox for Android (Fenix)
+    app_description: Firefox for Android (Fenix)
     canonical_app_name: Firefox for Android
     url: https://github.com/mozilla-mobile/fenix
     notification_emails:
@@ -259,7 +259,7 @@ applications:
 
   - app_name: firefox_ios
     canonical_app_name: Firefox for iOS
-    description: Firefox for iOS
+    app_description: Firefox for iOS
     notification_emails:
       - tlong@mozilla.com
       - frank@mozilla.com
@@ -282,7 +282,7 @@ applications:
 
   - app_name: reference_browser
     canonical_app_name: Reference Browser
-    description: >-
+    app_description: >-
       A full-featured browser reference implementation using Mozilla Android
       Components
     notification_emails:
@@ -301,7 +301,7 @@ applications:
 
   - app_name: firefox_fire_tv
     canonical_app_name: Firefox for Fire TV
-    description: Firefox for Amazon's Fire TV
+    app_description: Firefox for Amazon's Fire TV
     notification_emails:
       - frank@mozilla.com
     url: https://github.com/mozilla-mobile/firefox-tv
@@ -315,7 +315,7 @@ applications:
 
   - app_name: firefox_reality
     canonical_app_name: Firefox Reality
-    description: >-
+    app_description: >-
       A fast and secure browser for standalone virtual-reality and
       augmented-reality headsets
     notification_emails:
@@ -337,7 +337,7 @@ applications:
 
   - app_name: lockwise_android
     canonical_app_name: Lockwise for Android
-    description: >-
+    app_description: >-
       Firefox's Lockwise app for Android
     notification_emails:
       - frank@mozilla.com
@@ -354,7 +354,7 @@ applications:
 
   - app_name: lockwise_ios
     canonical_app_name: Lockwise for iOS
-    description: >-
+    app_description: >-
       Firefox's Lockwise app for iOS
     notification_emails:
       - frank@mozilla.com
@@ -369,7 +369,7 @@ applications:
 
   - app_name: mozregression
     canonical_app_name: mozregression
-    description: Regression range finder for Mozilla nightly builds
+    app_description: Regression range finder for Mozilla nightly builds
     notification_emails:
       - wlachance@mozilla.com
     url: https://github.com/mozilla/mozregression
@@ -385,7 +385,7 @@ applications:
 
   - app_name: burnham
     canonical_app_name: Burnham
-    description: Automated end-to-end testing for Mozilla's Glean telemetry
+    app_description: Automated end-to-end testing for Mozilla's Glean telemetry
     notification_emails:
       - rpierzina@mozilla.com
     url: https://github.com/mozilla/burnham
@@ -403,7 +403,7 @@ applications:
 
   - app_name: mozphab
     canonical_app_name: mozphab
-    description: Phabricator review submission/management tool
+    app_description: Phabricator review submission/management tool
     notification_emails:
       - pzalewa@mozilla.com
     url: https://github.com/mozilla-conduit/review
@@ -419,7 +419,7 @@ applications:
 
   - app_name: firefox_echo_show
     canonical_app_name: Firefox for Echo Show
-    description: Firefox for Amazon's Echo Show
+    app_description: Firefox for Amazon's Echo Show
     url: https://github.com/mozilla-mobile/firefox-echo-show
     notification_emails:
       - tlong@mozilla.com
@@ -433,7 +433,7 @@ applications:
 
   - app_name: firefox_reality_pc
     canonical_app_name: Firefox Reality for PC-connected VR platforms
-    description: Firefox Reality for PC-connected VR platforms
+    app_description: Firefox Reality for PC-connected VR platforms
     url: https://github.com/MozillaReality/FirefoxRealityPC
     notification_emails:
       - dmu@mozilla.com
@@ -449,7 +449,7 @@ applications:
 
   - app_name: mach
     canonical_app_name: mach
-    description: Mach build telemetry
+    app_description: Mach build telemetry
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - mhentges@mozilla.com
@@ -465,7 +465,7 @@ applications:
 
   - app_name: focus_ios
     canonical_app_name: Firefox Focus for iOS
-    description: Firefox Focus on iOS. Klar is the sibling application
+    app_description: Firefox Focus on iOS. Klar is the sibling application
     url: https://github.com/mozilla-mobile/focus-ios
     notification_emails:
       - jboek@mozilla.com
@@ -482,7 +482,7 @@ applications:
 
   - app_name: klar_ios
     canonical_app_name: Firefox Klar for iOS
-    description: Firefox Klar on iOS. Focus is the sibling application
+    app_description: Firefox Klar on iOS. Focus is the sibling application
     url: https://github.com/mozilla-mobile/focus-ios
     notification_emails:
       - jboek@mozilla.com

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -118,7 +118,7 @@ def proper_repo(branch="master"):
             {
                 "app_name": "proper_repo_example",
                 "canonical_app_name": "Proper Repo Example",
-                "description": "foo",
+                "app_description": "foo",
                 "url": location,
                 "notification_emails": ["frank@mozilla.com"],
                 "metrics_files": ["metrics.yaml"],
@@ -163,7 +163,7 @@ def improper_metrics_repo():
             {
                 "app_name": "mobile_metrics_example",
                 "canonical_app_name": "Mobile Metrics Example",
-                "description": "foo",
+                "app_description": "foo",
                 "url": location,
                 "notification_emails": ["frank@mozilla.com"],
                 "metrics_files": ["metrics.yaml"],
@@ -308,7 +308,7 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
             {
                 "app_name": "duplicate_metrics_example",
                 "canonical_app_name": "Duplicate Metrics Example",
-                "description": "foo",
+                "app_description": "foo",
                 "url": duplicate_repo,
                 "notification_emails": ["repo_bob@example.com"],
                 "metrics_files": ["metrics.yaml"],
@@ -387,7 +387,7 @@ def test_check_for_expired_metrics(expired_repo):
             {
                 "app_name": "expired_metrics_example",
                 "canonical_app_name": "Expired Metrics Example",
-                "description": "foo",
+                "app_description": "foo",
                 "url": expired_repo,
                 "notification_emails": ["repo_alice@example.com"],
                 "metrics_files": ["metrics.yaml"],


### PR DESCRIPTION
This is derived from the high-level "description" field and
should be applicable across any variants of an application.

We want this for mozilla/glean-dictionary#426

As it stands the front page looks like this because we don't expose this information in the /v2/ API:

![image](https://user-images.githubusercontent.com/20569/109563353-a6205600-7aad-11eb-983f-b6aa87028e1c.png)

(note the weird titles for each of the app groupings -- we should put what's currently the description there (e.g. "Firefox for Android") and put in something longer form for the description (which this PR would provide).