### PR TITLE
Revert "Add `service-nimbus` android-component library metrics.yaml"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -178,19 +178,6 @@ libraries:
         branch: main
         dependency_name: nimbus-cirrus
 
-  - library_name: service-nimbus
-    description: >
-      The Nimbus Android-Component used by Fenix and Focus
-    notification_emails:
-      - sync-team@mozilla.com
-    url: https://github.com/mozilla-mobile/firefox-android
-    metrics_files:
-      - android-components/components/service/nimbus/metrics.yaml
-    variants:
-      - v1_name: service-nimbus
-        branch: main
-        dependency_name: org.mozilla.components:service-nimbus
-
   - library_name: gecko
     description: The browser engine developed by Mozilla
     notification_emails:
@@ -393,7 +380,6 @@ applications:
       - org.mozilla.components:support-migration
       - org.mozilla.components:places
       - nimbus
-      - org.mozilla.components:service-nimbus
     moz_pipeline_metadata:
       topsites-impression:
         expiration_policy:
@@ -758,7 +744,6 @@ applications:
       - org.mozilla.components:service-glean
       - org.mozilla.components:lib-crash
       - nimbus
-      - org.mozilla.components:service-nimbus
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:
@@ -797,7 +782,6 @@ applications:
       - org.mozilla.components:service-glean
       - org.mozilla.components:lib-crash
       - nimbus
-      - org.mozilla.components:service-nimbus
       - gecko
     moz_pipeline_metadata_defaults:
       expiration_policy:


### PR DESCRIPTION
This reverts commit 12e0c6356dd39736dd9e0ea658e62b70efa3f39b.

---

https://github.com/mozilla-mobile/firefox-android/blob/4fd5f8ff15ee73c11717ed465aa8f1519bc6df1b/android-components/components/service/nimbus/metrics.yaml contains `nimbus_events.enrollment` and others that are also defined in https://github.com/mozilla/application-services/blob/d58715194a98867372cdce8f75bd32b2e68b953b/components/nimbus/metrics.yaml#L12

We can't have the same definition twice and that's currently breaking probe-scraper (in turn leading to 500 errros on the push action).