### PR TITLE
DENG-477 - Update spoc retention to match desktop

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -304,6 +304,9 @@ applications:
           - name: "geo_city"
             value: null
         submission_timestamp_granularity: "seconds"
+      spoc:
+        expiration_policy:
+          delete_after_days: 180
     channels:
       - v1_name: firefox-android-release
         app_id: org.mozilla.firefox


### PR DESCRIPTION
per @Dexterp37 on slack:

> retention needs to match the retention that we have on Firefox Desktop for the same tables

which for activity stream impression stats is 180 days. that said impression stats on fenix is 30 days, and also limits some other granularity (see immediately above my changes), and it's unclear to me which of those we want.