### PR TITLE
Bug 1728869 - Use `cp`, not `sync` to synchronize index.html

### DIFF
--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -453,7 +453,7 @@ def sync_output_and_cache_dirs(
                 [
                     "aws",
                     "s3",
-                    "sync",
+                    "cp",
                     f"{tmpdirname}/index.html",
                     f"s3://{output_bucket}/",
                     "--content-type",


### PR DESCRIPTION
See: https://stackoverflow.com/a/68136329/295132
