### PR TITLE
Skip FxA documentation (for now)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1197,6 +1197,7 @@ applications:
     channels:
       - v1_name: accounts-frontend
         app_id: accounts.frontend
+    skip_documentation: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 760
@@ -1217,6 +1218,7 @@ applications:
     channels:
       - v1_name: accounts-backend
         app_id: accounts.backend
+    skip_documentation: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 760


### PR DESCRIPTION
For now we skip FxA documentation because their ping and metric files are not ready yet.