### PR TITLE
Fix app_id for firefox.desktop

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -178,7 +178,7 @@ applications:
       - org.mozilla.components:service-glean
     channels:
       - v1_name: firefox-desktop
-        app_id: firefox-desktop
+        app_id: firefox.desktop
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)


### PR DESCRIPTION
The normalized values will stay the same, so this has no effect on the pipeline.

But the intent is for this value to exactly match what's set by the application which was not the case here.

See https://searchfox.org/mozilla-central/rev/08013752b4638f01d41d2a38ca7bd741bc572c86/toolkit/components/glean/src/lib.rs#117