### PR TITLE
Bug 1769579 - Use the Rally monorepo as a reference

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -698,19 +698,21 @@ applications:
     skip_documentation: true
 
   - app_name: rally_core
-    canonical_app_name: Rally Core Add-on
+    canonical_app_name: Rally Core Add-on and Web Platform
     app_description: |
-      The Rally Core Add-on orchestrates the installation
-      and the lifecycle of [Rally](https://rally.mozilla.org/)
+      The Rally Core Add-on and Web Platform orchestrates the
+      installation and the lifecycle of [Rally](https://rally.mozilla.org/)
       studies.
-    url: https://github.com/mozilla-rally/rally-core-addon
+    url: https://github.com/mozilla-rally/rally
     notification_emails:
       - than@mozilla.com
-    branch: master
+      - aagarwal@mozilla.com
+      - rhelmer@mozilla.com
+    branch: main
     metrics_files:
-      - metrics.yaml
+      - web-platform/glean/metrics.yaml
     ping_files:
-      - pings.yaml
+      - web-platform/glean/pings.yaml
     dependencies:
       - glean-js
     channels:


### PR DESCRIPTION
This changes the Rally Core Add-on entry to scrape data from the Rally monorepo instead of the legacy core-addon. The YAML
files are shared across the two projects. The team intends to use the same secure environment to process data coming from
both the add-on and the web-platform (they will use the channel and the version to distinguish them).

The dry run works fine locally:

```
python -m probe_scraper.runner --glean --glean-repo rally-core --dry-run
Unable to parse whitelist (/home/dexter/probe-scraper/probe_scraper/parsers/third_party/histogram-whitelists.json). Assuming all histograms are acceptable.
Getting commits for repository rally-core
Cloning https://github.com/mozilla-rally/rally into /tmp/tmpckky6i1i/rally-core.git
  Got 3 commits
Dry run! Monday or not, performing Glean expiry actions
Dry run! Wednesday or not, performing FOG expiry actions
No FOG-using repositories. Nothing to do.

writing output:
  ./glean/rally-core/tags
  ./glean/rally-core/general
  ./glean/rally-core/metrics
  ./glean/rally-core/dependencies
  ./glean/rally-core/pings
  ./glean/repositories
  ./general
  ./v2/glean/app-listings
  ./v2/glean/library-variants
```