### PR TITLE
Bug 1704878 - Firefox background updater

### DIFF
--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -524,7 +524,7 @@ components:
 
     V1Name:
       type: string
-      pattern: "^[a-z][a-z0-9-]{0,29}$"
+      pattern: "^[a-z][a-z0-9-]{0,39}$"
       description: Identifier used in v1 URI paths that reference a specific repository
       example: firefox-android-beta
 

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -154,26 +154,34 @@ applications:
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - chutten@mozilla.com
+    metrics_files:
+      - toolkit/components/glean/metrics.yaml
+    ping_files:
+      - toolkit/components/glean/pings.yaml
     dependencies:
       - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
     channels:
       - v1_name: firefox-desktop
         app_id: firefox-desktop
-        metrics_files:
-          - toolkit/components/glean/metrics.yaml
-        ping_files:
-          - toolkit/components/glean/pings.yaml
-        additional_dependencies:
-          # does not actually depend on glean-android, including for backwards
-          # compat
-          - org.mozilla.components:service-glean
-      - v1_name: firefox-background-updater
-        app_id: firefox-background-updater
-        description: The desktop version of Firefox's background update tasks
-        metrics_files:
-          - toolkit/mozapps/update/update_metrics.yaml
-        ping_files:
-          - toolkit/mozapps/update/update_pings.yaml
+
+  - app_name: firefox_desktop_background_updater
+    canonical_app_name: Firefox for Desktop Background Updater
+    app_description: >-
+      The desktop version of Firefox's background update tasks. This is
+      considered a seperate application because it has its own client
+      id and sends its own version of the standard pings.
+    metrics_files:
+      - toolkit/mozapps/update/update_metrics.yaml
+    ping_files:
+      - toolkit/mozapps/update/update_pings.yaml
+    dependencies:
+      - glean-core
+    channels:
+      - v1_name: firefox-desktop-background-updater
+        app_id: firefox-desktop-background-updater
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -173,6 +173,9 @@ applications:
       The desktop version of Firefox's background update tasks. This is
       considered a seperate application because it has its own client
       id and sends its own version of the standard pings.
+    url: https://github.com/mozilla/gecko-dev
+    notification_emails:
+      - chutten@mozilla.com
     metrics_files:
       - toolkit/mozapps/update/update_metrics.yaml
     ping_files:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -184,7 +184,7 @@ applications:
       - glean-core
     channels:
       - v1_name: firefox-desktop-background-updater
-        app_id: firefox-desktop-background-updater
+        app_id: firefox.desktop.backgroundupdate
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -180,10 +180,10 @@ applications:
       - v1_name: firefox-desktop
         app_id: firefox.desktop
 
-  - app_name: firefox_desktop_background_updater
-    canonical_app_name: Firefox for Desktop Background Updater
+  - app_name: firefox_desktop_background_update
+    canonical_app_name: Firefox for Desktop Background Update Task
     app_description: >-
-      The desktop version of Firefox's background update tasks. This is
+      Firefox Desktop's background update task. This is
       considered a separate application because it has its own client
       id and sends its own version of the standard pings.
     url: https://github.com/mozilla/gecko-dev
@@ -196,8 +196,8 @@ applications:
     dependencies:
       - glean-core
     channels:
-      - v1_name: firefox-desktop-background-updater
-        app_id: firefox.desktop.backgroundupdate
+      - v1_name: firefox-desktop-background-update
+        app_id: firefox.desktop.background.update
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -177,9 +177,9 @@ applications:
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
-      - toolkit/mozapps/update/update_metrics.yaml
+      - toolkit/mozapps/update/metrics.yaml
     ping_files:
-      - toolkit/mozapps/update/update_pings.yaml
+      - toolkit/mozapps/update/pings.yaml
     dependencies:
       - glean-core
     channels:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -184,7 +184,7 @@ applications:
     canonical_app_name: Firefox for Desktop Background Updater
     app_description: >-
       The desktop version of Firefox's background update tasks. This is
-      considered a seperate application because it has its own client
+      considered a separate application because it has its own client
       id and sends its own version of the standard pings.
     url: https://github.com/mozilla/gecko-dev
     notification_emails:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -154,18 +154,26 @@ applications:
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - chutten@mozilla.com
-    metrics_files:
-      - toolkit/components/glean/metrics.yaml
-    ping_files:
-      - toolkit/components/glean/pings.yaml
     dependencies:
       - glean-core
-      # does not actually depend on glean-android, including for backwards
-      # compat
-      - org.mozilla.components:service-glean
     channels:
       - v1_name: firefox-desktop
         app_id: firefox-desktop
+        metrics_files:
+          - toolkit/components/glean/metrics.yaml
+        ping_files:
+          - toolkit/components/glean/pings.yaml
+        additional_dependencies:
+          # does not actually depend on glean-android, including for backwards
+          # compat
+          - org.mozilla.components:service-glean
+      - v1_name: firefox-background-updater
+        app_id: firefox-background-updater
+        description: The desktop version of Firefox's background update tasks
+        metrics_files:
+          - toolkit/mozapps/update/update_metrics.yaml
+        ping_files:
+          - toolkit/mozapps/update/update_pings.yaml
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)


### PR DESCRIPTION
This is a prototype of how we might implement the background updater
as a variant of Firefox (imagine in your mind that we've changed
the schema to say "variants" instead of "channels" for applications).
