### PR TITLE
Bug 1738880 - Alllow any filename ending in `.yaml` for metrics and ping files

### DIFF
--- a/probeinfo_api.yaml
+++ b/probeinfo_api.yaml
@@ -636,7 +636,7 @@ components:
       default: []
       items:
         type: string
-        pattern: tags\.yaml$
+        pattern: .+\.yaml$
         example: app/tags.yaml
 
     MetricsFiles:
@@ -645,7 +645,7 @@ components:
       default: []
       items:
         type: string
-        pattern: metrics\.yaml$
+        pattern: .+\.yaml$
         example: app/metrics.yaml
 
     PingFiles:
@@ -654,7 +654,7 @@ components:
       default: []
       items:
         type: string
-        pattern: pings\.yaml$
+        pattern: .+\.yaml$
         example: app/pings.yaml
 
     RepoBranch:

--- a/schemas/repositories.json
+++ b/schemas/repositories.json
@@ -38,14 +38,14 @@
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "metrics\\.yaml$"
+          "pattern": ".+\\.yaml$"
         }
       },
       "ping_files": {
         "type": "array",
         "items": {
           "type": "string",
-          "pattern": "pings\\.yaml$"
+          "pattern": ".+\\.yaml$"
         }
       },
       "dependencies": {


### PR DESCRIPTION
Fixes #364

This will make #576 work