### PR TITLE
Skip tags.yaml backout in gecko-dev

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -45,6 +45,7 @@ SKIP_COMMITS = {
         "43d8cf138695faae2fca0adf44c94f47fdadfca8",  # Missing gfx/metrics.yaml
         "340c8521a54ad4d4a32dd16333676a6ff85aaec2",  # Missing toolkit/components/glean/pings.yaml
         "4520632fe0664572c5f70688595b7721d167e2d0",  # Missing toolkit/components/glean/pings.yaml
+        "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
     ],
 }
 


### PR DESCRIPTION
Fixes #395 

Tested locally via `python -m probe_scraper.runner --cache-dir .scraper_cache/ --dry-run --glean --glean-repo gecko --glean-repo firefox_desktop` which didn't fail and generated a `./glean/gecko/metrics` that had tags in them.