### PR TITLE
Use the correct dependency name: glean-js

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -844,7 +844,7 @@ applications:
         app_id: mozillavpn
         app_channel: release
         additional_dependencies:
-          - glean.js
+          - glean-js
       - v1_name: mozilla-vpn-android
         app_id: org.mozilla.firefox.vpn
         app_channel: release


### PR DESCRIPTION
Should fix https://github.com/mozilla/glean-dictionary/issues/1600