### PR TITLE
bug 1840646 - Apply Contextual Services rules to new top-sites and quick-suggest pings

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -239,6 +239,20 @@ applications:
       pageload:
         expiration_policy:
           delete_after_days: 120
+      top-sites:
+        expiration_policy:
+          delete_after_days: 30
+        override_attributes:
+          - name: "geo_city"
+            value: null
+        submission_timestamp_granularity: "seconds"
+      quick-suggest:
+        expiration_policy:
+          delete_after_days: 30
+        override_attributes:
+          - name: "geo_city"
+            value: null
+        submission_timestamp_granularity: "seconds"
 
   - app_name: firefox_desktop_background_update
     canonical_app_name: Firefox for Desktop Background Update Task


### PR DESCRIPTION
This matches not only the existing [contextual services config](https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/main/templates/contextual-services/defaults.schema.json), it matches "topsites-impression" pings' as well.