### PR TITLE
Consider `extra_keys` as well for similarity of metrics

### DIFF
--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -294,6 +294,7 @@ def metrics_equal(def1, def2):
                 "time_unit",
                 "type",
                 "version",
+                "extra_keys",
             }
         )
     )


### PR DESCRIPTION
`extra_keys` are only set on `event` metrics.
They have a description and an (optional) type.
Some Glean users already migrated to specifying the type
and this should be exposed in the metrics listing, to be consumed and shown by e.g. the Glean Dictionary.

---

Will allow further work on https://github.com/mozilla/glean-dictionary/pull/701.
