### PR TITLE
Add encryption to Application config

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -53,6 +53,7 @@ class Repository(object):
         self.dependencies = definition.get("dependencies", [])
         self.prototype = definition.get("prototype", False)
         self.retention_days = definition.get("retention_days", None)
+        self.encryption = definition.get("encryption", None)
 
     def get_branches(self):
         if self.branch == Repository.default_branch:

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -290,6 +290,8 @@ components:
             $ref: "#/components/schemas/PrototypeBool"
           retention_days:
             $ref: "#/components/schemas/RetentionDays"
+          encryption:
+            $ref: "#/components/schemas/Encryption"
 
     RepositoriesV1:
       type: array
@@ -326,6 +328,8 @@ components:
             $ref: "#/components/schemas/PrototypeBool"
           retention_days:
             $ref: "#/components/schemas/RetentionDays"
+          encryption:
+            $ref: "#/components/schemas/Encryption"
 
     RepositoriesYamlV2:
       type: object
@@ -381,6 +385,8 @@ components:
           $ref: "#/components/schemas/PrototypeBool"
         retention_days:
           $ref: "#/components/schemas/RetentionDays"
+        encryption:
+          $ref: "#/components/schemas/Encryption"
         channels:
           type: array
           description: >-
@@ -489,6 +495,8 @@ components:
           $ref: "#/components/schemas/PrototypeBool"
         retention_days:
           $ref: "#/components/schemas/RetentionDays"
+        encryption:
+          $ref: "#/components/schemas/Encryption"
 
     Library:
       type: object
@@ -696,6 +704,18 @@ components:
         The number of days to retain decoded ping data received for this application.
         If not specified, retention will be unlimited.
       type: integer
+
+    Encryption:
+      type: object
+      properties:
+        use_jwk:
+          type: boolean
+          description: |
+            If set to true, the pipeline will treat the entire payload as
+            a JSON Web Encryption (JWE) object in compact serialization,
+            using a private JSON Web Key (JWK) to decrypt it.
+      description: |
+        Options related to pipeline handling of encrypted fields.
 
     DependencyName:
       type: string

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -72,6 +72,14 @@
       },
       "retention_days": {
         "type": "integer"
+      },
+      "encryption": {
+        "type": "object",
+        "properties": {
+          "use_jwk": {
+            "type": "boolean"
+          }
+        }
       }
     },
     "required": [


### PR DESCRIPTION
Necessary to support https://github.com/mozilla/probe-scraper/pull/308

This field was specific in the [Glean data encryption proposal](https://docs.google.com/document/d/1Za-3Srfy2q3VnAnHoUMeBU0J-cEOTKS6EhnRZJz8q9A/edit#) but never implemented. Once this is integrated, we'll also need to make a change to mozilla-schema-generator to act on this field and put the appropriate info in `mozPipelineMetadata`.