### PR TITLE
Bug 1767513 - Add the Sync/* metric files to Firefox iOS

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -303,6 +303,11 @@ applications:
     url: https://github.com/mozilla-mobile/firefox-ios
     metrics_files:
       - Client/metrics.yaml
+      # The Sync/* files are meant to be a stop-gap measure, see
+      # https://mozilla-hub.atlassian.net/browse/SYNC-3008, until
+      # the Sync component from A-S is able to send Glean metrics.
+      - Sync/metrics.yaml
+      - Sync/pings.yaml
     branch: main
     dependencies:
       - glean-core


### PR DESCRIPTION
This complements the implementation work that happened in mozilla-mobile/firefox-ios#10353

Note that the pings are marked `temp-*` to clearly spell out that these are a temporary workaround to get data out since legacy telemetry is not working as expected in Firefox iOS.

They will go away once Firefox iOS starts using the implementation of Sync from A-S that already sends Glean data.