### PR TITLE
Fetch firefox-ios files from its new path

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -459,12 +459,12 @@ applications:
       - dthorn@mozilla.com
     url: https://github.com/mozilla-mobile/firefox-ios
     metrics_files:
-      - Client/metrics.yaml
-      - Storage/metrics.yaml
+      - firefox-ios/Client/metrics.yaml
+      - firefox-ios/Storage/metrics.yaml
     ping_files:
-      - Client/pings.yaml
+      - firefox-ios/Client/pings.yaml
     tag_files:
-      - Client/tags.yaml
+      - firefox-ios/Client/tags.yaml
     branch: main
     dependencies:
       - glean-core


### PR DESCRIPTION
The change landed in https://github.com/mozilla-mobile/firefox-ios/pull/17460

Fixes #666

---

Test command:

```
python3 -m probe_scraper.runner --dry-run --cache-dir tmp/cache --out-dir tmp/out --glean --glean-repo firefox-ios-release --glean-limit-date=2023-11-01
```

Current output on `main`:

```
[...]
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git show 240d2ce5a39dce12baed58f7133815be6276ae84:Client/metrics.yaml
  stderr: 'fatal: path 'Client/metrics.yaml' does not exist in '240d2ce5a39dce12baed58f7133815be6276ae84''
```

With this patch: no issues!