### PR TITLE
Update Glean dependency for mozilla_vpn

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -857,7 +857,7 @@ applications:
         app_id: mozillavpn
         app_channel: release
         additional_dependencies:
-          - glean-js
+          - glean-core
       - v1_name: mozilla-vpn-android
         app_id: org.mozilla.firefox.vpn
         app_channel: release


### PR DESCRIPTION
Ok, so. I thought it would be fine to just keep glean.js in there as a dependency until we validate the glean-core data and yank glean.js out (https://github.com/mozilla/probe-scraper/pull/556#event-9352957919).

Turns out that was a bad assesment, because now we are sending data with glean-core using the `metrics` ping, but there is no `mozilla_vpn.metrics` table generated.

If I am not mistaken -- calling on @badboy and @travis79 for a double check on this -- glean-js is just a subset of glean-core. So if we have both, we can just have glean-core and there will be no problems anymore. Is that correct?