### PR TITLE
Switch to Ubuntu 20.04 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@
 version: 2
 jobs:
   build_and_test:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     working_directory: ~/mozilla/probe-scraper
     steps:
       - checkout


### PR DESCRIPTION
The previous default (`machine: true`) was using Ubuntu 14.04, which is now EOL and will be removed in May.
See https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/ for details.