### PR TITLE
WIP #276 Firefox desktop expiry mails and bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,13 @@ apidoc:
 
 format:
 	python3 -m black probe_scraper tests ./*.py
-	python3 -m isort probe_scraper tests ./*.py
+	python3 -m isort --profile black probe_scraper tests ./*.py
 
 lint: build
 	docker-compose run app flake8 --max-line-length 100 .
 	docker-compose run app yamllint repositories.yaml .circleci
 	docker-compose run app python -m black --check probe_scraper tests ./*.py
-	docker-compose run app python -m isort --check-only probe_scraper tests ./*.py
+	docker-compose run app python -m isort --profile black --check-only probe_scraper tests ./*.py
 
 check-repos:
 	docker-compose run app python -m probe_scraper.check_repositories

--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -143,26 +143,28 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
 
 
 EXPIRED_METRICS_EMAIL_TEMPLATE = """
-The following metrics in {repo_name} will expire in the next {expire_days} days or have already expired.
+Each metric in the following list from {repo_name} will expire in the next {expire_days} days or has already expired.
 
 {expired_metrics}
 
 What to do about this:
 
-1. If the metric is no longer needed, remove it from the `metrics.yaml` [1] file.
+1. If the metric is no longer needed, remove it from its `metrics.yaml` [1] file.
 2. If the metric is still required, resubmit a data review [2] and extend its expiration date.
 
-If you have any problems, please ask for help on the #glean Slack channel. We'll give you a hand.
+If you have any problems, please ask for help on the #glean Matrix channel[3]. We'll give you a hand.
 
 What happens if you don't fix this:
 
-The metrics listed above will stop collecting data from builds built after this expiration date, and you will continue to get this e-mail as a daily reminder.
+The metrics listed above will stop collecting data from builds built after this expiration date,
+and you will continue to get this e-mail as a reminder.
 
 Your Friendly, Neighborhood Glean Team
 
-[1] One of these files:
+[1] The correct metrics.yaml is in this list:
 {metrics_yaml_url}
 [2] https://wiki.mozilla.org/Firefox/Data_Collection
+[3] https://chat.mozilla.org/#/room/#glean:mozilla.org
 
 This is an automated message sent from probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
 """  # noqa

--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -204,6 +204,13 @@ def check_for_expired_metrics(
         for metric_name, metric in metrics.items():
             if metric["expires"] == "never":
                 continue
+
+            # `expires` field supports manual expiry, too.
+            if metric["expires"] == "expired":
+                expired_metrics.append(f"- {metric_name} manually expired")
+                addresses.update(metric["notification_emails"])
+                continue
+
             try:
                 expires = datetime.datetime.strptime(
                     metric["expires"], "%Y-%m-%d"

--- a/probe_scraper/parsers/third_party/usecounters.py
+++ b/probe_scraper/parsers/third_party/usecounters.py
@@ -9,7 +9,7 @@ import sys
 
 def read_conf(conf_filename):
     # Can't read/write from a single StringIO, so make a new one for reading.
-    stream = open(conf_filename, "rU")
+    stream = open(conf_filename)
 
     def parse_counters(stream):
         for line_num, line in enumerate(stream):

--- a/tests/test_git_scraper.py
+++ b/tests/test_git_scraper.py
@@ -50,7 +50,7 @@ def rm_if_exists(*paths):
                 shutil.rmtree(path)
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def run_before_tests():
     rm_if_exists(EMAIL_FILE, cache_dir, out_dir)
     os.mkdir(cache_dir)

--- a/tests/test_glean_checks.py
+++ b/tests/test_glean_checks.py
@@ -1,6 +1,9 @@
 import pytest
 
-from probe_scraper.glean_checks import check_for_duplicate_metrics
+from probe_scraper.glean_checks import (
+    check_for_duplicate_metrics,
+    check_for_expired_metrics,
+)
 from probe_scraper.parsers.repositories import Repository
 
 OLD_DATE = "2019-10-04 17:30:42"
@@ -21,7 +24,67 @@ def fake_repositories():
             "fake-app",
             dict(BASE_METADATA, dependencies=["glean-core", "glean-android"]),
         ),
+        Repository("firefox-desktop", dict(BASE_METADATA, dependencies=["glean-core"])),
     ]
+
+
+GLEAN_EPOCH = 1  # Not really an epoch
+
+
+@pytest.fixture
+def fake_commit_timestamps():
+    return {
+        "glean-core": {
+            "facade": (GLEAN_EPOCH, 0),
+        },
+        "glean-android": {
+            "decafc0ffee": (GLEAN_EPOCH, 0),
+        },
+        "fake-app": {
+            "coffeecafe": (GLEAN_EPOCH, 0),
+        },
+        "firefox-desktop": {
+            "31337feed": (GLEAN_EPOCH, 0),
+        },
+    }
+
+
+@pytest.fixture
+def fake_repos_metrics():
+    return {
+        "glean-core": {
+            "facade": {
+                "glean.core.metric_name": {
+                    "expires": "never",
+                    "notification_emails": ["glean-core-team@allizom.com"],
+                }
+            },
+        },
+        "glean-android": {
+            "decafc0ffee": {
+                "glean.android.metric_name": {
+                    "expires": "expired",
+                    "notification_emails": ["glean-android-team@allizom.com"],
+                }
+            },
+        },
+        "fake-app": {
+            "coffeecafe": {
+                "fake.app.metric_name": {
+                    "expires": "never",
+                    "notification_emails": ["fake-app-team@allizom.com"],
+                }
+            },
+        },
+        "firefox-desktop": {
+            "31337feed": {
+                "firefox.desktop.metric_name": {
+                    "expires": "102",
+                    "notification_emails": ["firefox-desktop-team@allizom.com"],
+                }
+            },
+        },
+    }
 
 
 def test_check_duplicate_metrics_no_duplicates(fake_repositories):
@@ -49,6 +112,7 @@ def test_check_duplicate_metrics_no_duplicates(fake_repositories):
                 }
             },
             "fake-app": {},
+            "firefox-desktop": {},
         },
         {},
     )
@@ -79,6 +143,7 @@ def test_check_duplicate_metrics_duplicates(fake_repositories):
                 },
             },
             "fake-app": {},
+            "firefox-desktop": {},
         },
         {},
     )
@@ -119,6 +184,29 @@ def test_check_duplicate_metrics_duplicates_in_the_past(fake_repositories):
                 },
             },
             "fake-app": {},
+            "firefox-desktop": {},
         },
         {},
     )
+
+
+def test_check_for_expired_metrics(
+    fake_repositories, fake_commit_timestamps, fake_repos_metrics
+):
+    emails = {}
+
+    check_for_expired_metrics(
+        fake_repositories, {}, fake_commit_timestamps, emails, 57, 14
+    )
+    assert len(emails) == 0
+
+    check_for_expired_metrics(
+        fake_repositories, fake_repos_metrics, fake_commit_timestamps, emails, 57, 14
+    )
+    assert len(emails) == 1  # One manually-expired metric
+
+    emails = {}
+    check_for_expired_metrics(
+        fake_repositories, fake_repos_metrics, fake_commit_timestamps, emails, 101, 14
+    )
+    assert len(emails) == 2  # One manually-expired metric, and one that expires in 102


### PR DESCRIPTION
Please check my approach so far. This is the largest change I've made to `probe-scraper` and so I want to make sure I'm not bull-in-a-china-shopping it.

So far this supports email sending, not bug filing (yet). Fixes some nits while I was in the neighbourhood.

For bug filing I'm thinking about importing as much as I can from `probe_expiry_alert` and calling it directly from `runner.py`, but I'm not firm on that yet.