### PR TITLE
Add dom/metrics.yaml to gecko

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -174,6 +174,7 @@ libraries:
       - toolkit/components/glean/metrics.yaml
       - toolkit/components/processtools/metrics.yaml
       - dom/media/metrics.yaml
+      - dom/metrics.yaml
     ping_files:
       - toolkit/components/glean/pings.yaml
     tag_files:


### PR DESCRIPTION
dom/metrics.yaml was added in https://bugzilla.mozilla.org/show_bug.cgi?id=1759744