### PR TITLE
bug 1742161 - Add new browser component metrics.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -165,6 +165,7 @@ libraries:
       - chutten@mozilla.com
     url: https://github.com/mozilla/gecko-dev
     metrics_files:
+      - browser/base/content/metrics.yaml
       - gfx/metrics.yaml
       - toolkit/components/glean/metrics.yaml
       - toolkit/components/processtools/metrics.yaml
@@ -183,7 +184,6 @@ applications:
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
-      - browser/base/content/metrics.yaml
       - browser/components/metrics.yaml
     dependencies:
       - gecko

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -165,7 +165,6 @@ libraries:
       - chutten@mozilla.com
     url: https://github.com/mozilla/gecko-dev
     metrics_files:
-      - browser/base/content/metrics.yaml
       - gfx/metrics.yaml
       - toolkit/components/glean/metrics.yaml
       - toolkit/components/processtools/metrics.yaml
@@ -183,6 +182,9 @@ applications:
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - chutten@mozilla.com
+    metrics_files:
+      - browser/base/content/metrics.yaml
+      - browser/components/metrics.yaml
     dependencies:
       - gecko
       - glean-core


### PR DESCRIPTION
And move browser/base's metrics.yaml to Firefox Desktop. It's Firefox Desktop-specific and won't be needed in other gecko-dependent apps.