### PR TITLE
Add @akkomar to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Adding/changing the data in repositories.yaml can have large downstream
 # effects, so we're a little stricter on who can sign off on changes here.
-repositories.yaml @jklukas @relud @chutten @whd @cmharlow
+repositories.yaml @jklukas @relud @chutten @akkomar @whd @cmharlow
 
 # The exclusion list in git_scraper.py can cause similar problems (see e.g.
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1745771)
-probe_scraper/scrapers/git_scraper.py @jklukas @relud @chutten @whd @cmharlow
+probe_scraper/scrapers/git_scraper.py @jklukas @relud @chutten @akkomar @whd @cmharlow


### PR DESCRIPTION
These files are under CODEOWNERS restriction because changes to the files in question can result in ignoring history in probe scraper, which can have the unintentional impact of deleting tables and fields from schemas.

Adding @akkomar so that there is more than one DE authorized to review changes made by another DE in the list.

@akkomar this will cause you to be automatically tagged for review on changes to `repositories.yaml` and `probe_scraper/scrapers/git_scraper.py`.