### PR TITLE
Expose error message for cli failures in glean_push

### DIFF
--- a/probe_scraper/exc.py
+++ b/probe_scraper/exc.py
@@ -1,4 +1,20 @@
-class ProbeScraperInvalidRequest(Exception):
+class ProbeScraperError(Exception):
+    """Exception type for returning errors in push mode."""
+
+    def __init__(self, message, status_code):
+        self.status_code = status_code
+        self.message = message
+
+
+class ProbeScraperInvalidRequest(ProbeScraperError):
     """Exception type for returning HTTP 4XX in push mode."""
 
-    pass
+    def __init__(self, message, status_code=400):
+        super().__init__(message, status_code)
+
+
+class ProbeScraperServerError(ProbeScraperError):
+    """Exception type for returning HTTP 5XX in push mode."""
+
+    def __init__(self, message, status_code=500):
+        super().__init__(message, status_code)

--- a/probe_scraper/exc.py
+++ b/probe_scraper/exc.py
@@ -2,8 +2,8 @@ class ProbeScraperError(Exception):
     """Exception type for returning errors in push mode."""
 
     def __init__(self, message, status_code):
-        self.status_code = status_code
         self.message = message
+        self.status_code = status_code
 
 
 class ProbeScraperInvalidRequest(ProbeScraperError):

--- a/probe_scraper/glean_push.py
+++ b/probe_scraper/glean_push.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 from flask import Request, Response
 
 from . import runner
-from .exc import ProbeScraperInvalidRequest
+from .exc import ProbeScraperError
 
 
 def main(request: Request) -> Response:
@@ -64,8 +64,8 @@ def main(request: Request) -> Response:
                 update=True,
                 email_file=email_file,
             )
-        except ProbeScraperInvalidRequest as e:
-            return Response(f"Error: {e}\n", 400)
+        except ProbeScraperError as e:
+            return Response(f"Error: {e.message}\n", e.status_code)
         if updated_paths:
             updates = ", ".join(str(p.relative_to(out_dir)) for p in updated_paths)
             message = f"update published for {updates}\n"


### PR DESCRIPTION
Two failures in push mode earlier today were due to gsutil throwing `Caught non-retryable exception while listing gs://probe-scraper-prod-artifacts/glean/...: Could not reach metadata service: Internal Server Error`, and it would be useful if that message were visible in ci, but right now we just get a generic 500 error message, e.g. https://github.com/mozilla-mobile/mozilla-vpn-client/runs/8021419260?check_suite_focus=true

