### PR TITLE
Fix Rally Attention Stream url

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1026,7 +1026,7 @@ applications:
     app_description: |
       The Attention Stream is an ongoing, cross-browser data collection
       to understand the state of the internet in 2022 and beyond.
-    url: https://github.com/mozilla-rally/rally/
+    url: https://github.com/mozilla-rally/rally
     notification_emails:
       - than@mozilla.com
       - betling@mozilla.com


### PR DESCRIPTION
This is a follow up to https://github.com/mozilla/probe-scraper/pull/455/files. Looks like trailing slash in the git url causes probe scraper to fail here: https://github.com/mozilla/probe-scraper/blob/30c2783d4dd229703c86d028eb6d013f343ec7a1/probe_scraper/scrapers/git_scraper.py#L157 when retrieving files.