### PR TITLE
bug 1765429 - Add pine app to repositories.yaml

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -58,6 +58,9 @@ SKIP_COMMITS = {
         # Invalid extension/model/telemetry/metrics.yaml
         "02dc27b663178746499d092a987ec08c026ee560",
     ],
+    "pine": [
+        "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
+    ],
 }
 
 

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -191,7 +191,7 @@ applications:
     url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - chutten@mozilla.com
-    metrics_files:
+    metrics_files: # When adding here, consider if you should also add to pine.
       - browser/components/metrics.yaml
       - browser/modules/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
@@ -228,6 +228,31 @@ applications:
     channels:
       - v1_name: firefox-desktop-background-update
         app_id: firefox.desktop.background.update
+
+  - app_name: pine
+    canonical_app_name: Pinebuild
+    app_description: >-
+      The pine build of mozilla-central.
+    url: https://github.com/mozilla/gecko-dev
+    notification_emails:
+      - chutten@mozilla.com
+    metrics_files:
+      - browser/components/metrics.yaml
+      - browser/modules/metrics.yaml
+      - toolkit/components/telemetry/metrics.yaml
+      - toolkit/xre/metrics.yaml
+    tag_files:
+      - toolkit/components/glean/tags.yaml
+    dependencies:
+      - gecko
+      - glean-core
+      # does not actually depend on glean-android, including for backwards
+      # compat
+      - org.mozilla.components:service-glean
+    channels:
+      - v1_name: pine
+        app_id: pine
+    skip_documentation: true
 
   - app_name: fenix
     app_description: Firefox for Android (Fenix)


### PR DESCRIPTION
Might've been cleaner if I could've marked `firefox-desktop` as a dep, or done something refined by extracting a common dep as a "library", but this gets us where we need to be in the most understandable way, I think.