### PR TITLE
Bug 1802982 - ffx-ios: Add missing Storage/metrics.yaml file

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -359,6 +359,7 @@ applications:
     url: https://github.com/mozilla-mobile/firefox-ios
     metrics_files:
       - Client/metrics.yaml
+      - Storage/metrics.yaml
       # The Sync/* files are meant to be a stop-gap measure, see
       # https://mozilla-hub.atlassian.net/browse/SYNC-3008, until
       # the Sync component from A-S is able to send Glean metrics.


### PR DESCRIPTION
Added in https://github.com/mozilla-mobile/firefox-ios/pull/11634 and recently updated in https://github.com/mozilla-mobile/firefox-ios/pull/12306