### PR TITLE
Mark firefox-translations as deprecated

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -834,6 +834,7 @@ applications:
   - app_name: firefox_translations
     canonical_app_name: Firefox Translations
     app_description: Web extension for on-device machine translation
+    deprecated: true
     url: https://github.com/mozilla/firefox-translations
     notification_emails:
       - epavlov@mozilla.com


### PR DESCRIPTION
The webextension it not maintained anymore, development has moved directly into firefox.

---

This will also stop those "expired" emails ;)