### PR TITLE
chore: changing moso backend canonical app name and expiration to reflect how moso web is setup

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1414,9 +1414,9 @@ applications:
         delete_after_days: 760
 
   - app_name: moso_mastodon_backend
-    canonical_app_name: Mozilla.Social Mastodon Backend
+    canonical_app_name: Mozilla Social Mastodon Backend
     app_description: |
-      Mastodon instance for Mozilla.Social
+      Mastodon instance for Mozilla Social
     url: https://github.com/MozillaSocial/mastodon
     notification_emails:
       - breyes@mozilla.com
@@ -1430,7 +1430,7 @@ applications:
         app_id: moso.mastodon.backend
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 400
+        delete_after_days: 1110 # 37 months
 
   - app_name: moso_mastodon_web
     canonical_app_name: Mozilla Social Web App


### PR DESCRIPTION
simply changing the canonical name to match the style of Moso Web and also updating the expiration to match that of Moso Web

asked about this in Slack: https://mozilla.slack.com/archives/CEE12R4E8/p1701807225068819