### PR TITLE
Library names

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -168,13 +168,16 @@ class RepositoriesParser(object):
         for lib in repos_v2["libraries"]:
             variants = lib.pop("variants")
             for variant in variants:
-                newlib = {**lib, **variant}
-                newlib.pop("library_name")
-                newlib["library_names"] = [newlib["dependency_name"]]
-                newlib.pop("dependency_name")
-                v1_name = newlib.pop("v1_name")
-                newlib["app_id"] = v1_name
-                repos[v1_name] = newlib
+                lib_info = {**lib, **variant}
+                v1_name = lib_info["v1_name"]
+                lib_info["library_names"] = [lib_info["dependency_name"]]
+                lib_info["app_id"] = v1_name
+                
+                del lib_info["library_name"]
+                del lib_info["dependency_name"]
+                del lib_info["v1_name"]
+                
+                repos[v1_name] = lib_info
         for app in repos_v2["applications"]:
             app_channel = app.pop("app_channel", None)
             if app_channel is not None:

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -172,11 +172,9 @@ class RepositoriesParser(object):
                 v1_name = lib_info["v1_name"]
                 lib_info["library_names"] = [lib_info["dependency_name"]]
                 lib_info["app_id"] = v1_name
-                
                 del lib_info["library_name"]
                 del lib_info["dependency_name"]
                 del lib_info["v1_name"]
-                
                 repos[v1_name] = lib_info
         for app in repos_v2["applications"]:
             app_channel = app.pop("app_channel", None)

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -129,9 +129,9 @@ def write_repositories_data(repos, out_dir):
     dump_json(json_data, os.path.join(out_dir, "glean"), "repositories")
 
 
-def write_v2_app_listings_data(repos, out_dir):
-    json_data = repos["applications"]
-    dump_json(json_data, os.path.join(out_dir, "v2", "glean"), "app-listings")
+def write_v2_data(repos, out_dir):
+    dump_json(repos["applications"], os.path.join(out_dir, "v2", "glean"), "app-listings")
+    dump_json(repos["libraries"], os.path.join(out_dir, "v2", "glean"), "library-variants")
 
 
 def parse_moz_central_probes(scraped_data):
