### PR TITLE
Bug 1763467  Remove unused elements in probeinfo_api.yaml and repositories.yaml

### DIFF
--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -290,10 +290,6 @@ components:
             $ref: "#/components/schemas/LibraryNames"
           prototype:
             $ref: "#/components/schemas/PrototypeBool"
-          retention_days:
-            $ref: "#/components/schemas/RetentionDays"
-          encryption:
-            $ref: "#/components/schemas/Encryption"
           moz_pipeline_metadata_defaults:
             $ref: "#/components/schemas/MozPipelineMetadataDefaults"
           moz_pipeline_metadata:
@@ -336,10 +332,6 @@ components:
             $ref: "#/components/schemas/LibraryNames"
           prototype:
             $ref: "#/components/schemas/PrototypeBool"
-          retention_days:
-            $ref: "#/components/schemas/RetentionDays"
-          encryption:
-            $ref: "#/components/schemas/Encryption"
           moz_pipeline_metadata_defaults:
             $ref: "#/components/schemas/MozPipelineMetadataDefaults"
           moz_pipeline_metadata:
@@ -401,10 +393,6 @@ components:
           $ref: "#/components/schemas/DeprecatedBool"
         prototype:
           $ref: "#/components/schemas/PrototypeBool"
-        retention_days:
-          $ref: "#/components/schemas/RetentionDays"
-        encryption:
-          $ref: "#/components/schemas/Encryption"
         moz_pipeline_metadata_defaults:
           $ref: "#/components/schemas/MozPipelineMetadataDefaults"
         moz_pipeline_metadata:
@@ -521,10 +509,6 @@ components:
           $ref: "#/components/schemas/DeprecatedBool"
         prototype:
           $ref: "#/components/schemas/PrototypeBool"
-        retention_days:
-          $ref: "#/components/schemas/RetentionDays"
-        encryption:
-          $ref: "#/components/schemas/Encryption"
         moz_pipeline_metadata_defaults:
           $ref: "#/components/schemas/MozPipelineMetadataDefaults"
         moz_pipeline_metadata:
@@ -744,16 +728,9 @@ components:
         type: string
         example: org.mozilla.components:service-glean
 
-    RetentionDays:
-      description: |
-        The number of days to retain decoded ping data received for this application.
-        If not specified, retention will be unlimited.
-      type: integer
-
     OverrideAttributes:
       type: array
       description: |
-        Currently not in use.
         Mappings of Pub/Sub attribute names to static values; these are applied in the Decoder
         immediately before incorporating metadata into the payload, so can be used to overwrite values calculated in
         the pipeline; a null value will cause the pipeline to drop the named attribute; some attribute names differ
@@ -778,26 +755,26 @@ components:
     ExpirationPolicy:
       type: object
       description: |
-        Currently not in use.  Various options controlling data lifecycle.
+        Various options controlling data lifecycle.
       additionalProperties: false
       properties:
         collect_through_date:
           type: string
           description: |
-            Currently not in use.  If present, the pipeline will reject new data with submission_timestamp after the
+            If present, the pipeline will reject new data with submission_timestamp after the
             given date, sending it to error output.  Example: `2025-12-31`
           pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
           example: "2025-12-31"
         delete_after_days:
           type: integer
           description: |
-            Currently not in use. The number of days to retain decoded ping data received for this application.
+            The number of days to retain decoded ping data received for this application.
             If not specified, retention will be unlimited.
 
     JweMappings:
       type: array
       description: |
