### PR TITLE
Move VPN Android app to be channel of main VPN app

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -805,13 +805,13 @@ applications:
     notification_emails:
       - vpn@mozilla.com
       - amarchesini@mozilla.com
+      - brizental@mozilla.com
     branch: main
     metrics_files:
       - glean/metrics.yaml
     ping_files:
       - glean/pings.yaml
-    dependencies:
-      - glean-js
+    dependencies: []
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
@@ -819,31 +819,14 @@ applications:
       - v1_name: mozilla-vpn
         app_id: mozillavpn
         app_channel: release
-
-  - app_name: mozilla_vpn_android
-    canonical_app_name: Mozilla VPN (Android)
-    app_description: |
-      Mozilla VPN is a VPN client application. The first
-      Mozilla premium service.
-    url: https://github.com/mozilla-mobile/mozilla-vpn-client
-    notification_emails:
-      - vpn@mozilla.com
-      - amarchesini@mozilla.com
-      - brizental@mozilla.com
-    branch: main
-    metrics_files:
-      - glean/metrics.yaml
-    ping_files:
-      - glean/pings.yaml
-    dependencies:
-      - glean-core
-    moz_pipeline_metadata_defaults:
-      expiration_policy:
-        delete_after_days: 180
-    channels:
+        additional_dependencies:
+          - glean-js
       - v1_name: mozilla-vpn-android
         app_id: org.mozilla.firefox.vpn
         app_channel: release
+        description: Mozilla VPN (Android)
+        additional_dependencies:
+          - glean-core
 
   - app_name: rally_study_zero_one
     canonical_app_name: Rally Study-01


### PR DESCRIPTION
Both are from the same [mozilla-mobile/mozilla-vpn-client](https://github.com/mozilla-mobile/mozilla-vpn-client) repo, both use the same metrics and ping files (though I understand the different Glean SDKs used may cause minor differences), and the VPN team would like unified views of all the VPN app Glean data in BigQuery & Looker ([DENG-210](https://mozilla-hub.atlassian.net/browse/DENG-210)).

Based on a dry run, the only consequential result of this change is in the v2 API the Android app's `app_name` would change from `mozilla_vpn_android` to `mozilla_vpn` (its `app_id` would remain the same).