### PR TITLE
Add Fenix tags.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -233,6 +233,8 @@ applications:
       - app/metrics.yaml
     ping_files:
       - app/pings.yaml
+    tag_files:
+      - app/tags.yaml
     dependencies:
       - gecko
       - glean-core


### PR DESCRIPTION
Scrape Fenix tag metadata as `tags.yaml` was [recently added to the fenix repository](https://github.com/mozilla-mobile/fenix/commit/af5b2c94d3889585b5bc748866d9fa8fafc086df).