### PR TITLE
Temporarily scrape ipc/ipdl/metrics.yaml for gecko

### DIFF
--- a/probe_scraper/check_repositories.py
+++ b/probe_scraper/check_repositories.py
@@ -17,7 +17,8 @@ REPOSITORIES = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "repositories.yaml"
 )
 EXPECTED_MISSING_FILES: Set[Tuple[str, str]] = {
-    ("support-migration", "components/support/migration/metrics.yaml")
+    ("support-migration", "components/support/migration/metrics.yaml"),
+    ("gecko", "ipc/ipdl/metrics.yaml"),
 }
 validation_errors = []
 repos = RepositoriesParser().parse(REPOSITORIES)

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -174,6 +174,7 @@ libraries:
       - dom/media/webrtc/metrics.yaml
       - dom/metrics.yaml
       - gfx/metrics.yaml
+      - ipc/ipdl/metrics.yaml
       - netwerk/metrics.yaml
       - netwerk/protocol/http/metrics.yaml
       - toolkit/components/cookiebanners/metrics.yaml


### PR DESCRIPTION
this will be backed out after i trigger some pushes to restore history for impacted metrics