### PR TITLE
Fix buildhub fetcher to account for v100 and upwards

### DIFF
--- a/tests/test_buildhub.py
+++ b/tests/test_buildhub.py
@@ -102,20 +102,17 @@ def test_no_min_max_version_overlap():
         )
 
 
-# FIXME: 99 is out!
-# However >100 fails, see probe_scraper/scrapers/buildhub.py#L156
-# and the next test
-@pytest.mark.skip
+@pytest.mark.web_dependency
 def test_no_released_version():
-    channel, min_version = "release", 99
+    channel, min_version = "release", 199
     bh = Buildhub()
 
     with pytest.raises(NoDataFoundException):
         bh.get_revision_dates(channel, min_version, verbose=VERBOSE)
 
 
-def test_version_100():
-    channel, min_version = "release", 100
+def test_version_200():
+    channel, min_version = "release", 200
     bh = Buildhub()
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
The `target.version` in buildhub is a string field like `99.0a1`.
Now `"100" < "99"` in string comparison, which is what's used for the
elasticsearch-powered search API.
We therefore failed to have those versions included when asking buildhub
for a list of releases.

Fixing that is a bit more involved.
If we ask for versions from something below 100 and upwards we now
explicitly include everything between 100 and 200.
Yes, that will break on us with v200. At current release rate and if my
math is correct that's gonna be in 2029. I'm ok with not caring about
that now.

Fixes #411

---

I'm still checking if that actually impacts generating the probe information.