### PR TITLE
Revert "Revert "Bug 1804256 - Add Mozilla VPN (Android) as a separate channel of Mozilla VPN""

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -829,6 +829,7 @@ applications:
     notification_emails:
       - vpn@mozilla.com
       - amarchesini@mozilla.com
+      - brizental@mozilla.com
     branch: main
     metrics_files:
       - glean/metrics.yaml
@@ -841,10 +842,13 @@ applications:
     channels:
       - v1_name: mozilla-vpn
         app_id: mozillavpn
+        app_channel: release
         additional_dependencies:
           - glean.js
       - v1_name: mozilla-vpn-android
         app_id: org.mozilla.firefox.vpn
+        app_channel: release
+        description: Mozilla VPN (Android)
         additional_dependencies:
           - glean-core
           - org.mozilla.components:service-glean

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -834,40 +834,20 @@ applications:
       - glean/metrics.yaml
     ping_files:
       - glean/pings.yaml
-    dependencies:
-      - glean-js
+    dependencies: []  # Empty. Dependencies are set per channel.
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
     channels:
       - v1_name: mozilla-vpn
         app_id: mozillavpn
-        app_channel: release
-
-  - app_name: mozilla_vpn_android
-    canonical_app_name: Mozilla VPN (Android)
-    app_description: |
-      Mozilla VPN is a VPN client application. The first
-      Mozilla premium service.
-    url: https://github.com/mozilla-mobile/mozilla-vpn-client
-    notification_emails:
-      - vpn@mozilla.com
-      - amarchesini@mozilla.com
-      - brizental@mozilla.com
-    branch: main
-    metrics_files:
-      - glean/metrics.yaml
-    ping_files:
-      - glean/pings.yaml
-    dependencies:
-      - glean-core
-    moz_pipeline_metadata_defaults:
-      expiration_policy:
-        delete_after_days: 180
-    channels:
+        additional_dependencies:
+          - glean.js
       - v1_name: mozilla-vpn-android
         app_id: org.mozilla.firefox.vpn
-        app_channel: release
+        additional_dependencies:
+          - glean-core
+          - org.mozilla.components:service-glean
 
   - app_name: rally_study_zero_one
     canonical_app_name: Rally Study-01


### PR DESCRIPTION
Reverts mozilla/probe-scraper#550

This will essentially apply the changes from https://github.com/mozilla/probe-scraper/pull/541 which we had to revert.

