### PR TITLE
Revert "Bug 1769579 - Use the Rally monorepo as a reference"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -766,21 +766,19 @@ applications:
     skip_documentation: true
 
   - app_name: rally_core
-    canonical_app_name: Rally Core Add-on and Web Platform
+    canonical_app_name: Rally Core Add-on
     app_description: |
-      The Rally Core Add-on and Web Platform orchestrates the
-      installation and the lifecycle of [Rally](https://rally.mozilla.org/)
+      The Rally Core Add-on orchestrates the installation
+      and the lifecycle of [Rally](https://rally.mozilla.org/)
       studies.
-    url: https://github.com/mozilla-rally/rally
+    url: https://github.com/mozilla-rally/rally-core-addon
     notification_emails:
       - than@mozilla.com
-      - aagarwal@mozilla.com
-      - rhelmer@mozilla.com
-    branch: main
+    branch: master
     metrics_files:
-      - web-platform/glean/metrics.yaml
+      - metrics.yaml
     ping_files:
-      - web-platform/glean/pings.yaml
+      - pings.yaml
     dependencies:
       - glean-js
     moz_pipeline_metadata_defaults:


### PR DESCRIPTION
Reverts mozilla/probe-scraper#428 which caused `metrics.labeled_boolean.user_income` to be dropped from the rally-core demographics v1 schema

```
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - --- /app/validate_schema_evolution/da26f512f0f322e06a297ffa05f2cc51d3eabc72_base-revision/rally-core.demographics.1.txt
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - +++ /app/validate_schema_evolution/97fad6adf5de1a80deb777074b36a40037fbe520_generated-schemas/rally-core.demographics.1.txt
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - @@ -46,4 +46,2 @@
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - root.metrics.labeled_boolean.user_gender.[].value BOOL
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - -root.metrics.labeled_boolean.user_income.[].key STRING
[2022-05-18 20:31:29,051] {{pod_launcher.py:149}} INFO - -root.metrics.labeled_boolean.user_income.[].value BOOL
[2022-05-18 20:31:29,052] {{pod_launcher.py:149}} INFO - root.metrics.labeled_boolean.user_origin.[].key STRING
```