### PR TITLE
Bug 1764332 - Filter empty commit lines

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -76,6 +76,8 @@ def get_commits(repo, filename):
     log_format = '--format="%H{}%ct"'.format(sep)
     # include "--" to prevent error for filename not in current tree
     change_commits = repo.git.log(log_format, "--", filename).split("\n")
+    # filter out empty strings
+    change_commits = filter(None, change_commits)
     commits = set(enumerate(change_commits))
     if _file_in_repo_head(repo, filename):
         # include HEAD when it contains filename


### PR DESCRIPTION
This might happen if there are no actual commits touching the file (that
is: the file never existed).
It's an edge case and shouldn't actually happen, but might make this
more robust.

---

This would fix bug 1764332 for now, but means in the future we won't learn about these issues quite so loudely.
Not sure what's better.