### PR TITLE
Add crash pings back to firefox-desktop-background-update

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -242,8 +242,10 @@ applications:
       - chutten@mozilla.com
     metrics_files:
       - toolkit/mozapps/update/metrics.yaml
+      - toolkit/components/crashes/metrics.yaml
     ping_files:
       - toolkit/mozapps/update/pings.yaml
+      - toolkit/components/crashes/pings.yaml
     tag_files:
       - toolkit/components/glean/tags.yaml
     dependencies:


### PR DESCRIPTION
blocks [Bug 1815432](https://bugzilla.mozilla.org/show_bug.cgi?id=1815432)