### PR TITLE
Bug 1764332 - Update bergamot to point to the legacy branch

### DIFF
--- a/probe_scraper/check_repositories.py
+++ b/probe_scraper/check_repositories.py
@@ -15,9 +15,7 @@ GITHUB_RAW_URL = "https://raw.githubusercontent.com"
 REPOSITORIES = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "repositories.yaml"
 )
-EXPECTED_MISSING_FILES = {
-    ("bergamot", "src/core/ts/background-scripts/background.js/telemetry/metrics.yaml"),
-}
+EXPECTED_MISSING_FILES = {}
 validation_errors = []
 repos = RepositoriesParser().parse(REPOSITORIES)
 

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -629,10 +629,10 @@ applications:
     canonical_app_name: Bergamot Translator
     app_description: Web extension for on-device machine translation
     deprecated: true
-    url: https://github.com/mozilla-extensions/bergamot-browser-extension
+    url: https://github.com/mozilla-extensions/firefox-translations
     notification_emails:
       - epavlov@mozilla.com
-    branch: main
+    branch: legacy
     metrics_files:
       - src/core/ts/background-scripts/background.js/telemetry/metrics.yaml
     ping_files:

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,20 @@ from setuptools import setup
 setup(
     name="probe-scraper",
     version="0.1",
-    description="Scrape probe data from Firefox repositories.",
-    author="Georg Fritzsche (gfritzsche)",
-    author_email="gfritzsche@mozilla.com",
-    url="https://github.com/georgf/probe-scraper/",
+    description="Scrape metric data from Mozilla products repositories.",
+    author="Mozilla",
+    # While this is not owned by the Glean team, I could not find a better
+    # email address for this.
+    author_email="glean-team@mozilla.com",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    url="https://github.com/mozilla/probe-scraper/",
     packages=["probe_scraper"],
     license="MPL 2.0",
 )


### PR DESCRIPTION
The probe-scraper requires files to be always available and it will break if products are removed or not scrape-able. To unblock the current runs, we need to point the offending product to the legacy branch.
Moreover, since removing a product would cause problems downstream (schema generator), we remove the expectation for the missing Bergamot files.