### PR TITLE
Bug 1879155 - Add Mastodon android client to repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1467,8 +1467,9 @@ applications:
     dependencies:
       - glean-core
     channels:
-      - v1_name: moso-mastodon-android # TODO: confirm this
-        app_id: moso-mastodon-android # TODO: confirm this
+      - v1_name: moso-mastodon-android-nightly
+        app_id: org.mozilla.social.nightly
+        app_channel: nightly
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 1110  # 37 months

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1453,6 +1453,26 @@ applications:
       expiration_policy:
         delete_after_days: 1110  # 37 months
 
+  - app_name: moso_mastodon_android
+    canonical_app_name: Mozilla Social Android App
+    app_description: Android client for Mozilla Social
+    url: https://github.com/MozillaSocial/mozilla-social-android
+    notification_emails:
+      - kdemtchouk@mozilla.com
+      - klong@mozilla.com
+    branch: main
+    metrics_files:
+      - core/analytics/metrics.yaml
+    ping_files: []
+    dependencies:
+      - glean-core
+    channels:
+      - v1_name: moso-mastodon-android # TODO: confirm this
+        app_id: moso-mastodon-android # TODO: confirm this
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 1110  # 37 months
+
   - app_name: tiktokreporter_ios
     canonical_app_name: TikTok Reporter (iOS)
     app_description: |


### PR DESCRIPTION
Tested with
```
export COMMAND='python -m probe_scraper.runner --glean --glean-repo moso-mastodon-android-nightly --dry-run'
make run
```
which ran successfully.