### PR TITLE
Fix library name in repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -237,7 +237,7 @@ applications:
         app_id: org.mozilla.firefox
         app_channel: release
         additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko-release
+          - org.mozilla.components:browser-engine-gecko
         description: >-
           Release channel of Firefox for Android.
       - v1_name: firefox-android-beta


### PR DESCRIPTION
the dependency name for release omits channel:
https://github.com/mozilla/probe-scraper/blob/2d5d0638f01797d9c9cce722121484bc516f1d06/repositories.yaml#L78-L80