### PR TITLE
bug 1771794 - Firefox Desktop Background Update also reports gecko metrics

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -240,6 +240,7 @@ applications:
     tag_files:
       - toolkit/components/glean/tags.yaml
     dependencies:
+      - gecko
       - glean-core
     channels:
       - v1_name: firefox-desktop-background-update


### PR DESCRIPTION
What remains to be seen in the fullness of time is how many supposedly-Firefox-Desktop-specific metrics _also_ get sent from Firefox Desktop Background Update. We can cross that bridge when we come to it.