### PR TITLE
Bug 1790478 - Add Viu Politica to repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1093,6 +1093,7 @@ applications:
     url: https://github.com/evoluchico/viu-politica
     notification_emails:
       - chico@mozillafoundation.org
+      - ranadheer@mozillafoundation.org
     branch: main
     metrics_files:
       - source/telemetry/metrics.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1090,7 +1090,7 @@ applications:
       This is a "spin-off" of the Mozilla YouTube RegretsReporter extension.
       It is an opt-in browser extension where users can anonymously tag videos
       related to the 2022 Brazilian Elections.
-    url: https://github.com/evoluchico/viu-politica
+    url: https://github.com/mozilla/viu-politica
     notification_emails:
       - chico@mozillafoundation.org
       - ranadheer@mozillafoundation.org

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1083,3 +1083,26 @@ applications:
       - v1_name: rally-attention-stream
         app_id: rally-attention-stream
     skip_documentation: true
+
+  - app_name: viu_politica
+    canonical_app_name: Viu Politica
+    app_description: |
+      This is a "spin-off" of the Mozilla YouTube RegretsReporter extension.
+      It is an opt-in browser extension where users can anonymously tag videos
+      related to the 2022 Brazilian Elections.
+    url: https://github.com/evoluchico/viu-politica
+    notification_emails:
+      - chico@mozillafoundation.org
+    branch: main
+    metrics_files:
+      - source/telemetry/metrics.yaml
+    ping_files:
+      - source/telemetry/pings.yaml
+    dependencies:
+      - glean-js
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 365
+    channels:
+      - v1_name: viu-politica
+        app_id: viu.politica


### PR DESCRIPTION
Tried locally:

```
python -m probe_scraper.runner --glean --glean-repo viu-politica
Unable to parse whitelist (/home/dexter/probe-scraper/probe_scraper/parsers/third_party/histogram-whitelists.json). Assuming all histograms are acceptable.
Getting commits for repository viu-politica
Cloning https://github.com/evoluchico/viu-politica into /tmp/tmp7rw6yq2r/evoluchico/viu-politica.git
  Got 14 commits
Not Wednesday. Not performing FOG expiry actions.

writing output:
  glean/viu-politica/tags
  glean/viu-politica/general
  glean/viu-politica/metrics
  glean/viu-politica/dependencies
  glean/viu-politica/pings
  glean/repositories
  general
  v2/glean/app-listings
  v2/glean/library-variants
```
