### PR TITLE
Upgrade glean-parser to v7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.2
 GitPython==3.1.29
 boto3==1.18.15
 Flask==2.1.1
-glean-parser~=6.3
+glean-parser~=7.0
 google-cloud-storage==2.2.1
 gsutil==5.10
 Jinja2==3.1.1


### PR DESCRIPTION
Breaking change of glean-parser, but it shouldn't affect probe-scraper. The changes were mostly in code generation, the parsed data is mostly the same (minus some internal stuff stripped now)