### PR TITLE
Skip expire checks for Glean repositories which use expire-by-version

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -219,6 +219,11 @@ def check_for_expired_metrics(
                 addresses.update(metric["notification_emails"])
                 continue
 
+            if isinstance(metric["expires"], int):
+                # Uses expire-by-version.
+                # We don't currently handle expiration checks for these.
+                continue
+
             try:
                 expires = datetime.datetime.strptime(
                     metric["expires"], "%Y-%m-%d"

--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -171,7 +171,12 @@ This is an automated message sent from probe-scraper.  See https://github.com/mo
 
 
 def check_for_expired_metrics(
-    repositories, repos_metrics, commit_timestamps, emails, expire_days=14
+    repositories,
+    repos_metrics,
+    commit_timestamps,
+    emails,
+    expire_days=14,
+    dry_run: bool = True,
 ):
     """
     Checks for all expired metrics and generates e-mails, one per repository.
@@ -179,7 +184,10 @@ def check_for_expired_metrics(
     This check is only performed on Mondays, to avoid daily spamming.
     """
     # Only perform the check on Mondays.
-    if datetime.date.today().weekday() != 0:
+    if dry_run:
+        print("Dry run! Monday or not, performing Glean expiry actions")
+    elif datetime.date.today().weekday() != 0:
+        print("Not a Monday, skipping expire checks")
         return
 
     expiration_cutoff = datetime.datetime.utcnow().date() + datetime.timedelta(

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -390,7 +390,7 @@ def load_glean_metrics(
             repositories, metrics_by_repo, emails
         )
     glean_checks.check_for_expired_metrics(
-        repositories, metrics, commit_timestamps, emails
+        repositories, metrics, commit_timestamps, emails, dry_run=dry_run
     )
 
     # FOG repos (e.g. firefox-desktop, gecko) use a different expiry mechanism.


### PR DESCRIPTION
Fenix is starting to use expire-by-version.
This was merged last night: https://github.com/mozilla-mobile/fenix/pull/23805

Without this skip probe-scraper will fail due to:

```
    expires = datetime.datetime.strptime(
TypeError: strptime() argument 1 must be str, not int
```