### PR TITLE
Bug 1878674 - Properly exclude all engine-gecko dependencies from duplication checks

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -137,13 +137,13 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
                 if metric["history"][-1]["dates"]["last"] == last_timestamp:
                     metric_sources.setdefault(metric_name, []).append(dependency)
 
-        duplicate_sources = dict(
+        duplicate_sources = {}
+        for (k, v) in metric_sources.items():
             # Exempt cases when one of the sources is Geckoview Streaming to
             # avoid false positive duplication accross app channels.
-            (k, v)
-            for (k, v) in metric_sources.items()
-            if len(v) > 1 and "engine-gecko" not in v
-        )
+            v = [dep for dep in v if "engine-gecko" not in dep]
+            if len(v) > 1:
+                duplicate_sources[k] = v
 
         if not len(duplicate_sources):
             continue


### PR DESCRIPTION
Ok, instead of checking if there's an exact match in the list, this now ensures that all of the engine-gecko like dependencies (engine-gecko, engine-gecko-beta, engine-gecko-nightly, etc) will be removed from duplication checking.

Once Geckoview Streaming is migrated I will revert this to the original code and remove the repository so this is no longer an issue.

Passes with this dry run:
```python -m probe_scraper.runner --glean --glean-repo glean-core --glean-repo glean-android --glean-repo engine-gecko --glean-repo fenix-nightly --glean-repo gecko --glean-repo engine-gecko-beta --glean-repo engine-gecko-nightly --cache-dir ./.scraper_cache/ --dry-run```