### PR TITLE
Rename focus-ios metrics.yaml file

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -713,7 +713,7 @@ applications:
       - tlong@mozilla.com
     branch: main
     metrics_files:
-      - Blockzilla/metrics.yaml
+      - focus-ios/Blockzilla/metrics.yaml
     dependencies:
       - glean-core
       - nimbus
@@ -733,7 +733,7 @@ applications:
       - tlong@mozilla.com
     branch: main
     metrics_files:
-      - Blockzilla/metrics.yaml
+      - focus-ios/Blockzilla/metrics.yaml
     dependencies:
       - glean-core
       - nimbus


### PR DESCRIPTION
files is being renamed in https://github.com/mozilla-mobile/focus-ios/pull/3917 and merging should be coordinated with that PR.

fixes #659