### PR TITLE
Bump the FF background task retention to 400 days

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1210,7 +1210,7 @@ applications:
         app_id: firefox.desktop.background.tasks
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 180
+        delete_after_days: 400
 
   - app_name: accounts_frontend
     canonical_app_name: Firefox Accounts Frontend


### PR DESCRIPTION
400 days matches better with keeping autoland build for 1 year.