### PR TITLE
Bug 1827949 - Update firefox_ios to get sync metrics from the syncmanager component

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -395,16 +395,8 @@ applications:
     metrics_files:
       - Client/metrics.yaml
       - Storage/metrics.yaml
-      # The Sync/* files are meant to be a stop-gap measure, see
-      # https://mozilla-hub.atlassian.net/browse/SYNC-3008, until
-      # the Sync component from A-S is able to send Glean metrics.
-      - Sync/metrics.yaml
     ping_files:
       - Client/pings.yaml
-      # The Sync/* files are meant to be a stop-gap measure, see
-      # https://mozilla-hub.atlassian.net/browse/SYNC-3008, until
-      # the Sync component from A-S is able to send Glean metrics.
-      - Sync/pings.yaml
     tag_files:
       - Client/tags.yaml
     branch: main
@@ -415,6 +407,7 @@ applications:
       - org.mozilla.components:service-glean
       - nimbus
       - org.mozilla.appservices:logins
+      - org.mozilla.appservices:syncmanager
     moz_pipeline_metadata:
       topsites-impression:
         expiration_policy:


### PR DESCRIPTION
iOS changes in https://github.com/mozilla-mobile/firefox-ios/pull/15544