### PR TITLE
Define custom gsutil state dir that is not read-only

### DIFF
--- a/.gce_boto
+++ b/.gce_boto
@@ -1,2 +1,5 @@
 [GoogleCompute]
 service_account = default
+
+[GSUtil]
+state_dir = /tmp/gsutil


### PR DESCRIPTION
because some upstream change to google cloud functions made the default state dir (~/.gsutil) read-only.

fixes #521