### PR TITLE
Bug 1769998 - Add new toolkit/components/search/metrics.yaml to Firefox desktop and pine for scraping

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -194,6 +194,7 @@ applications:
     metrics_files: # When adding here, consider if you should also add to pine.
       - browser/components/metrics.yaml
       - browser/modules/metrics.yaml
+      - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
     tag_files:
@@ -239,6 +240,7 @@ applications:
     metrics_files:
       - browser/components/metrics.yaml
       - browser/modules/metrics.yaml
+      - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
     tag_files:


### PR DESCRIPTION
I think this should be for both desktop and pine only. Gecko doesn't apply here as Android has its own search engine management.