### PR TITLE
Remove nimbus metric file from "pine", fix availability of nimbus metrics file and ignore deprecated library

### DIFF
--- a/probe_scraper/check_repositories.py
+++ b/probe_scraper/check_repositories.py
@@ -16,7 +16,9 @@ GITHUB_RAW_URL = "https://raw.githubusercontent.com"
 REPOSITORIES = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "repositories.yaml"
 )
-EXPECTED_MISSING_FILES: Set[Tuple[str, str]] = set()
+EXPECTED_MISSING_FILES: Set[Tuple[str, str]] = {
+    ("support-migration", "components/support/migration/metrics.yaml")
+}
 validation_errors = []
 repos = RepositoriesParser().parse(REPOSITORIES)
 

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -83,6 +83,9 @@ SKIP_COMMITS = {
     "rally-attention-stream": [
         "9fd0b2aeb82ca37f817dcda51bd2f34b6925b487",  # `bugs`/`data_reviews` is not of type `string`
     ],
+    "support-migration": [
+        "2e05b2b7d775ea726e035a7a7f16d889d63fc09a",  # No components/support/migration/metrics.yaml
+    ],
 }
 
 

--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -61,6 +61,8 @@ SKIP_COMMITS = {
     "firefox-desktop": [
         "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml
         "3e81d4efd88a83e89da56b690f39ca2a78623810",  # No browser/components/newtab/metrics.yaml
+        "d556b247aaec64b3ab6a033d40f2022f1213101e",  # No toolkit/components/nimbus/metrics.yaml
+        "d1d0b69871e3d38ead989d73f30563a501a448b6",  # No toolkit/components/nimbus/metrics.yaml
     ],
     "firefox-desktop-background-update": [
         "c5d5f045aaba41933622b5a187c39da0d6ab5d80",  # Missing toolkit/components/glean/tags.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -117,6 +117,7 @@ libraries:
     variants:
       - v1_name: support-migration
         dependency_name: org.mozilla.components:support-migration
+        deprecated: true
 
   - library_name: android-places
     description: >-

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -254,7 +254,6 @@ applications:
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml
-      - toolkit/components/nimbus/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
     tag_files:


### PR DESCRIPTION
I mistakenly thought that pine had nimbus with the Glean changes I had made, this was not the case. This removes the metric.yaml link for Nimbus under the "pine" app which should fix the failure to find the file.