### PR TITLE
Allow to skip certain commits with inconsistent metric files

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -32,8 +32,8 @@ MIN_DATES = {
     "mozilla-vpn": "2021-05-25 00:00:00",
 }
 
-# Some commits in projects might contain inconsistent metric files.
-# When we know the metric files are fixed in later commits we can skip those.
+# Some commits in projects might contain invalid metric files.
+# When we know these problems are fixed in later commits we can skip them.
 SKIP_COMMITS = {
     "engine-gecko": [
         "9bd9d7fa6c679f35d8cbeb157ff839c63b21a2e6"  # Missing schema update from v1 to v2


### PR DESCRIPTION
Occasionally projects might commit metric files that don't pass
validation, as recently happend on mozilla-central where the schema
update was applied separately from breaking changes to the definitions
(too many labels).

This now gives us a simple way to skip certain commits (by their commit
hash).
The probe-scraper will not try to parse these
and thus they will not show up as the commits introducing metrics,
but will be picked up after that.

---

I'm not perfectly happy with hardcoding these in the source code, but I would also like to unblock this to not further stall probe-scraper runs.