### PR TITLE
bug 1785251 - Add t/c/telemetry pings.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -206,6 +206,7 @@ applications:
       - toolkit/components/pdfjs/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
+      - toolkit/components/telemetry/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
     dependencies:
@@ -257,6 +258,7 @@ applications:
       - toolkit/xre/metrics.yaml
     ping_files:
       - browser/components/newtab/pings.yaml
+      - toolkit/components/telemetry/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
     dependencies:


### PR DESCRIPTION
Tested, as usual, with `python -m probe_scraper.runner --glean --glean-repo glean-core --glean-repo glean-android --glean-repo gecko --glean-repo firefox-desktop --dry-run --cache-dir .scraper_cache/`
