### PR TITLE
Use dependabot to automatically update glean-parser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Auto-update to next glean-parser major version
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    versioning-strategy: lockfile-only
+    reviewers:
+      - "mozilla/glean"
+    versioning-strategy: increase-if-necessary
+    allow:
+      - dependency-name: "glean-parser"


### PR DESCRIPTION
This will get us a PR within a day of a glean-parser release so we can update.
If we open up the version requirement a bit (#526) we get this only for major releases, so we can explicitly test them for incompatibilities.

Note: I explicitly restricted this to only glean-parser. I don't know for the other dependencies how up-to-date they are (and we would probably would lower the update interval for those to once a week only)