### PR TITLE
Bug1763467 add metadata to ping

### DIFF
--- a/probe_scraper/parsers/repositories.py
+++ b/probe_scraper/parsers/repositories.py
@@ -54,6 +54,10 @@ class Repository(object):
         self.retention_days = definition.get("retention_days", None)
         self.encryption = definition.get("encryption", None)
         self.skip_documentation = definition.get("skip_documentation", False)
+        self.moz_pipeline_metadata_defaults = definition.get(
+            "moz_pipeline_metadata_defaults", {}
+        )
+        self.moz_pipeline_metadata = definition.get("moz_pipeline_metadata", {})
 
     def get_metrics_file_paths(self):
         return self.metrics_file_paths

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -236,10 +236,15 @@ def apply_ping_specific_metadata(metadata, ping_metadata):
 def add_pipeline_metadata(pings_by_repo, repositories):
     for repo in repositories:
         metadata_defaults = repo.moz_pipeline_metadata_defaults
+        metadata_defaults['bq_dataset_family'] = repo.app_id.replace("-", "_")
+        metadata_defaults['bq_metadata_format'] =  ("pioneer" if repo.app_id.startswith("rally") else "structured")
+        
         current_pings = pings_by_repo.get(repo.name)
         for ping_name, ping in current_pings.items():
             ping_metadata = repo.moz_pipeline_metadata.get(ping_name, {})
             pipeline_metadata = copy.deepcopy(metadata_defaults)
+            pipeline_metadata['bq_table'] = ping_name.replace("-", "_") + "_v1"
+
             apply_ping_specific_metadata(pipeline_metadata, ping_metadata)
 
             if pipeline_metadata:

--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -236,14 +236,16 @@ def apply_ping_specific_metadata(metadata, ping_metadata):
 def add_pipeline_metadata(pings_by_repo, repositories):
     for repo in repositories:
         metadata_defaults = repo.moz_pipeline_metadata_defaults
-        metadata_defaults['bq_dataset_family'] = repo.app_id.replace("-", "_")
-        metadata_defaults['bq_metadata_format'] =  ("pioneer" if repo.app_id.startswith("rally") else "structured")
-        
+        metadata_defaults["bq_dataset_family"] = repo.app_id.replace("-", "_")
+        metadata_defaults["bq_metadata_format"] = (
+            "pioneer" if repo.app_id.startswith("rally") else "structured"
+        )
+
         current_pings = pings_by_repo.get(repo.name)
         for ping_name, ping in current_pings.items():
             ping_metadata = repo.moz_pipeline_metadata.get(ping_name, {})
             pipeline_metadata = copy.deepcopy(metadata_defaults)
-            pipeline_metadata['bq_table'] = ping_name.replace("-", "_") + "_v1"
+            pipeline_metadata["bq_table"] = ping_name.replace("-", "_") + "_v1"
 
             apply_ping_specific_metadata(pipeline_metadata, ping_metadata)
 

--- a/tests/test_repositories_parser.py
+++ b/tests/test_repositories_parser.py
@@ -100,4 +100,6 @@ def test_repositories_class(parser, correct_repos_file):
         "tag_file_paths": [],
         "url": "www.github.com/fbertsch/mobile-metrics-example",
         "skip_documentation": False,
+        "moz_pipeline_metadata_defaults": {},
+        "moz_pipeline_metadata": {},
     }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -173,7 +173,6 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
     assert repo_with_two_pings == result
 
 
-
 def test_add_pipeline_metadata_no_default_ping_specific(
     repo_with_one_ping, repo_with_two_pings
 ):
@@ -250,7 +249,7 @@ def test_add_pipeline_metadata_no_default_ping_specific(
                     "bq_dataset_family": "repo_1",
                     "bq_table": "ping_2_v1",
                     "bq_metadata_format": "structured",
-                }
+                },
             },
         }
     }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -93,7 +93,7 @@ def repo_with_two_pings():
     return {
         "repo1": {
             "ping1": {"name": "ping1", "in-source": True},
-            "ping2": {"name": "ping2", "in-source": False},
+            "ping-2": {"name": "ping-2", "in-source": False},
         }
     }
 
@@ -107,7 +107,7 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
             },
             "submission_timestamp_granularity": "seconds",
         },
