### PR TITLE
(Partial) Revert "bug 1877836 - Remove GeckoView Streaming Telemetry"

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -137,9 +137,13 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
                 if metric["history"][-1]["dates"]["last"] == last_timestamp:
                     metric_sources.setdefault(metric_name, []).append(dependency)
 
-        duplicate_sources = dict(
-            (k, v) for (k, v) in metric_sources.items() if len(v) > 1
-        )
+        duplicate_sources = {}
+        for (k, v) in metric_sources.items():
+            # Exempt cases when one of the sources is Geckoview Streaming to
+            # avoid false positive duplication accross app channels.
+            v = [dep for dep in v if "engine-gecko" not in dep]
+            if len(v) > 1:
+                duplicate_sources[k] = v
 
         if not len(duplicate_sources):
             continue


### PR DESCRIPTION
This reverts commit 4559963a2f80d2f18490f3e35cae4f3d32b2e496.

This currently breaks at the very least update tasks like the push mode, due to the metrics still being there in the other component, even though they are "gone".

I ran this locally:

```
python -m probe_scraper.runner --dry-run --cache-dir tmp/cache --out-dir tmp/out --glean --update --glean-url https://github.com/mdn/yari --glean-commit fe09a825bdd440fd36996fceb47978250e5c692b --output-bucket=gs://probe-scraper-prod-artifacts/
```

fails with the dupes error message on `main`, succeeds with this revert.