@@ -351,7 +351,7 @@ def load_glean_metrics(cache_dir, out_dir, repositories_file, dry_run, glean_rep
     write_general_data(out_dir)
 
     repos_v2 = RepositoriesParser().parse_v2(repositories_file)
-    write_v2_app_listings_data(repos_v2, out_dir)
+    write_v2_data(repos_v2, out_dir)
 
     for repo_name, email_info in list(emails.items()):
         addresses = email_info["addresses"] + [DEFAULT_TO_EMAIL]

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -130,8 +130,12 @@ def write_repositories_data(repos, out_dir):
 
 
 def write_v2_data(repos, out_dir):
-    dump_json(repos["applications"], os.path.join(out_dir, "v2", "glean"), "app-listings")
-    dump_json(repos["libraries"], os.path.join(out_dir, "v2", "glean"), "library-variants")
+    dump_json(
+        repos["applications"], os.path.join(out_dir, "v2", "glean"), "app-listings"
+    )
+    dump_json(
+        repos["libraries"], os.path.join(out_dir, "v2", "glean"), "library-variants"
+    )
 
 
 def parse_moz_central_probes(scraped_data):

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -649,7 +649,9 @@ components:
     DependencyName:
       type: string
       description: |
-        Name of this dependency, to be referenced by the dependencies section of an application's definition.
+        Build system-specific name of this dependency, to be referenced by the `dependencies` section
+        of an application's definition.
+      example: org.mozilla.components:browser-engine-gecko
 
     Dependencies:
       type: array

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -649,7 +649,7 @@ components:
     DependencyName:
       type: string
       description: |
-        Name of this dependency name, to be referenced by dependencies by an application.
+        Name of this dependency, to be referenced by the dependencies section of an application's definition.
 
     Dependencies:
       type: array

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -31,7 +31,7 @@ tags:
   - name: library
     x-displayName: The repositories.yaml Library Format
     description: |
-      <SchemaDefinition schemaRef="#/components/schemas/Library" exampleRef="#/components/examples/Library" />
+      <SchemaDefinition schemaRef="#/components/schemas/LibraryYaml" />
   - name: application
     x-displayName: The repositories.yaml Application Format
     description: |
@@ -321,7 +321,7 @@ components:
           type: array
           description: Repositories that define Glean dependencies
           items:
-            $ref: "#/components/schemas/Library"
+            $ref: "#/components/schemas/LibraryYaml"
         applications:
           type: array
           description: Repositories that define Glean applications
@@ -398,34 +398,26 @@ components:
                 items:
                   type: string
 
-    Library:
+    LibraryYaml:
       type: object
       additionalProperties: false
       required:
-        - v1_name
+        - library_name
         - description
         - notification_emails
         - url
-        - library_names
+        - variants
       properties:
-        v1_name:
-          $ref: "#/components/schemas/V1Name"
+        library_name:
+          $ref: "#/components/schemas/LibraryName"
         description:
           $ref: "#/components/schemas/Description"
-        deprecated:
-          $ref: "#/components/schemas/DeprecatedBool"
         notification_emails:
           $ref: "#/components/schemas/NotificationEmails"
         url:
           $ref: "#/components/schemas/RepoUrl"
-        branch:
-          $ref: "#/components/schemas/RepoBranch"
-        metrics_files:
-          $ref: "#/components/schemas/MetricsFiles"
-        ping_files:
-          $ref: "#/components/schemas/PingFiles"
-        library_names:
-          $ref: "#/components/schemas/LibraryNames"
+        variants:
+          $ref: "#/components/schemas/LibraryVariants"
 
     Application:
       type: object
@@ -604,6 +596,38 @@ components:
       default: false
       description: Set to `true` if the repo corresponds to a deprecated product or library.
 
+    LibraryName:
+      type: string
+      description: |
+        A unique identifier for this library, applicable across all variants of it.
+      example: glean-core
+
+    LibraryVariants:
+      type: array
+      description: |
+        Variants of this library.
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - dependency_name
+          - v1_name
+        properties:
+          v1_name:
+            $ref: "#/components/schemas/V1Name"
+          description:
+            $ref: "#/components/schemas/Description"
+          deprecated:
+            $ref: "#/components/schemas/DeprecatedBool"
+          branch:
+            $ref: "#/components/schemas/RepoBranch"
+          metrics_files:
+            $ref: "#/components/schemas/MetricsFiles"
+          ping_files:
+            $ref: "#/components/schemas/PingFiles"
+          dependency_name:
+            $ref: "#/components/schemas/DependencyName"
+
     LibraryNames:
       type: array
       description: |
@@ -622,12 +646,17 @@ components:
         If not specified, retention will be unlimited.
       type: integer
 
+    DependencyName:
+      type: string
+      description: |
+        Name of this dependency name, to be referenced by dependencies by an application.
+
     Dependencies:
       type: array
       default: []
       description: |
         List of libraries that this application imports. The values here must
-        match a value defined under `library_names` by one of the libraries.
+        match a value defined under `dependency_name` by a library variant.
       items:
         type: string
         example: org.mozilla.components:service-glean

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -6,67 +6,35 @@ version: "2"
 
 # See https://mozilla.github.io/probe-scraper/#tag/library
 libraries:
-  - v1_name: glean-core
+  - library_name: glean-core
     description: Modern cross-platform telemetry (core library)
     notification_emails:
       - frank@mozilla.com
       - mdroettboom@mozilla.com
     url: https://github.com/mozilla/glean
-    branch: main
-    metrics_files:
-      - glean-core/metrics.yaml
-    ping_files:
-      - glean-core/pings.yaml
-    library_names:
-      - glean-core
+    variants:
+      - v1_name: glean-core
+        branch: main
+        metrics_files:
+          - glean-core/metrics.yaml
+        ping_files:
+          - glean-core/pings.yaml
+        dependency_name: glean-core
 
-  - v1_name: glean-android
+  - library_name: glean-android
     description: Modern cross-platform telemetry (Android-specific)
     notification_emails:
       - frank@mozilla.com
       - mdroettboom@mozilla.com
     url: https://github.com/mozilla/glean
-    branch: main
-    metrics_files:
-      - glean-core/android/metrics.yaml
-      - glean-core/metrics.yaml
-    ping_files:
-      - glean-core/pings.yaml
-    library_names:
-      - org.mozilla.components:service-glean
+    variants:
+      - v1_name: glean-android
+        metrics_files:
+          - glean-core/android/metrics.yaml
+        branch: main
+        dependency_name: org.mozilla.components:service-glean
 
-  - v1_name: glean
-    description: Modern cross-platform telemetry (old)
-    deprecated: true
-    notification_emails:
-      - frank@mozilla.com
-      - mdroettboom@mozilla.com
-    url: https://github.com/mozilla/glean
-    branch: main
-    metrics_files:
-      - glean-core/android/metrics.yaml
-      - glean-core/metrics.yaml
-    ping_files:
-      - glean-core/pings.yaml
-    library_names: []
-
-  - v1_name: glean-deprecated
-    description: Modern cross-platform telemetry (old)
-    deprecated: true
-    notification_emails:
-      - frank@mozilla.com
-      - mdroettboom@mozilla.com
-    url: https://github.com/mozilla/glean
-    branch: main
-    metrics_files:
-      - glean-core/android/metrics.yaml
-      - glean-core/metrics.yaml
-    ping_files:
-      - glean-core/pings.yaml
-    library_names:
-      - org.mozilla.deprecated:glean
-
-  - v1_name: lib-crash
+  - library_name: lib-crash
     description: >-
       A generic crash reporter component that can report crashes to multiple
       services
@@ -75,26 +43,28 @@ libraries:
       - mdroettboom@mozilla.com
       - android-components-team@mozilla.com
     url: https://github.com/mozilla-mobile/android-components
-    metrics_files:
-      - components/lib/crash/metrics.yaml
-    library_names:
-      - org.mozilla.components:lib-crash
+    variants:
+      - v1_name: lib-crash
+        metrics_files:
+          - components/lib/crash/metrics.yaml
+        dependency_name: org.mozilla.components:lib-crash
 
-  - v1_name: sync
+  - library_name: sync
     description: Sync telemetry helper functionality
     notification_emails:
       - frank@mozilla.com
       - lina@mozilla.com
       - grisha@mozilla.com
     url: https://github.com/mozilla-mobile/android-components
-    metrics_files:
-      - components/support/sync-telemetry/metrics.yaml
-    ping_files:
-      - components/support/sync-telemetry/pings.yaml
-    library_names:
-      - org.mozilla.components:support-sync-telemetry
+    variants:
+      - v1_name: sync
+        metrics_files:
+          - components/support/sync-telemetry/metrics.yaml
+        ping_files:
+          - components/support/sync-telemetry/pings.yaml
+        dependency_name: org.mozilla.components:support-sync-telemetry
 
-  - v1_name: engine-gecko
+  - library_name: engine-gecko
     description: GeckoView metrics
     notification_emails:
       - frank@mozilla.com
@@ -102,40 +72,23 @@ libraries:
       - android-components-team@mozilla.com
       - geckoview-team@mozilla.com
     url: https://github.com/mozilla/gecko-dev
-    metrics_files:
-      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-    branch: release
-    library_names:
-      - org.mozilla.components:browser-engine-gecko
+    variants:
+      - v1_name: engine-gecko
+        branch: release
+        metrics_files:
+          - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+        dependency_name: org.mozilla.components:browser-engine-gecko
+      - v1_name: engine-gecko-beta
+        branch: beta
+        metrics_files:
+          - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+        dependency_name: org.mozilla.components:browser-engine-gecko-beta
+      - v1_name: engine-gecko-nightly
+        metrics_files:
+          - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
+        dependency_name: org.mozilla.components:browser-engine-gecko-nightly
 
-  - v1_name: engine-gecko-beta
-    description: GeckoView metrics
-    notification_emails:
-      - frank@mozilla.com
-      - mdroettboom@mozilla.com
-      - android-components-team@mozilla.com
-      - geckoview-team@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
-    metrics_files:
-      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-    branch: beta
-    library_names:
-      - org.mozilla.components:browser-engine-gecko-beta
-
-  - v1_name: engine-gecko-nightly
-    description: GeckoView metrics
-    notification_emails:
-      - frank@mozilla.com
-      - mdroettboom@mozilla.com
-      - android-components-team@mozilla.com
-      - geckoview-team@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
-    metrics_files:
-      - toolkit/components/telemetry/geckoview/streaming/metrics.yaml
-    library_names:
-      - org.mozilla.components:browser-engine-gecko-nightly
-
-  - v1_name: logins-store
+  - library_name: logins-store
     description: >-
       A collection of Android libraries to build browsers or browser-like
       applications
@@ -144,27 +97,29 @@ libraries:
       - lina@mozilla.com
       - sync-team@mozilla.com
     url: https://github.com/mozilla/application-services
-    metrics_files:
-      - components/logins/android/metrics.yaml
-    branch: main
-    library_names:
-      - org.mozilla.appservices:logins
+    variants:
+      - v1_name: logins-store
+        branch: main
+        metrics_files:
+          - components/logins/android/metrics.yaml
+        dependency_name: org.mozilla.appservices:logins
 
-  - v1_name: support-migration
+  - library_name: support-migration
     description: >-
       Helper code to migrate from a Fennec-based (Firefox for Android) app to
       an Android Components based app
     notification_emails:
       - frank@mozilla.com
     url: https://github.com/mozilla-mobile/android-components
-    metrics_files:
-      - components/support/migration/metrics.yaml
-    ping_files:
-      - components/support/migration/pings.yaml
-    library_names:
-      - org.mozilla.components:support-migration
+    variants:
+      - v1_name: support-migration
+        metrics_files:
+          - components/support/migration/metrics.yaml
+        ping_files:
+          - components/support/migration/pings.yaml
+        dependency_name: org.mozilla.components:support-migration
 
-  - v1_name: android-places
+  - library_name: android-places
     description: >-
       A collection of Android libraries to build browsers or browser-like
       applications
@@ -172,25 +127,28 @@ libraries:
       - frank@mozilla.com
       - sync-team@mozilla.com
     url: https://github.com/mozilla/application-services
-    metrics_files:
-      - components/places/android/metrics.yaml
-    branch: main
-    library_names:
-      - org.mozilla.components:places
-  - v1_name: glean-js
+    variants:
+      - v1_name: android-places
+        branch: main
+        metrics_files:
+          - components/places/android/metrics.yaml
+        dependency_name: org.mozilla.components:places
+
+  - library_name: glean-js
     description: Modern cross-platform telemetry (Javascript library)
     notification_emails:
       - frank@mozilla.com
       - mdroettboom@mozilla.com
       - brizental@mozilla.com
     url: https://github.com/mozilla/glean.js
-    branch: main
-    metrics_files:
-      - glean/src/metrics.yaml
-    ping_files:
-      - glean/src/pings.yaml
-    library_names:
-      - glean-js
+    variants:
+      - v1_name: glean-js
+        branch: main
+        metrics_files:
+        - glean/src/metrics.yaml
+        ping_files:
+        - glean/src/pings.yaml
+        dependency_name: glean-js
 
 # See https://mozilla.github.io/probe-scraper/#tag/application
 applications:
@@ -205,11 +163,13 @@ applications:
     ping_files:
       - toolkit/components/glean/pings.yaml
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: firefox-desktop
         app_id: firefox-desktop
-
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)
@@ -282,7 +242,10 @@ applications:
       - Client/metrics.yaml
     branch: main
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: firefox-ios-release
         app_id: org.mozilla.ios.Firefox
