### PR TITLE
Bug 1828666 - Extend retention for Focus Android and Klar Android

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -688,7 +688,7 @@ applications:
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 180
+        delete_after_days: 760
     channels:
       - v1_name: firefox-focus-android
         app_id: org.mozilla.focus
@@ -726,7 +726,7 @@ applications:
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 180
+        delete_after_days: 760
     channels:
       - v1_name: firefox-klar-android
         app_id: org.mozilla.klar


### PR DESCRIPTION
Extend data retention for Focus Android and Klar Android from 180 to 760 days to allow year-over-year calculations over two year periods.