### PR TITLE
Mark whether metrics and pings are in source code (fixes #320)

### DIFF
--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -14,6 +14,7 @@ TYPE_KEY = "type"
 REFLOG_KEY = "reflog-index"
 IN_SOURCE_KEY = "in-source"
 
+
 def is_test_probe(probe_type, name):
     if probe_type == "histogram":
         # These are test-only probes and never sent out.
@@ -309,7 +310,12 @@ def ping_equal(def1, def2):
 
 
 def metric_constructor(defn, metric):
-    return {TYPE_KEY: defn[TYPE_KEY], NAME_KEY: metric, HISTORY_KEY: [defn], IN_SOURCE_KEY: False}
+    return {
+        TYPE_KEY: defn[TYPE_KEY],
+        NAME_KEY: metric,
+        HISTORY_KEY: [defn],
+        IN_SOURCE_KEY: False,
+    }
 
 
 def ping_constructor(defn, metric):
@@ -317,7 +323,14 @@ def ping_constructor(defn, metric):
 
 
 def update_or_add_item(
-    repo_items, commit_hash, item, definition, commit_timestamps, last_timestamp, equal_fn, type_ctor
+    repo_items,
+    commit_hash,
+    item,
+    definition,
+    commit_timestamps,
+    last_timestamp,
+    equal_fn,
+    type_ctor,
 ):
     # If we've seen this item before, check previous definitions
     if item in repo_items:
@@ -347,7 +360,6 @@ def update_or_add_item(
         # if this commit has the latest timestamp for the repository, we consider
         # this object to be present "in-source" (aka in the source code and not removed)
         repo_items[item]["in-source"] = True
-
 
     return repo_items
 

--- a/tests/test_transform_probes.py
+++ b/tests/test_transform_probes.py
@@ -72,8 +72,9 @@ IN_METRICS_DATA = {
     for repo in REPOS
 }
 
+
 def _fake_metric_repo_data(in_source):
-    return { 
+    return {
         "example.duration": {
             "type": "timespan",
             "name": "example.duration",
@@ -100,15 +101,10 @@ def _fake_metric_repo_data(in_source):
         }
     }
 
-OUT_METRICS_DATA = {
-    repo: _fake_metric_repo_data(True)
-    for repo in REPOS
-}
 
-OUT_METRICS_DATA_NOT_IN_SOURCE = {
-    repo: _fake_metric_repo_data(False)
-    for repo in REPOS
-}
+OUT_METRICS_DATA = {repo: _fake_metric_repo_data(True) for repo in REPOS}
+
+OUT_METRICS_DATA_NOT_IN_SOURCE = {repo: _fake_metric_repo_data(False) for repo in REPOS}
 
 IN_PING_DATA = {
     repo: {


### PR DESCRIPTION
This will allow us to make more intelligent decisions in downstream
code like Looker or the Glean Dictionary about how to display such
objects. We may, for example, want to hide metrics which are no longer
present in the source code from Looker explores.