@@ -392,7 +355,10 @@ applications:
     ping_files:
       - mozregression/pings.yaml
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: mozregression
         app_id: org.mozilla.mozregression
@@ -409,7 +375,10 @@ applications:
     ping_files:
       - application/src/burnham/config/pings.yaml
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     prototype: false
     channels:
       - v1_name: burnham
@@ -426,7 +395,10 @@ applications:
     ping_files:
       - mozphab/pings.yaml
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: mozphab
         app_id: mozphab
@@ -472,7 +444,10 @@ applications:
     ping_files:
       - python/mach/pings.yaml
     dependencies:
-      - org.mozilla.deprecated:glean
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: mach
         app_id: mozilla-mach

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -145,9 +145,9 @@ libraries:
       - v1_name: glean-js
         branch: main
         metrics_files:
-        - glean/src/metrics.yaml
+          - glean/src/metrics.yaml
         ping_files:
-        - glean/src/pings.yaml
+          - glean/src/pings.yaml
         dependency_name: glean-js
 
 # See https://mozilla.github.io/probe-scraper/#tag/application

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -100,18 +100,28 @@ def proper_repo(branch="master"):
         "version": "2",
         "libraries": [
             {
-                "v1_name": "glean",
+                "library_name": "glean-core",
                 "description": "foo",
                 "notification_emails": ["frank@mozilla.com"],
                 "url": location,
-                "library_names": ["org.mozilla.components:service-glean"],
+                "variants": [
+                    {
+                        "v1_name": "glean",
+                        "dependency_name": "org.mozilla.components:service-glean",
+                    }
+                ],
             },
             {
-                "v1_name": "boollib",
+                "library_name": "boollib",
                 "description": "foo",
                 "notification_emails": ["frank@mozilla.com"],
                 "url": location,
-                "library_names": ["org.mozilla.components:lib-crash"],
+                "variants": [
+                    {
+                        "v1_name": "boollib",
+                        "dependency_name": "org.mozilla.components:lib-crash",
+                    }
+                ],
             },
         ],
         "applications": [
@@ -296,12 +306,17 @@ def test_check_for_duplicate_metrics(normal_duplicate_repo, duplicate_repo):
         "version": "2",
         "libraries": [
             {
-                "v1_name": "mylib",
+                "library_name": "mylib",
                 "description": "foo",
                 "notification_emails": ["repo_alice@example.com"],
                 "url": normal_duplicate_repo,
-                "metrics_files": ["metrics.yaml"],
-                "library_names": ["duplicate_library"],
+                "variants": [
+                    {
+                        "v1_name": "mylib",
+                        "metrics_files": ["metrics.yaml"],
+                        "dependency_name": "duplicate_library",
+                    }
+                ],
             },
         ],
         "applications": [


### PR DESCRIPTION
This is a proof of concept for specify library names in a way that is unique per-repository. The idea is that we could then put this parameter into the metrics themselves, so we can route edits to the metric annotations repository correctly (i.e. an edit to a metric annotation for glean-core should be under the glean-core namespace, irrespective of which application you're getting commentary on). See also mozilla/glean-dictionary#457.

It may also be interesting/useful to expose other metadata about libraries in the Glean Dictionary. Not sure if that belongs in this PR or in a followup. At least this gets the ball rolling.

@jklukas @fbertsch curious if you have any early feedback on this approach. Consider the edits to `repositories.yaml` a mini-proposal of sorts.