### PR TITLE
Update Mozilla VPN paths

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -871,13 +871,8 @@ applications:
       - brizental@mozilla.com
     branch: main
     metrics_files:
-      - src/shared/telemetry/metrics.yaml
-      - src/shared/telemetry/metrics_deprecated.yaml
       - src/telemetry/metrics.yaml
-      - src/telemetry/metrics_deprecated.yaml
     ping_files:
-      - src/shared/telemetry/pings.yaml
-      - src/shared/telemetry/pings_deprecated.yaml
       - src/telemetry/pings.yaml
     dependencies: [] # Empty. Dependencies are set per channel.
     moz_pipeline_metadata_defaults:


### PR DESCRIPTION
These changes will be introduced by https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7936. Since this is just removing paths I guess there is no harm merging before that PR is merged.