### PR TITLE
Bug 1796067 - Consider needinfo a best-effort attempt

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -243,12 +243,12 @@ def create_bug(
     except requests.exceptions.HTTPError:
         print(f"Failed to create bugs with arguments: {create_params}", file=sys.stderr)
         print(f"Error response: {create_response.text}", file=sys.stderr)
-        if needinfo and (
-            NEEDINFO_BLOCKED_TEXT in create_response.text
-            or NEEDINFO_USER_INACTIVE in create_response.text
-        ):
+        # If filing a bug failed, try again without the needinfo. Chances are the requestee
+        # accounts are inactive, disabled or no longer existing. Instead of playing whackamole
+        # with the different errors, just retry without needinfo.
+        if needinfo:
             print(
-                "Needinfo request blocked or for inactive users, retrying request without needinfo",
+                "Needinfo request failed, retrying request without needinfo",
                 file=sys.stderr,
             )
             return create_bug(


### PR DESCRIPTION
Instead of looking for specific needinfo errors, always try one more time without needinfos and hope for the best. The priorites for the probe-scraper are (a) to keep on scraping and (b) to do its best to file a bug about problems.