### PR TITLE
Extend timeout so fenix has enough time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
             --set-env-vars=BOTO_PATH=.gce_boto,OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/
             --trigger-http
             --service-account=$PROD_SERVICE_ACCOUNT_INVOKER
+            --timeout=540s
 
   docs_build:
     docker:


### PR DESCRIPTION
540s is the maximum timeout https://cloud.google.com/functions/docs/configuring/timeout

