### PR TITLE
 Bug 1797446 - Don't cc folks as it might break

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -233,7 +233,6 @@ def create_bug(
             for email in probes[0].emails
             if needinfo
         ],
-        "cc": [email for email in probes[0].emails if not needinfo],
     }
     create_response = requests.post(
         BUGZILLA_BUG_URL, json=create_params, headers=bugzilla_request_header(api_key)

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -311,10 +311,8 @@ def test_create_bug_try_on_needinfo_blocked(mock_post):
     call_args_2 = mock_post.call_args_list[1][1]["json"]
 
     assert len(call_args_1["flags"]) == 1
-    assert len(call_args_1["cc"]) == 0
 
     assert len(call_args_2["flags"]) == 0
-    assert len(call_args_2["cc"]) == 1
 
 
 @mock.patch("requests.post")
@@ -356,10 +354,8 @@ def test_create_bug_try_on_requestee_inactive(mock_post):
     call_args_2 = mock_post.call_args_list[1][1]["json"]
 
     assert len(call_args_1["flags"]) == 1
-    assert len(call_args_1["cc"]) == 0
 
     assert len(call_args_2["flags"]) == 0
-    assert len(call_args_2["cc"]) == 1
 
 
 @mock.patch("requests.get")


### PR DESCRIPTION
Bugzilla doesn't allow cc'ing non bugzilla accounts. cc'ing non bugzilla accounts will make the REST API call fail. I think we can safely skip cc'ing people as cc will be done automatically when adding a needinfo and the expectations is that bugs will be handled with triage once filed, so no cc is needed if we are not able to needinfo.