### PR TITLE
Add VPN iOS app using native SDK rather than Glean.js (bug 1804256)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -866,6 +866,12 @@ applications:
         additional_dependencies:
           - glean-core
           - org.mozilla.components:service-glean
+      - v1_name: mozilla-vpn-ios
+        app_id: org.mozilla.ios.FirefoxVPN
+        app_channel: release
+        description: Mozilla VPN (iOS)
+        additional_dependencies:
+          - glean-core
 
   - app_name: rally_study_zero_one
     canonical_app_name: Rally Study-01


### PR DESCRIPTION
[Bug 1804256](https://bugzilla.mozilla.org/show_bug.cgi?id=1804256): Enable new Glean App `org.mozilla.ios.FirefoxVPN`