### PR TITLE
Update repositories.yaml to replace notification email for logins-store

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -93,8 +93,7 @@ libraries:
       A collection of Android libraries to build browsers or browser-like
       applications
     notification_emails:
-      - rfkelly@mozilla.com
-      - lina@mozilla.com
+      - teshaq@mozilla.com
       - sync-team@mozilla.com
     url: https://github.com/mozilla/application-services
     metrics_files:


### PR DESCRIPTION
Noticed when looking at the repositories - 

rfkelly left Mozilla a while ago, and Lina (although is back 🪃, is probably not the best email) putting my own email instead.