### PR TITLE
bug 1737357 - Add processtools' metrics.yaml to repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -165,9 +165,9 @@ libraries:
       - chutten@mozilla.com
     url: https://github.com/mozilla/gecko-dev
     metrics_files:
-      - toolkit/components/glean/metrics.yaml
       - browser/base/content/metrics.yaml
       - gfx/metrics.yaml
+      - toolkit/components/glean/metrics.yaml
       - toolkit/components/processtools/metrics.yaml
     ping_files:
       - toolkit/components/glean/pings.yaml


### PR DESCRIPTION
It contains gecko metrics, not just desktop metrics.