### PR TITLE
[Bug 1729938] Revert "bug 1728642 - Add desktop's `gfx/metrics.yaml`"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -170,7 +170,6 @@ applications:
     metrics_files:
       - toolkit/components/glean/metrics.yaml
       - browser/base/content/metrics.yaml
-      - gfx/metrics.yaml
     ping_files:
       - toolkit/components/glean/pings.yaml
     dependencies:


### PR DESCRIPTION
Since `gfx/metrics.yaml` got removed, we should also remove it here to make probe-scraper happy