### PR TITLE
[Bug 1863382] Add support-migration back to fenix

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -391,6 +391,7 @@ applications:
       - org.mozilla.components:lib-crash
       - org.mozilla.appservices:syncmanager
       - org.mozilla.appservices:logins
+      - org.mozilla.components:support-migration
       - org.mozilla.components:places
       - org.mozilla.appservices:fxaclient
       - nimbus


### PR DESCRIPTION
Mozilla schema generator is currently failing due to the `migration` ping schemas having been removed in this PR: https://github.com/mozilla/probe-scraper/commit/760f8d951a41ea840e39e320b75bf3aade70f104

@travis79 Is it ok to simply add `support-migration` back to unblock schema generation?