### PR TITLE
Bug 1873431 - Add TikTok Reporter apps (iOS and Android)

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -114,6 +114,9 @@ SKIP_COMMITS = {
     "moso-mastodon-backend": [
         "cd5c69456d88b7023366fd50806855086a039dba",  # No .glean/metrics.yaml
     ],
+    "tiktokreporter-android": [
+        "96bf78fbde4dc1eddd8fc7de175d6c58fe82e23e",  # Improperly named metric
+    ],
 }
 
 

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1430,7 +1430,7 @@ applications:
         app_id: moso.mastodon.backend
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 1110 # 37 months
+        delete_after_days: 1110  # 37 months
 
   - app_name: moso_mastodon_web
     canonical_app_name: Mozilla Social Web App
@@ -1450,4 +1450,48 @@ applications:
         app_id: moso-mastodon-web
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 1110 # 37 months
+        delete_after_days: 1110  # 37 months
+
+  - app_name: tiktokreporter_ios
+    canonical_app_name: TikTok Reporter (iOS)
+    app_description: |
+      An app for iOS to enable Mozilla Foundation research into TikTok
+    url: https://github.com/MozillaFoundation/tiktok-reporter-app-ios
+    notification_emails:
+      - jessed@mozillafoundation.org
+      - tlong@mozilla.com
+    branch: main
+    metrics_files:
+      - "TikTok Reporter/metrics.yaml"
+    ping_files:
+      - "TikTok Reporter/pings.yaml"
+    dependencies:
+      - glean-core
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400
+    channels:
+      - v1_name: tiktokreporter-ios
+        app_id: org.mozilla.ios.TikTok-Reporter
+
+  - app_name: tiktokreporter_android
+    canonical_app_name: TikTok Reporter (Android)
+    app_description: |
+      An app for Android to enable Mozilla Foundation research into TikTok
+    url: https://github.com/MozillaFoundation/tiktok-reporter-app-android
+    notification_emails:
+      - jessed@mozillafoundation.org
+      - tlong@mozilla.com
+    branch: main
+    metrics_files:
+      - "app/metrics.yaml"
+    ping_files:
+      - "app/pings.yaml"
+    dependencies:
+      - glean-core
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400
+    channels:
+      - v1_name: tiktokreporter-android
+        app_id: org.mozilla.tiktokreporter


### PR DESCRIPTION
This is blocked on the feature branch in the iOS version of the TikTok Reporter with the metrics.yaml and pings.yaml files being merged into the main branch. Once that's done, I'll need to perform another dry-run and this should be good to go.