### PR TITLE
Upgrade to GitPython 3.1.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.20.15
 beautifulsoup4==4.8.2
-GitPython==3.0.8
+GitPython==3.1.29
 boto3==1.18.15
 Flask==2.1.1
 glean_parser==6.2.0


### PR DESCRIPTION
This addresses https://github.com/mozilla/probe-scraper/security/dependabot/1