### PR TITLE
Un-deprecated Fenix apps

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -416,7 +416,6 @@ applications:
       - v1_name: fenix-nightly
         app_id: org.mozilla.fenix.nightly
         app_channel: nightly
-        deprecated: true
         additional_dependencies:
           - org.mozilla.components:browser-engine-gecko-nightly
         description: >-
@@ -424,7 +423,6 @@ applications:
       - v1_name: firefox-android-nightly
         app_id: org.mozilla.fennec.aurora
         app_channel: nightly
-        deprecated: true
         additional_dependencies:
           - org.mozilla.components:browser-engine-gecko-beta
         description: >-


### PR DESCRIPTION
While these apps may not be reporting data, I would argue that they are definitely not deprecated since we still count them towards our KPIs.

When we disinclude these from KPI counts, we can deprecate them (which would mean we can stop processing data in the pipeline).