### PR TITLE
Bug 1709260 - Add Focus and Klar for Android

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -530,6 +530,48 @@ applications:
       - v1_name: firefox-klar-ios
         app_id: org.mozilla.ios.Klar
 
+  - app_name: focus_android
+    canonical_app_name: Firefox Focus for Android
+    app_description: Firefox Focus on Android. Klar is the sibling application
+    url: https://github.com/mozilla-mobile/focus-android
+    notification_emails:
+      - jalmeida@mozilla.com
+      - tlong@mozilla.com
+    branch: main
+    metrics_files:
+      - app/metrics.yaml
+    ping_files:
+      - app/pings.yaml
+    dependencies:
+      - glean-core
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:lib-crash
+    retention_days: 180
+    channels:
+      - v1_name: firefox-focus-android
+        app_id: org.mozilla.focus
+
+  - app_name: klar_android
+    canonical_app_name: Firefox Klar for Android
+    app_description: Firefox Klar on Android. Focus is the sibling application
+    url: https://github.com/mozilla-mobile/focus-android
+    notification_emails:
+      - jalmeida@mozilla.com
+      - tlong@mozilla.com
+    branch: main
+    metrics_files:
+      - app/metrics.yaml
+    ping_files:
+      - app/pings.yaml
+    dependencies:
+      - glean-core
+      - org.mozilla.components:service-glean
+      - org.mozilla.components:lib-crash
+    retention_days: 180
+    channels:
+      - v1_name: firefox-klar-android
+        app_id: org.mozilla.klar
+
   - app_name: bergamot
     canonical_app_name: Bergamot Translator
     app_description: Web extension for on-device machine translation


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1709260)

```
$ export COMMAND='python -m probe_scraper.runner --glean --dry-run --glean-repo firefox-focus-android'
$ make run

Unable to parse whitelist (/app/probe_scraper/parsers/third_party/histogram-whitelists.json). Assuming all histograms are acceptable.
Getting commits for repository firefox-focus-android
  Got 2 commits

writing output:
  ./glean/firefox-focus-android/general
  ./glean/firefox-focus-android/metrics
  ./glean/firefox-focus-android/dependencies
  ./glean/firefox-focus-android/pings
  ./glean/repositories
  ./general
  ./v2/glean/app-listings
  ./v2/glean/library-variants
```