### PR TITLE
No bug - Update rally-markup-fb-pixel-hunt minimum date again

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -29,7 +29,7 @@ MIN_DATES = {
     "firefox-desktop": "2020-07-29 00:00:00",
     "glean-js": "2020-09-21 13:35:00",
     "mozilla-vpn": "2021-05-25 00:00:00",
-    "rally-markup-fb-pixel-hunt": "2021-12-01 00:00:00",
+    "rally-markup-fb-pixel-hunt": "2021-12-04 00:00:00",
 }
 
 # Some commits in projects might contain invalid metric files.


### PR DESCRIPTION
Apologies for getting the date incorrectly before. I was poitning to the commit in the PR and not in the main branch, thus the error. Now I got the right one: https://github.com/mozilla-rally/facebook-pixel-hunt/commit/c1ca461717583be19057042a4f7f227cfdc0698e#

I also ran the dry-run incorrectly the first time around. This time I am sure I ran it correctly.