### PR TITLE
No bug - Add min date for fb-pixel-hunt

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -29,6 +29,7 @@ MIN_DATES = {
     "firefox-desktop": "2020-07-29 00:00:00",
     "glean-js": "2020-09-21 13:35:00",
     "mozilla-vpn": "2021-05-25 00:00:00",
+    "rally-markup-fb-pixel-hunt": "2021-12-01 00:00:00",
 }
 
 # Some commits in projects might contain invalid metric files.


### PR DESCRIPTION
The `pings.yaml` file in that repo had a bug previous to this date.

Bug was fixed in this commit https://github.com/mozilla-rally/facebook-pixel-hunt/commit/c1ca461717583be19057042a4f7f227cfdc0698e#diff-86dec8486564878e8e1738a30f318cd78506f33accc39e36f9696ed3c9280d8d.

