### PR TITLE
Use the correct branch for mozillavpn_cirrus

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -971,7 +971,7 @@ applications:
     url: https://github.com/mozilla/experimenter
     notification_emails:
       - brizental@mozilla.com
-    branch: master
+    branch: main
     metrics_files:
       - cirrus/server/telemetry/metrics.yaml
     ping_files:


### PR DESCRIPTION
Added in #667. Let's correct it.