### PR TITLE
Pin python 3.11 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.11
 MAINTAINER Harold Woo <hwoo@mozilla.com>
 
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
because python 3.12 is failing in CI https://app.circleci.com/pipelines/github/mozilla/probe-scraper/1653/workflows/18fb8d7f-3215-4023-a494-7278c35e6b2b/jobs/3708