### PR TITLE
Add gecko tags.yaml, xre metrics.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -214,6 +214,8 @@ applications:
       - toolkit/mozapps/update/metrics.yaml
     ping_files:
       - toolkit/mozapps/update/pings.yaml
+    tag_files:
+      - toolkit/components/glean/tags.yaml
     dependencies:
       - glean-core
     channels:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -171,6 +171,8 @@ libraries:
       - toolkit/components/processtools/metrics.yaml
     ping_files:
       - toolkit/components/glean/pings.yaml
+    tag_files:
+      - toolkit/components/glean/tags.yaml
     variants:
       - v1_name: gecko
         dependency_name: gecko
@@ -186,6 +188,9 @@ applications:
     metrics_files:
       - browser/components/metrics.yaml
       - browser/modules/metrics.yaml
+      - toolkit/xre/metrics.yaml
+    tag_files:
+      - toolkit/components/glean/tags.yaml
     dependencies:
       - gecko
       - glean-core


### PR DESCRIPTION
Adding the tags.yaml to firefox_desktop as well since the tags are used in both

xre's metrics are Firefox Desktop only and not Gecko because XRE stands for XUL Runtime Environment,
and on Android there is no XUL.

Part of bug 1746941 and bug 1743333

Should not land until tags.yaml lands in bug 1746941