### PR TITLE
Bug 1778196 - Skip broken commits for rally-attention-stream

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -75,6 +75,9 @@ SKIP_COMMITS = {
         "69559324f775b79c9a39c6a95fdb3657c184ed0e",  # Bug 1769579 omit deleted onboarding ping
         "f633df7676b6ef64e496fea1b3687eff22680d49",  # Missing web-platform/glean/pings.yaml
     ],
+    "rally-attention-stream": [
+        "9fd0b2aeb82ca37f817dcda51bd2f34b6925b487",  # `bugs`/`data_reviews` is not of type `string`
+    ],
 }
 
 


### PR DESCRIPTION
This skips mozilla-rally/rally@9fd0b2aeb82ca37f817dcda51bd2f34b6925b487 which contains invalid pings.yaml and metrics.yaml. We didn't catch this because the "push model" is currently not working and the Rally team landed a broken commit after I tested :-)