### PR TITLE
Fix marking whether metrics are in source code or not

### DIFF
--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -328,7 +328,6 @@ def update_or_add_item(
     item,
     definition,
     commit_timestamps,
-    last_timestamp,
     equal_fn,
     type_ctor,
 ):
@@ -356,10 +355,10 @@ def update_or_add_item(
         defn = make_item_defn(definition, commit_hash, commit_timestamps)
         repo_items[item] = type_ctor(defn, item)
 
-    if commit_timestamps[commit_hash][1] == last_timestamp:
-        # if this commit has the latest timestamp for the repository, we consider
-        # this object to be present "in-source" (aka in the source code and not removed)
-        repo_items[item]["in-source"] = True
+    if commit_timestamps[commit_hash][1] == 0:
+        # if this commit is the first one, we consider this object to be present
+        # "in-source" (aka in the source code and not removed)
+        repo_items[item][IN_SOURCE_KEY] = True
 
     return repo_items
 
@@ -419,7 +418,6 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
             iter(commits.items()),
             key=lambda x_y: timestamp_sorter(commit_timestamps[repo_name][x_y[0]]),
         )
-        last_timestamp = max([t[1] for t in commit_timestamps[repo_name].values()])
         for commit_hash, items in sorted_commits:
             for item, definition in items.items():
                 repo_items = update_or_add_item(
@@ -428,7 +426,6 @@ def transform_by_hash(commit_timestamps, data, equal_fn, type_ctor):
                     item,
                     definition,
                     commit_timestamps[repo_name],
-                    last_timestamp,
                     equal_fn,
                     type_ctor,
                 )


### PR DESCRIPTION
In my previous approach, I was using a commit index (not a timestamp, as
I thought I was),  which is actually *lower* for the latest value. This
would work only for metrics with one history entry: other metrics would
always be marked as not "in source". The right solution is actually
really simple: just see if the metric is present in the latest commit
index ("0") -- if it is, it's in source. If it isn't, it's not. No need
to bother with timestamps at all.

Hopefully fixes #320 for good