### PR TITLE
Update Firefox Desktop metrics_files directories

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -196,9 +196,18 @@ applications:
       - browser/components/newtab/metrics.yaml
       - browser/components/search/metrics.yaml
       - browser/modules/metrics.yaml
+      - dom/media/metrics.yaml
+      - dom/metrics.yaml
+      - gfx/metrics.yaml
+      - netwerk/protocol/http/metrics.yaml
       - toolkit/components/extensions/metrics.yaml
+      - toolkit/components/glean/metrics.yaml
+      - toolkit/components/glean/tests/test_metrics.yaml
+      - toolkit/components/nimbus/metrics.yaml
+      - toolkit/components/processtools/metrics.yaml
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
+      - toolkit/mozapps/update/metrics.yaml
       - toolkit/xre/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -196,19 +196,11 @@ applications:
       - browser/components/newtab/metrics.yaml
       - browser/components/search/metrics.yaml
       - browser/modules/metrics.yaml
-      - dom/media/metrics.yaml
-      - dom/metrics.yaml
-      - gfx/metrics.yaml
-      - netwerk/protocol/http/metrics.yaml
       - toolkit/components/extensions/metrics.yaml
-      - toolkit/components/glean/metrics.yaml
-      - toolkit/components/glean/tests/test_metrics.yaml
-      - toolkit/components/nimbus/metrics.yaml
-      - toolkit/components/processtools/metrics.yaml
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
-      - toolkit/mozapps/update/metrics.yaml
       - toolkit/xre/metrics.yaml
+      - netwerk/protocol/http/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
     tag_files:


### PR DESCRIPTION
Recently probeinfo API was not able to pick up some new Firefox Desktop metrics, such as [the new Early Hints type](https://github.com/mozilla/gecko-dev/commit/f15f91dc5652019b375263935ea59ddffc2b084c), because we did not have the most up-to-date `metrics_files` map.

I copied this list over from [toolkit/components/glean/metrics_index.py](https://github.com/mozilla/gecko-dev/blob/master/toolkit/components/glean/metrics_index.py#L14-L33), let me know if we need to leave out anything.