### PR TITLE
Fix firefox-desktop's and background-update's bouncy tags

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -47,6 +47,12 @@ SKIP_COMMITS = {
         "4520632fe0664572c5f70688595b7721d167e2d0",  # Missing toolkit/components/glean/pings.yaml
         "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
     ],
+    "firefox-desktop": [
+        "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
+    ],
+    "firefox-desktop-background-update": [
+        "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
+    ],
 }
 
 


### PR DESCRIPTION
They use the same repository and `tags.yaml` as `gecko`,
meaning they too are affected by that file landing, then being backed out,
then landing again.

Related to #396 and #395 