### PR TITLE
Add an index file to the root of the deploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[headers]]
-  for = "/index.html"
-
-  [headers.values]
-    Content-Type = "text/html"
-
-[[headers]]
   for = "/*"
 
   [headers.values]
     Content-Type = "application/json"
+
+[[headers]]
+  for = "/"
+
+  [headers.values]
+    Content-Type = "text/html"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[headers]]
-  for = "/*"
-
-  [headers.values]
-    Content-Type = "application/json"
-
-[[headers]]
   for = "/index.html"
 
   [headers.values]
     Content-Type = "text/html"
+
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+    Content-Type = "application/json"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "^(?!\/index\.html).*$"
+
+  [headers.values]
+    content-type = "application/json"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,11 @@
 [[headers]]
-  # Define which paths this specific [[headers]] block will cover.
-  for = "^(?!\/index\.html).*$"
+  for = "/*"
 
   [headers.values]
-    content-type = "application/json"
+    Content-Type = "application/json"
+
+[[headers]]
+  for = "/index.html"
+
+  [headers.values]
+    Content-Type = "text/html"

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -101,6 +101,13 @@ def write_moz_central_probe_data(probe_data, revisions, out_dir):
 
 def write_general_data(out_dir):
     dump_json(general_data(), out_dir, "general")
+    open(os.path.join(out_dir, "index.html"), 'w').write(
+        "<html><head><title>Mozilla Probe Info</title></head>"
+        "<body>This site contains metadata used by Mozilla's data collection "
+        "infrastructure, for more information see "
+        "<a href=\"https://mozilla.github.io/probe-scraper/\">the generated documentation</a>."
+        "</body></html>"
+    )
 
 
 def write_glean_metric_data(metrics, dependencies, out_dir):

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -103,11 +103,13 @@ def write_general_data(out_dir):
     dump_json(general_data(), out_dir, "general")
     with open(os.path.join(out_dir, "index.html"), "w") as f:
         f.write(
-            "<html><head><title>Mozilla Probe Info</title></head>"
-            "<body>This site contains metadata used by Mozilla's data collection "
-            "infrastructure, for more information see "
-            '<a href="https://mozilla.github.io/probe-scraper/">the generated documentation</a>.'
-            "</body></html>"
+            """
+            <html><head><title>Mozilla Probe Info</title></head>
+            <body>This site contains metadata used by Mozilla's data collection
+            infrastructure, for more information see "
+            <a href=\"https://mozilla.github.io/probe-scraper/\">the generated documentation</a>.
+            </body></html>
+            """
         )
 
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -101,11 +101,11 @@ def write_moz_central_probe_data(probe_data, revisions, out_dir):
 
 def write_general_data(out_dir):
     dump_json(general_data(), out_dir, "general")
-    open(os.path.join(out_dir, "index.html"), 'w').write(
+    open(os.path.join(out_dir, "index.html"), "w").write(
         "<html><head><title>Mozilla Probe Info</title></head>"
         "<body>This site contains metadata used by Mozilla's data collection "
         "infrastructure, for more information see "
-        "<a href=\"https://mozilla.github.io/probe-scraper/\">the generated documentation</a>."
+        '<a href="https://mozilla.github.io/probe-scraper/">the generated documentation</a>.'
         "</body></html>"
     )
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -101,13 +101,14 @@ def write_moz_central_probe_data(probe_data, revisions, out_dir):
 
 def write_general_data(out_dir):
     dump_json(general_data(), out_dir, "general")
-    open(os.path.join(out_dir, "index.html"), "w").write(
-        "<html><head><title>Mozilla Probe Info</title></head>"
-        "<body>This site contains metadata used by Mozilla's data collection "
-        "infrastructure, for more information see "
-        '<a href="https://mozilla.github.io/probe-scraper/">the generated documentation</a>.'
-        "</body></html>"
-    )
+    with open(os.path.join(out_dir, "index.html"), "w") as f:
+        f.write(
+            "<html><head><title>Mozilla Probe Info</title></head>"
+            "<body>This site contains metadata used by Mozilla's data collection "
+            "infrastructure, for more information see "
+            '<a href="https://mozilla.github.io/probe-scraper/">the generated documentation</a>.'
+            "</body></html>"
+        )
 
 
 def write_glean_metric_data(metrics, dependencies, out_dir):


### PR DESCRIPTION
This will help people understand how to get their bearings when
they reach the URL. It may also assist with making the netlify
deploy work.