### PR TITLE
Bug 1804304 - Add new app: firefox.desktop.background.tasks

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1149,3 +1149,27 @@ applications:
     channels:
       - v1_name: treeherder
         app_id: treeherder
+
+  - app_name: firefox_desktop_background_tasks
+    canonical_app_name: Firefox Desktop background tasks
+    app_description: |
+      Background tasks of Firefox Desktop.
+      Currently used by `BackgroundTask_removeDirectory`.
+    url: https://github.com/mozilla/gecko-dev
+    notification_emails:
+      - necko@mozilla.com
+      - krosylight@mozilla.com
+      - vgosu@mozilla.com
+    branch: master
+    metrics_files:
+      - toolkit/components/backgroundtasks/metrics.yaml
+    ping_files:
+      - toolkit/components/backgroundtasks/pings.yaml
+    dependencies:
+      - glean-core
+    channels:
+      - v1_name: firefox-desktop-background-tasks
+        app_id: firefox.desktop.background.tasks
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 180


### PR DESCRIPTION
https://phabricator.services.mozilla.com/D156941 has not yet landed, so the files don't actually exist yet.
We need to wait for this to land before merging.