### PR TITLE
Add retention period of 120 days for pageload ping

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -223,6 +223,10 @@ applications:
     channels:
       - v1_name: firefox-desktop
         app_id: firefox.desktop
+    moz_pipeline_metadata:
+      pageload:
+        expiration_policy:
+          delete_after_days: 120
 
   - app_name: firefox_desktop_background_update
     canonical_app_name: Firefox for Desktop Background Update Task


### PR DESCRIPTION
The pageload ping generates quite a bit of data.  Add a retention period of 120 days to limit the overall data.