### PR TITLE
Bug 1804033 - Update to glean-parser 6.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.2
 GitPython==3.0.8
 boto3==1.18.15
 Flask==2.1.1
-glean_parser==6.2.0
+glean-parser~=6.3
 google-cloud-storage==2.2.1
 gsutil==5.10
 Jinja2==3.1.1


### PR DESCRIPTION
That comes with a higher limit for allowed event extras, which is already used in FOG.