### PR TITLE
Consistently use app-listings and library-variants internally

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -167,14 +167,14 @@ class RepositoriesParser(object):
                 library_listings.append(listing)
 
         return {
-            "libraries": library_listings,
-            "applications": app_listings,
+            "library-variants": library_listings,
+            "app-listings": app_listings,
         }
 
     def _v2_to_v1(self, filename):
         repos_v2 = self.parse_v2(filename)
         repos = {}
-        for lib in repos_v2["libraries"]:
+        for lib in repos_v2["library-variants"]:
             v1_name = lib["v1_name"]
             lib["library_names"] = [lib["dependency_name"]]
             lib["app_id"] = v1_name
@@ -182,7 +182,7 @@ class RepositoriesParser(object):
             del lib["dependency_name"]
             del lib["v1_name"]
             repos[v1_name] = lib
-        for app in repos_v2["applications"]:
+        for app in repos_v2["app-listings"]:
             app_channel = app.pop("app_channel", None)
             if app_channel is not None:
                 app["channel"] = app_channel

--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -155,19 +155,19 @@ class RepositoriesParser(object):
                     app_id.lower().replace("-", "_").replace(".", "_")
                 )
                 listing = remove_none(listing)
-                model_validation.validate_as(listing, "Application")
+                model_validation.validate_as(listing, "AppListing")
                 app_listings.append(listing)
 
-        library_listings = []
+        library_variants = []
         for lib in repos["libraries"]:
             variants = lib.pop("variants")
             for variant in variants:
                 listing = {**lib, **variant}
-                model_validation.validate_as(listing, "Library")
-                library_listings.append(listing)
+                model_validation.validate_as(listing, "LibraryVariant")
+                library_variants.append(listing)
 
         return {
-            "library-variants": library_listings,
+            "library-variants": library_variants,
             "app-listings": app_listings,
         }
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -144,7 +144,9 @@ def write_v2_data(repos, out_dir):
         repos["app-listings"], os.path.join(out_dir, "v2", "glean"), "app-listings"
     )
     dump_json(
-        repos["library-variants"], os.path.join(out_dir, "v2", "glean"), "library-variants"
+        repos["library-variants"],
+        os.path.join(out_dir, "v2", "glean"),
+        "library-variants",
     )
 
 

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -141,10 +141,10 @@ def write_repositories_data(repos, out_dir):
 
 def write_v2_data(repos, out_dir):
     dump_json(
-        repos["applications"], os.path.join(out_dir, "v2", "glean"), "app-listings"
+        repos["app-listings"], os.path.join(out_dir, "v2", "glean"), "app-listings"
     )
     dump_json(
-        repos["libraries"], os.path.join(out_dir, "v2", "glean"), "library-variants"
+        repos["library-variants"], os.path.join(out_dir, "v2", "glean"), "library-variants"
     )
 
 

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -224,7 +224,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Application"
+                  $ref: "#/components/schemas/AppListing"
 
   /v2/glean/library-variants:
     get:
@@ -244,7 +244,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Library"
+                  $ref: "#/components/schemas/LibraryVariant"
 
 components:
   schemas:
@@ -446,9 +446,9 @@ components:
         ping_files:
           $ref: "#/components/schemas/PingFiles"
         variants:
-          $ref: "#/components/schemas/LibraryVariants"
+          $ref: "#/components/schemas/LibraryVariantsYaml"
 
-    Application:
+    AppListing:
       type: object
       additionalProperties: false
       required:
@@ -498,7 +498,7 @@ components:
         encryption:
           $ref: "#/components/schemas/Encryption"
 
-    Library:
+    LibraryVariant:
       type: object
       additionalProperties: false
       required:
@@ -665,7 +665,7 @@ components:
         A unique identifier for this library, applicable across all variants of it.
       example: glean-core
 
-    LibraryVariants:
+    LibraryVariantsYaml:
       type: array
       description: |
         Variants of this library.
@@ -978,7 +978,7 @@ components:
             version: 0
           name: app.opened_as_default_browser
           type: counter
-    Library:
+    LibraryVariant:
       value:
         v1_name: glean-core
         description: Modern cross-platform telemetry (core library)


### PR DESCRIPTION
This is a helpful step to enable adding endpoints for "applications"
and "libraries", which are nested views of this info.

It's currently confusing that we use "applications" for the flattened
data internally, but use app-listings for that concept in the API.