### PR TITLE
Bug 1789931 - Update repositories.yaml to support the firefox-android monorepo

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -44,10 +44,10 @@ libraries:
       - dthorn@mozilla.com
       - aplacitelli@mozilla.com
       - glean-team@mozilla.com
-      - android-components-team@mozilla.com
-    url: https://github.com/mozilla-mobile/android-components
+      - android-probes@mozilla.com
+    url: https://github.com/mozilla-mobile/firefox-android
     metrics_files:
-      - components/lib/crash/metrics.yaml
+      - android-components/components/lib/crash/metrics.yaml
     variants:
       - v1_name: lib-crash
         dependency_name: org.mozilla.components:lib-crash
@@ -56,13 +56,12 @@ libraries:
     description: Sync telemetry helper functionality
     notification_emails:
       - dthorn@mozilla.com
-      - lina@mozilla.com
-      - grisha@mozilla.com
-    url: https://github.com/mozilla-mobile/android-components
+      - android-probes@mozilla.com
+    url: https://github.com/mozilla-mobile/firefox-android
     metrics_files:
-      - components/support/sync-telemetry/metrics.yaml
+      - android-components/components/support/sync-telemetry/metrics.yaml
     ping_files:
-      - components/support/sync-telemetry/pings.yaml
+      - android-components/components/support/sync-telemetry/pings.yaml
     variants:
       - v1_name: sync
         dependency_name: org.mozilla.components:support-sync-telemetry


### PR DESCRIPTION
👋 We're looking to move the https://github.com/mozilla-mobile/android-components repo into a monorepo at https://github.com/mozilla-mobile/firefox-android. You can see an initial prep branch at https://github.com/mozilla-mobile/firefox-android/tree/ac-prep.

We'll want to coordinate how we want to land this while moving to the monorepo at some point. If there is someone from the data team that can take a look at the proposed change and provide feedback, and if there are folks on the team that should be in sync of this monorepo migration to continue supporting the [glean-probe-scraper.yml](https://github.com/mozilla-mobile/firefox-android/blob/ac-prep/android-components/.github/workflows/glean-probe-scraper.yml) workflow, please let me know. Thanks