-        "app_id": "repo1",
+        "app_id": "repo-1",
     }
     repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
     runner.add_pipeline_metadata(
@@ -120,6 +120,9 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -141,6 +144,9 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -148,10 +154,13 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
                     "submission_timestamp_granularity": "seconds",
                 },
             },
-            "ping2": {
-                "name": "ping2",
+            "ping-2": {
+                "name": "ping-2",
                 "in-source": False,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping_2_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -161,6 +170,8 @@ def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pi
             },
         }
     }
+    assert repo_with_two_pings == result
+
 
 
 def test_add_pipeline_metadata_no_default_ping_specific(
@@ -179,7 +190,7 @@ def test_add_pipeline_metadata_no_default_ping_specific(
                 ],
             }
         },
-        "app_id": "repo1",
+        "app_id": "repo-1",
     }
 
     repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
@@ -193,6 +204,9 @@ def test_add_pipeline_metadata_no_default_ping_specific(
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "jwe-mappings": {
                         "decrypted_field_path": "",
                         "source_field_path": "/payload",
@@ -209,13 +223,16 @@ def test_add_pipeline_metadata_no_default_ping_specific(
     runner.add_pipeline_metadata(
         pings_by_repo=repo_with_two_pings, repositories=repository_list
     )
-    # Notice that this result only has metadata for ping1, not ping2
+    # Notice that this result only has metadata for ping1, not ping-2
     result = {
         "repo1": {
             "ping1": {
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "jwe-mappings": {
                         "decrypted_field_path": "",
                         "source_field_path": "/payload",
@@ -226,9 +243,14 @@ def test_add_pipeline_metadata_no_default_ping_specific(
                     ],
                 },
             },
-            "ping2": {
-                "name": "ping2",
+            "ping-2": {
+                "name": "ping-2",
                 "in-source": False,
+                "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping_2_v1",
+                    "bq_metadata_format": "structured",
+                }
             },
         }
     }
@@ -258,7 +280,7 @@ def test_add_pipeline_metadata_with_default_with_ping_specfic_additions(
                 ],
             }
         },
-        "app_id": "repo1",
+        "app_id": "repo-1",
     }
     repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
     runner.add_pipeline_metadata(
@@ -271,6 +293,9 @@ def test_add_pipeline_metadata_with_default_with_ping_specfic_additions(
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -286,10 +311,13 @@ def test_add_pipeline_metadata_with_default_with_ping_specfic_additions(
                     ],
                 },
             },
-            "ping2": {
-                "name": "ping2",
+            "ping-2": {
+                "name": "ping-2",
                 "in-source": False,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo_1",
+                    "bq_table": "ping_2_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -320,7 +348,7 @@ def test_add_pipeline_metadata_with_default_with_ping_specific_override(
                 },
             }
         },
