### PR TITLE
Bug 1715216 - Allow products to opt-out of automated docs

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -54,6 +54,7 @@ class Repository(object):
         self.prototype = definition.get("prototype", False)
         self.retention_days = definition.get("retention_days", None)
         self.encryption = definition.get("encryption", None)
+        self.skip_documentation = definition.get("skip_documentation", False)
 
     def get_branches(self):
         if self.branch == Repository.default_branch:

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -730,7 +730,7 @@ components:
       default: false
       description: |
         Set to `true` if the application does not want to show up in automated
-        documentation tools (e.g. Glean Dictionary).
+        documentation tools (e.g. the Glean Dictionary).
 
     DependencyName:
       type: string

--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -292,6 +292,8 @@ components:
             $ref: "#/components/schemas/RetentionDays"
           encryption:
             $ref: "#/components/schemas/Encryption"
+          skip_documentation:
+            $ref: "#/components/schemas/SkipDocumentationBool"
 
     RepositoriesV1:
       type: array
@@ -330,6 +332,8 @@ components:
             $ref: "#/components/schemas/RetentionDays"
           encryption:
             $ref: "#/components/schemas/Encryption"
+          skip_documentation:
+            $ref: "#/components/schemas/SkipDocumentationBool"
 
     RepositoriesYamlV2:
       type: object
@@ -387,6 +391,8 @@ components:
           $ref: "#/components/schemas/RetentionDays"
         encryption:
           $ref: "#/components/schemas/Encryption"
+        skip_documentation:
+          $ref: "#/components/schemas/SkipDocumentationBool"
         channels:
           type: array
           description: >-
@@ -497,6 +503,8 @@ components:
           $ref: "#/components/schemas/RetentionDays"
         encryption:
           $ref: "#/components/schemas/Encryption"
+        skip_documentation:
+          $ref: "#/components/schemas/SkipDocumentationBool"
 
     LibraryVariant:
       type: object
@@ -716,6 +724,13 @@ components:
             using a private JSON Web Key (JWK) to decrypt it.
       description: |
         Options related to pipeline handling of encrypted fields.
+
+    SkipDocumentationBool:
+      type: boolean
+      default: false
+      description: |
+        Set to `true` if the application does not want to show up in automated
+        documentation tools (e.g. Glean Dictionary).
 
     DependencyName:
       type: string

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -568,6 +568,7 @@ applications:
         deprecated: true
     encryption:
       use_jwk: true
+    skip_documentation: true
 
   - app_name: rally_core
     canonical_app_name: Rally Core Add-on
@@ -590,6 +591,7 @@ applications:
         app_id: rally-core
     encryption:
       use_jwk: true
+    skip_documentation: true
 
   - app_name: mozilla_vpn
     canonical_app_name: Mozilla VPN

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -80,6 +80,10 @@
             "type": "boolean"
           }
         }
+      },
+      "skip_documentation":{
+        "type": "boolean",
+        "default": false
       }
     },
     "required": [

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -99,4 +99,5 @@ def test_repositories_class(parser, correct_repos_file):
         "ping_file_paths": [],
         "prototype": False,
         "url": "www.github.com/fbertsch/mobile-metrics-example",
+        "skip_documentation": False,
     }


### PR DESCRIPTION
This enables products to express their intent of opting out of tools such as Glean Dictionary because they want to own and handle the way they are presenting their data documentation and provide additional context.