### PR TITLE
Avoiding gcloud faults in latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
   deploy:
     docker:
-      - image: google/cloud-sdk
+      - image: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0
     working_directory: ~/mozilla/probe-scraper
     steps:
       - checkout


### PR DESCRIPTION
Pinning to a specific version until https://github.com/GoogleCloudPlatform/cloud-sdk-docker/issues/257 is taken care of and deployed.