### PR TITLE
collect_through_date on rally-markup-fb-pixel-hunt

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -940,6 +940,8 @@ applications:
       jwe_mappings:
         - source_field_path: /payload
           decrypted_field_path: ""
+      expiration_policy:
+        collect_through_date: "2022-07-13"
     channels:
       - v1_name: rally-markup-fb-pixel-hunt
         app_id: rally-markup-fb-pixel-hunt


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1779801 - add a collect_through_date to stop data collection on the Rally/Markup FB Pixel Hunt study.