-        "app_id": "repo1",
+        "app_id": "repo.1",
     }
     repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
     runner.add_pipeline_metadata(
@@ -334,6 +362,9 @@ def test_add_pipeline_metadata_with_default_with_ping_specific_override(
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo.1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 90,
                         "collect_through_date": "2025-12-31",
@@ -341,10 +372,13 @@ def test_add_pipeline_metadata_with_default_with_ping_specific_override(
                     "submission_timestamp_granularity": "seconds",
                 },
             },
-            "ping2": {
-                "name": "ping2",
+            "ping-2": {
+                "name": "ping-2",
                 "in-source": False,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo.1",
+                    "bq_table": "ping_2_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2025-12-31",
@@ -372,7 +406,7 @@ def test_add_pipeline_metadata_with_default_with_pings_override(repo_with_two_pi
                     "delete_after_days": 90,
                 },
             },
-            "ping2": {
+            "ping-2": {
                 "expiration_policy": {"collect_through_date": "2022-12-31"},
                 "jwe-mappings": {
                     "decrypted_field_path": "",
@@ -380,7 +414,7 @@ def test_add_pipeline_metadata_with_default_with_pings_override(repo_with_two_pi
                 },
             },
         },
-        "app_id": "repo1",
+        "app_id": "repo.1",
     }
     repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
     runner.add_pipeline_metadata(
@@ -395,6 +429,9 @@ def test_add_pipeline_metadata_with_default_with_pings_override(repo_with_two_pi
                 "name": "ping1",
                 "in-source": True,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo.1",
+                    "bq_table": "ping1_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 90,
                         "collect_through_date": "2025-12-31",
@@ -402,10 +439,13 @@ def test_add_pipeline_metadata_with_default_with_pings_override(repo_with_two_pi
                     "submission_timestamp_granularity": "seconds",
                 },
             },
-            "ping2": {
-                "name": "ping2",
+            "ping-2": {
+                "name": "ping-2",
                 "in-source": False,
                 "moz_pipeline_metadata": {
+                    "bq_dataset_family": "repo.1",
+                    "bq_table": "ping_2_v1",
+                    "bq_metadata_format": "structured",
                     "expiration_policy": {
                         "delete_after_days": 180,
                         "collect_through_date": "2022-12-31",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,7 +2,10 @@ import os
 from copy import deepcopy
 from datetime import datetime
 
+import pytest
+
 from probe_scraper import runner
+from probe_scraper.parsers import repositories
 
 
 def test_add_first_appeared_dates():
@@ -78,3 +81,342 @@ def test_trailing_space(tmp_path):
                     trailing_spaces += 1
 
         assert not trailing_spaces
+
+
+@pytest.fixture
+def repo_with_one_ping():
+    return {"repo1": {"ping1": {"name": "ping1", "in-source": True}}}
+
+
+@pytest.fixture
+def repo_with_two_pings():
+    return {
+        "repo1": {
+            "ping1": {"name": "ping1", "in-source": True},
+            "ping2": {"name": "ping2", "in-source": False},
+        }
+    }
+
+
+def test_add_pipeline_metadata_with_default(repo_with_one_ping, repo_with_two_pings):
+    repo_config = {
+        "moz_pipeline_metadata_defaults": {
+            "expiration_policy": {
+                "delete_after_days": 180,
+                "collect_through_date": "2025-12-31",
+            },
+            "submission_timestamp_granularity": "seconds",
+        },
+        "app_id": "repo1",
+    }
+    repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_one_ping, repositories=repository_list
+    )
+
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            }
+        }
+    }
+    assert repo_with_one_ping == result
+
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_two_pings, repositories=repository_list
+    )
+    # Notice that the metadata defaults are present in both pings
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+            "ping2": {
+                "name": "ping2",
+                "in-source": False,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+        }
+    }
+
+
+def test_add_pipeline_metadata_no_default_ping_specific(
+    repo_with_one_ping, repo_with_two_pings
+):
+    repo_config = {
+        "moz_pipeline_metadata": {
+            "ping1": {
+                "jwe-mappings": {
+                    "decrypted_field_path": "",
+                    "source_field_path": "/payload",
+                },
+                "override_attributes": [
+                    {"name": "geo_city", "value": "a_city"},
+                    {"name": "geo_subdivision1", "value": "sub"},
+                ],
+            }
+        },
+        "app_id": "repo1",
+    }
+
+    repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_one_ping, repositories=repository_list
+    )
+
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "jwe-mappings": {
+                        "decrypted_field_path": "",
+                        "source_field_path": "/payload",
+                    },
+                    "override_attributes": [
+                        {"name": "geo_city", "value": "a_city"},
+                        {"name": "geo_subdivision1", "value": "sub"},
+                    ],
+                },
+            }
+        }
+    }
+    assert repo_with_one_ping == result
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_two_pings, repositories=repository_list
+    )
+    # Notice that this result only has metadata for ping1, not ping2
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "jwe-mappings": {
+                        "decrypted_field_path": "",
+                        "source_field_path": "/payload",
+                    },
+                    "override_attributes": [
+                        {"name": "geo_city", "value": "a_city"},
+                        {"name": "geo_subdivision1", "value": "sub"},
+                    ],
+                },
+            },
+            "ping2": {
+                "name": "ping2",
+                "in-source": False,
+            },
+        }
+    }
+    assert repo_with_two_pings == result
+
+
+def test_add_pipeline_metadata_with_default_with_ping_specfic_additions(
+    repo_with_two_pings,
+):
+    repo_config = {
+        "moz_pipeline_metadata_defaults": {
+            "expiration_policy": {
+                "delete_after_days": 180,
+                "collect_through_date": "2025-12-31",
+            },
+            "submission_timestamp_granularity": "seconds",
+        },
+        "moz_pipeline_metadata": {
+            "ping1": {
+                "jwe-mappings": {
+                    "decrypted_field_path": "",
+                    "source_field_path": "/payload",
+                },
+                "override_attributes": [
+                    {"name": "geo_city", "value": "a_city"},
+                    {"name": "geo_subdivision1", "value": "sub"},
+                ],
+            }
+        },
+        "app_id": "repo1",
+    }
+    repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_two_pings, repositories=repository_list
+    )
+    # Notice that the ping1 specific metadata is in addition to the default_metadata
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                    "jwe-mappings": {
+                        "decrypted_field_path": "",
+                        "source_field_path": "/payload",
+                    },
+                    "override_attributes": [
+                        {"name": "geo_city", "value": "a_city"},
+                        {"name": "geo_subdivision1", "value": "sub"},
+                    ],
+                },
+            },
+            "ping2": {
+                "name": "ping2",
+                "in-source": False,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+        }
+    }
+    assert repo_with_two_pings == result
+
+
+def test_add_pipeline_metadata_with_default_with_ping_specific_override(
+    repo_with_two_pings,
+):
+    repo_config = {
+        "moz_pipeline_metadata_defaults": {
+            "expiration_policy": {
+                "delete_after_days": 180,
+                "collect_through_date": "2025-12-31",
+            },
+            "submission_timestamp_granularity": "seconds",
+        },
+        "moz_pipeline_metadata": {
+            "ping1": {
+                "expiration_policy": {
+                    "delete_after_days": 90,
+                },
+            }
+        },
+        "app_id": "repo1",
+    }
+    repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_two_pings, repositories=repository_list
+    )
+    # Notice that the default metadata for collect_through_date is applied to both pings, wth ping1
+    # having the ping specific value for delete_after_days
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 90,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+            "ping2": {
+                "name": "ping2",
+                "in-source": False,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+        }
+    }
+    assert repo_with_two_pings == result
+
+
+def test_add_pipeline_metadata_with_default_with_pings_override(repo_with_two_pings):
+    repo_config = {
+        "moz_pipeline_metadata_defaults": {
+            "expiration_policy": {
+                "delete_after_days": 180,
+                "collect_through_date": "2025-12-31",
+            },
+            "submission_timestamp_granularity": "seconds",
+        },
+        "moz_pipeline_metadata": {
+            "ping1": {
+                "expiration_policy": {
+                    "delete_after_days": 90,
+                },
+            },
+            "ping2": {
+                "expiration_policy": {"collect_through_date": "2022-12-31"},
+                "jwe-mappings": {
+                    "decrypted_field_path": "",
+                    "source_field_path": "/payload",
+                },
+            },
+        },
+        "app_id": "repo1",
+    }
+    repository_list = [repositories.Repository(name="repo1", definition=repo_config)]
+    runner.add_pipeline_metadata(
+        pings_by_repo=repo_with_two_pings, repositories=repository_list
+    )
+    # Notice that the default metadata for collect_through_date is applied to both pings, wth ping1
+    # having the ping specific value for delete_after_days and ping 2 adding jwe-mappings and
+    # changing collect_through_date
+    result = {
+        "repo1": {
+            "ping1": {
+                "name": "ping1",
+                "in-source": True,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 90,
+                        "collect_through_date": "2025-12-31",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+            "ping2": {
+                "name": "ping2",
+                "in-source": False,
+                "moz_pipeline_metadata": {
+                    "expiration_policy": {
+                        "delete_after_days": 180,
+                        "collect_through_date": "2022-12-31",
+                    },
+                    "jwe-mappings": {
+                        "decrypted_field_path": "",
+                        "source_field_path": "/payload",
+                    },
+                    "submission_timestamp_granularity": "seconds",
+                },
+            },
+        }
+    }
+    assert repo_with_two_pings == result


### PR DESCRIPTION
- publish moz_pipeline_metadata as a top-level field for each ping, handling default and ping specific values
- publish added bq_dataset_family, bq_metadata_format, bq_table as top-level fields for each ping
