### PR TITLE
Upgrade to glean-parser v10.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.2
 GitPython==3.1.40
 boto3==1.28.7
 Flask==2.3.3
-glean-parser~=10.0.2
+glean-parser~=10.0.3
 google-cloud-storage==2.2.1
 gsutil==5.10
 Jinja2==3.1.2


### PR DESCRIPTION
This should fix another failure on firefox-ios.

Dry run:

```
python3 -m probe_scraper.runner --dry-run --cache-dir tmp/cache --out-dir tmp/out --glean --glean-repo firefox-ios-release
```

fails on main, runs on this branch.