-        Currently not in use.  Mappings of encrypted JWE field paths to destinations where the value decrypted by the
+        Mappings of encrypted JWE field paths to destinations where the value decrypted by the
         pipeline should be placed; initial use case is Account Ecosystem Telemetry; paths must be in
         [JSON Pointer format](https://tools.ietf.org/html/rfc6901) like '/payload/ecosystemAnonId'.
       items:
@@ -817,7 +794,6 @@ components:
     MozPipelineMetadataDefaults:
       type: object
       description: |
-        Currently not in use.
         Container for per-doctype metadata that can affect how pings are processed in the pipeline.
       additionalProperties: false
       properties:
@@ -830,7 +806,6 @@ components:
         submission_timestamp_granularity:
           type: string
           description: |
-            Currently not in use.
             If specified, the submission_timestamp field will be truncated to the specified
             granularity in the pipeline before being output to BigQuery; this can be used to reduce the potential for
             using time-based attacks to correlate datasets using different client-level identifiers; see Java's
@@ -845,7 +820,6 @@ components:
     MozPipelineMetadata:
       type: object
       description: |
-        Currently not in use.
         Allows ping level override of metadata values.
       additionalProperties:
         type: object
@@ -862,7 +836,6 @@ components:
           submission_timestamp_granularity:
             type: string
             description: |
-              Currently not in use.
               If specified, the submission_timestamp field will be truncated to the specified
               granularity in the pipeline before being output to BigQuery; this can be used to reduce the potential for
               using time-based attacks to correlate datasets using different client-level identifiers; see Java's
@@ -873,17 +846,6 @@ components:
               - minutes
               - hours
               - days
-    Encryption:
-      type: object
-      properties:
-        use_jwk:
-          type: boolean
-          description: |
-            If set to true, the pipeline will treat the entire payload as
-            a JSON Web Encryption (JWE) object in compact serialization,
-            using a private JSON Web Key (JWK) to decrypt it.
-      description: |
-        Options related to pipeline handling of encrypted fields.
 
     SkipDocumentationBool:
       type: boolean

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -611,7 +611,6 @@ applications:
     dependencies:
       - glean-core
       - nimbus
-    retention_days: 720
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 720
@@ -632,7 +631,6 @@ applications:
     dependencies:
       - glean-core
       - nimbus
-    retention_days: 720
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 720
@@ -658,7 +656,6 @@ applications:
       - org.mozilla.components:lib-crash
       - nimbus
       - gecko
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -697,7 +694,6 @@ applications:
       - org.mozilla.components:lib-crash
       - nimbus
       - gecko
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -719,7 +715,6 @@ applications:
       - src/core/ts/background-scripts/background.js/telemetry/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -740,7 +735,6 @@ applications:
       - extension/model/telemetry/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -762,7 +756,6 @@ applications:
       - pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -773,8 +766,6 @@ applications:
       - v1_name: rally-debug
         app_id: rally.debug
         deprecated: true
-    encryption:
-      use_jwk: true
     skip_documentation: true
 
   - app_name: rally_core
@@ -802,8 +793,6 @@ applications:
     channels:
       - v1_name: rally-core
         app_id: rally-core
-    encryption:
-      use_jwk: true
     skip_documentation: true
 
   - app_name: mozilla_vpn
@@ -822,7 +811,6 @@ applications:
       - glean/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -848,7 +836,6 @@ applications:
       - glean/pings.yaml
     dependencies:
       - glean-core
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -882,8 +869,6 @@ applications:
     channels:
       - v1_name: rally-study-zero-one
         app_id: rally-study-zero-one
-    encryption:
-      use_jwk: true
     skip_documentation: true
 
   - app_name: mlhackweek_search
@@ -924,7 +909,6 @@ applications:
       - source/telemetry/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 365
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 365
@@ -959,8 +943,6 @@ applications:
     channels:
       - v1_name: rally-markup-fb-pixel-hunt
         app_id: rally-markup-fb-pixel-hunt
-    encryption:
-      use_jwk: true
     skip_documentation: true
 
   - app_name: glean_dictionary
@@ -979,7 +961,6 @@ applications:
       - src/telemetry/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -1018,8 +999,6 @@ applications:
     channels:
       - v1_name: rally-citp-search-engine-usage
         app_id: rally-citp-search-engine-usage
-    encryption:
-      use_jwk: true
     skip_documentation: true
 
   - app_name: bedrock
@@ -1035,7 +1014,6 @@ applications:
       - glean/pings.yaml
     dependencies:
       - glean-js
-    retention_days: 180
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180


### PR DESCRIPTION
Last PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1763467
The new metadata fields (**_moz_pipeline_metadata_defaults_** and **_moz_pipeline_metadata_**) are now active.
This final step removes the now unused fields (**_retention_days_** and **_encryption_**) and updates the field descriptions.
