### PR TITLE
Update type definition of a metric on each scrape

### DIFF
--- a/probe_scraper/transform_probes.py
+++ b/probe_scraper/transform_probes.py
@@ -367,6 +367,10 @@ def update_or_add_item(
             new_defn = make_item_defn(definition, commit)
             repo_items[item][HISTORY_KEY] = prev_defns + [new_defn]
 
+        # In rare cases the type can change.
+        # We always pick the latest one.
+        repo_items[item]["type"] = definition["type"]
+
     # We haven't seen this item before, add it
     else:
         defn = make_item_defn(definition, commit)


### PR DESCRIPTION
In rare cases the type can change.
We always pick the latest one.

Fixes #677

---

Tested with:

```
python3 -m probe_scraper.runner --dry-run --cache-dir tmp/cache --out-dir tmp/out --glean --glean-repo moso-mastodon-web --update --glean-limit-date=2024-01-01 --output-bucket=gs://probe-scraper-prod-artifacts/
```

Before:

```
$ gron tmp/out/glean/moso-mastodon-web/metrics | rg web.page_url.+type
json["web.page_url"].history[0].type = "string";
json["web.page_url"].history[1].type = "string";
json["web.page_url"].history[2].type = "url";
json["web.page_url"].type = "string";
```

After:

```
$ gron tmp/out/glean/moso-mastodon-web/metrics | rg web.page_url.+type
json["web.page_url"].history[0].type = "string";
json["web.page_url"].history[1].type = "string";
json["web.page_url"].history[2].type = "url";
json["web.page_url"].type = "url";
```

---

\* <sub> [gron](https://github.com/tomnomnom/gron) </sub>