### PR TITLE
Adding some missing Desktop components to repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -202,7 +202,7 @@ applications:
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
       - toolkit/components/nimbus/metrics.yaml
-+     - toolkit/components/pdfjs/metrics.yaml
+      - toolkit/components/pdfjs/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
     tag_files:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -201,6 +201,8 @@ applications:
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
+      - toolkit/components/nimbus/metrics.yaml
++     - toolkit/components/pdfjs/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
     tag_files:
@@ -252,6 +254,7 @@ applications:
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
+      - toolkit/components/nimbus/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
     tag_files:


### PR DESCRIPTION
Adding the pdfjs and nimbus components to firefox_desktop and also adding nimbus to pine. The pdfjs one does not currently need enabled for Pine, but may need so in the future.