### PR TITLE
Make mozilla vpn's sole channel "release"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -668,6 +668,7 @@ applications:
     channels:
       - v1_name: mozilla-vpn
         app_id: mozillavpn
+        app_channel: release
 
   - app_name: rally_study_zero_one
     canonical_app_name: Rally Study-01


### PR DESCRIPTION
This provides a hint to lookml-generator that it should use the cross-app dataset "mozilla_vpn" 
instead of "mozillavpn".

See: https://github.com/mozilla/lookml-generator/blob/1e25ef91b2a1cea9abefccb2b9fdc62b7603f010/generator/namespaces.py#L167

For https://github.com/mozilla/lookml-generator/pull/269