### PR TITLE
Bug 176997 - Enable rally-citp-search-engine-usage

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -845,3 +845,34 @@ applications:
     channels:
       - v1_name: glean-dictionary
         app_id: glean-dictionary
+
+  - app_name: rally_citp_search_engine_usage
+    canonical_app_name: Search Engine Usage and Result Quality
+    app_description: |
+      In a collaboration between researchers at Princeton University’s
+      Center for Information Technology Policy and Mozilla, this study
+      examines the search engine market and how individuals interact
+      with search engines. The motivation for this research is to
+      understand how users interact with and make choices about search
+      engines. Understanding the search engine marketplace will inform
+      competition policy, promoting a diverse digital ecosystem that
+      benefits users.
+    url: https://github.com/mozilla-rally/search-engine-usage-study/
+    notification_emails:
+      - than@mozilla.com
+      - jepstein@mozilla.com
+      - betling@mozilla.com
+      - rhelmer@mozilla.com
+    branch: main
+    metrics_files:
+      - metrics.yaml
+    ping_files:
+      - pings.yaml
+    dependencies:
+      - glean-js
+    channels:
+      - v1_name: rally-citp-search-engine-usage
+        app_id: rally-citp-search-engine-usage
+    encryption:
+      use_jwk: true
+    skip_documentation: true


### PR DESCRIPTION
This is based on #415 and requires it to be merged before moving on.

Note that we can't merge this until the data-review and the bugs fields in the projects YAML files (e.g. [here](https://github.com/mozilla-rally/search-engine-usage-study/blob/eff93de9e1ca930b89dd982d063c24b050c4120d/metrics.yaml#L36)) are not updated to point to the relevant issue and data-review response.