### PR TITLE
bug 1696907 - Don't early-return if one FOG repo has no expiring metrics

### DIFF
--- a/probe_scraper/fog_checks.py
+++ b/probe_scraper/fog_checks.py
@@ -284,9 +284,9 @@ def file_bugs_and_get_emails_for_expiring_metrics(
             current_metrics, latest_nightly_version
         )
 
+        print(f"Found {len(expiring_metrics)} expiring metrics in {fog_repo}.")
         if len(expiring_metrics) == 0:
-            print("No expiring metrics. Nothing to do.")
-            return
+            continue
 
         metrics_addresses = set(repo_addresses[fog_repo])
         for metric in expiring_metrics.values():


### PR DESCRIPTION
There are multiple FOG repos (two of them), so just because there are no expiring metrics in `gecko` doesn't mean there aren't 3 in `firefox-desktop`)