### PR TITLE
Revert skipping documentation for accounts_frontend

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1197,7 +1197,6 @@ applications:
     channels:
       - v1_name: accounts-frontend
         app_id: accounts.frontend
-    skip_documentation: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 760


### PR DESCRIPTION
`accounts_frontend` do have their metrics and pings defined and we'd like this application to be included in Glean Dictionary.

This is a follow-up to https://github.com/mozilla/probe-scraper/pull/595