### PR TITLE
Add `service-nimbus` android-component library metrics.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -178,6 +178,19 @@ libraries:
         branch: main
         dependency_name: nimbus-cirrus
 
+  - library_name: service-nimbus
+    description: >
+      The Nimbus Android-Component used by Fenix and Focus
+    notification_emails:
+      - sync-team@mozilla.com
+    url: https://github.com/mozilla-mobile/firefox-android
+    metrics_files:
+      - android-components/components/service/nimbus/metrics.yaml
+    variants:
+      - v1_name: service-nimbus
+        branch: main
+        dependency_name: org.mozilla.components:service-nimbus
+
   - library_name: gecko
     description: The browser engine developed by Mozilla
     notification_emails:
@@ -380,6 +393,7 @@ applications:
       - org.mozilla.components:support-migration
       - org.mozilla.components:places
       - nimbus
+      - org.mozilla.components:service-nimbus
     moz_pipeline_metadata:
       topsites-impression:
         expiration_policy:
@@ -744,6 +758,7 @@ applications:
       - org.mozilla.components:service-glean
       - org.mozilla.components:lib-crash
       - nimbus
+      - org.mozilla.components:service-nimbus
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:
@@ -782,6 +797,7 @@ applications:
       - org.mozilla.components:service-glean
       - org.mozilla.components:lib-crash
       - nimbus
+      - org.mozilla.components:service-nimbus
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:


### PR DESCRIPTION
This adds the metrics.yaml file found in service-nimbus android-component, picking up the messaging metrics which were migrated from fenix's metrics.yaml file so that they don't appear as "removed" in the Glean Dictionary.