### PR TITLE
Bug 1762997 - Do not scrape old version of the new Rally study

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -30,6 +30,7 @@ MIN_DATES = {
     "glean-js": "2020-09-21 13:35:00",
     "mozilla-vpn": "2021-05-25 00:00:00",
     "rally-markup-fb-pixel-hunt": "2021-12-04 00:00:00",
+    "rally-citp-search-engine-usage": "2022-04-15 00:00:00",
 }
 
 # Some commits in projects might contain invalid metric files.


### PR DESCRIPTION
See bug 1762997 for more context, but this boils down to older commits being temporary.