### PR TITLE
Add CODEOWNERS for repositories.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Adding/changing the data in repositories.yaml can have large downstream
+# effects, so we're a little stricter on who can sign off on changes here.
+repositories.yaml @wlach @jklukas @relud @whd @jasonthomas


### PR DESCRIPTION
Adding/changing the data in repositories.yaml can have large downstream
effects, so we want to be a little strict on who can sign off on changes
here.
