### PR TITLE
[Bug 1879657] Skip bugs with invalid descriptions in expiry alerts

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -128,14 +128,14 @@ def find_existing_bugs(
 
     probes_with_bugs = {}
     for bug in found_bugs:
-        if (
-            re.search(r"release: \[?version (\d+)", bug["description"]).group(1)
-            != version
-        ):
+        version_re = re.search(r"release: \[?version (\d+)", bug["description"])
+        probes_re = re.search(r"```(.*)```", bug["description"], re.DOTALL)
+
+        # if version or a list of probes is not found in the description then the bug is skipped
+        if version_re is None or probes_re is None or version_re.group(1) != version:
             continue
-        probes_in_bug = (
-            re.search(r"```(.*)```", bug["description"], re.DOTALL).group(1).split()
-        )
+
+        probes_in_bug = probes_re.group(1).split()
         for probe_name in probes_in_bug:
             probes_with_bugs[probe_name] = bug["id"]
 


### PR DESCRIPTION
Closes https://github.com/mozilla/probe-scraper/issues/651

Used bug for testing https://bugzilla.mozilla.org/show_bug.cgi?id=1879657

This makes the probe expiry alerts ignore bugs that have the `[probe-expiry-alert]` tag but Firefox version or probes can't be parsed from the description instead of failing.  If someone edits the description of the bug such that it can't be parsed then a duplicate bug will be created.  I'm not sure this has happened in the last 4 years so I don't think it's necessary to add "do not edit" to the description.