### PR TITLE
bug 1755549 - Add new metrics.yaml for firefox-desktop

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -188,6 +188,7 @@ applications:
     metrics_files:
       - browser/components/metrics.yaml
       - browser/modules/metrics.yaml
+      - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml


### PR DESCRIPTION
Why yes, I too am surprised it took this long for Telemetry to get its own metrics.yaml.

Telemetry is considered part of firefox_desktop, not the reusable gecko portion,
despite it having systems that ship as part of geckoview.
(Noticeably GeckoView Streaming Telemetry).
This is deliberate since those few subsystems are of diminishing importance.

Should Telemetry require cross-product instrumentation in Glean,
it can add a second metrics.yaml (perhaps in `t/c/t/core`)