### PR TITLE
Bug 1878674 - Exempt metrics moving out of geckoview-streaming from duplication checks

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -138,7 +138,11 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
                     metric_sources.setdefault(metric_name, []).append(dependency)
 
         duplicate_sources = dict(
-            (k, v) for (k, v) in metric_sources.items() if len(v) > 1
+            # Exempt cases when one of the sources is Geckoview Streaming to
+            # avoid false positive duplication accross app channels.
+            (k, v)
+            for (k, v) in metric_sources.items()
+            if len(v) > 1 and "engine-gecko" not in v
         )
 
         if not len(duplicate_sources):


### PR DESCRIPTION
This is a fix as we migrate metrics out of Geckoview Streaming and is intended to be removed once that effort is complete.

As per https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml#L69 engine-gecko is the library for Geckoview.

