### PR TITLE
Library endpoint updates

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -174,16 +174,13 @@ class RepositoriesParser(object):
         repos_v2 = self.parse_v2(filename)
         repos = {}
         for lib in repos_v2["libraries"]:
-            variants = lib.pop("variants")
-            for variant in variants:
-                lib_info = {**lib, **variant}
-                v1_name = lib_info["v1_name"]
-                lib_info["library_names"] = [lib_info["dependency_name"]]
-                lib_info["app_id"] = v1_name
-                del lib_info["library_name"]
-                del lib_info["dependency_name"]
-                del lib_info["v1_name"]
-                repos[v1_name] = lib_info
+            v1_name = lib["v1_name"]
+            lib["library_names"] = [lib["dependency_name"]]
+            lib["app_id"] = v1_name
+            del lib["library_name"]
+            del lib["dependency_name"]
+            del lib["v1_name"]
+            repos[v1_name] = lib
         for app in repos_v2["applications"]:
             app_channel = app.pop("app_channel", None)
             if app_channel is not None:

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -157,8 +157,16 @@ class RepositoriesParser(object):
                 model_validation.validate_as(listing, "Application")
                 app_listings.append(listing)
 
+        library_listings = []
+        for lib in repos["libraries"]:
+            variants = lib.pop("variants")
+            for variant in variants:
+                listing = {**lib, **variant}
+                model_validation.validate_as(listing, "Library")
+                library_listings.append(listing)
+
         return {
-            "libraries": repos["libraries"],
+            "libraries": library_listings,
             "applications": app_listings,
         }
 

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -45,7 +45,6 @@ tags:
     description: |
       **⚠** The v2 API is in-development and subject to change without notice. **Do not** depend on it in production!
 
-
 x-tagGroups:
   - name: Input Formats
     tags:
@@ -470,6 +469,41 @@ components:
           $ref: "#/components/schemas/PrototypeBool"
         retention_days:
           $ref: "#/components/schemas/RetentionDays"
+
+    Library:
+      type: object
+      additionalProperties: false
+      required:
+        - library_name
+        - description
+        - notification_emails
+        - url
+        - variants
+        - dependency_name
+        - v1_name
+      properties:
+        library_name:
+          $ref: "#/components/schemas/LibraryName"
+        description:
+          $ref: "#/components/schemas/Description"
+        notification_emails:
+          $ref: "#/components/schemas/NotificationEmails"
+        url:
+          $ref: "#/components/schemas/RepoUrl"
+        metrics_files:
+          $ref: "#/components/schemas/MetricsFiles"
+        ping_files:
+          $ref: "#/components/schemas/PingFiles"
+        variants:
+          $ref: "#/components/schemas/LibraryVariants"
+        v1_name:
+          $ref: "#/components/schemas/V1Name"
+        deprecated:
+          $ref: "#/components/schemas/DeprecatedBool"
+        branch:
+          $ref: "#/components/schemas/RepoBranch"
+        dependency_name:
+          $ref: "#/components/schemas/DependencyName"
 
     V1Name:
       type: string

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -226,6 +226,26 @@ paths:
                 items:
                   $ref: "#/components/schemas/Application"
 
+  /v2/glean/library-variants:
+    get:
+      summary: "v2 Glean library variants"
+      tags:
+        - v2
+      description: |
+        Flattened view of all Glean library variant (one entry per `dependency_name`).
+
+        **⚠** The v2 API is in-development and subject to change without notice. **Do not** depend on it in production!
+      operationId: "getLibraryVariants"
+      responses:
+        "200":
+          description: "successful operation"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Library"
+
 components:
   schemas:
     RepositoriesYamlV1:
@@ -478,7 +498,6 @@ components:
         - description
         - notification_emails
         - url
-        - variants
         - dependency_name
         - v1_name
       properties:
@@ -494,8 +513,6 @@ components:
           $ref: "#/components/schemas/MetricsFiles"
         ping_files:
           $ref: "#/components/schemas/PingFiles"
-        variants:
-          $ref: "#/components/schemas/LibraryVariants"
         v1_name:
           $ref: "#/components/schemas/V1Name"
         deprecated:


### PR DESCRIPTION
* Unnests the `library-variants` endpoint, this is what @jklukas originally asked for and is actually closer to what's needed by the Glean Dictionary for metric annotations
* Add an OpenAPI definition for `library-variants`