### PR TITLE
pine: Remove extension metrics

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -273,7 +273,6 @@ applications:
       - browser/components/newtab/metrics.yaml
       - browser/components/search/metrics.yaml
       - browser/modules/metrics.yaml
-      - toolkit/components/extensions/metrics.yaml
       - toolkit/components/search/metrics.yaml
       - toolkit/components/telemetry/metrics.yaml
       - toolkit/xre/metrics.yaml


### PR DESCRIPTION
This was moved in https://github.com/mozilla/probe-scraper/pull/601 and thus is now part of the `gecko` dependency.

---

We need this otherwise we will keep getting "duplicated metrics" emails.