### PR TITLE
Bug 1741655 - Allow process socket for event network.dns#trrConfirmation

### DIFF
--- a/probe_scraper/parsers/third_party/shared_telemetry_utils.py
+++ b/probe_scraper/parsers/third_party/shared_telemetry_utils.py
@@ -19,6 +19,7 @@ KNOWN_PROCESS_FLAGS = {
     "main": "Main",
     "content": "Content",
     "gpu": "Gpu",
+    "socket": "Socket",
     # Historical Values
     "all_childs": "AllChildren",  # Supporting files from before bug 1363725
 }


### PR DESCRIPTION
fixes dag failure: https://workflow.telemetry.mozilla.org/log?dag_id=probe_scraper&task_id=probe-expiry-alerts&execution_date=2021-11-16T00%3A00%3A00%2B00%3A00