### PR TITLE
Bug 1875033 - Fetch a-c/fenix/focus-android metrics from m-c now

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -42,11 +42,11 @@ libraries:
       - aplacitelli@mozilla.com
       - glean-team@mozilla.com
       - android-probes@mozilla.com
-    url: https://github.com/mozilla-mobile/firefox-android
+    url: https://github.com/mozilla/gecko-dev
     metrics_files:
-      - android-components/components/lib/crash/metrics.yaml
+      - mobile/android/android-components/components/lib/crash/metrics.yaml
     ping_files:
-      - android-components/components/lib/crash/pings.yaml
+      - mobile/android/android-components/components/lib/crash/pings.yaml
     variants:
       - v1_name: lib-crash
         dependency_name: org.mozilla.components:lib-crash
@@ -383,15 +383,15 @@ applications:
   - app_name: fenix
     app_description: Firefox for Android (Fenix)
     canonical_app_name: Firefox for Android
-    url: https://github.com/mozilla-mobile/firefox-android
+    url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - aplacitelli@mozilla.com
     metrics_files:
-      - fenix/app/metrics.yaml
+      - mobile/android/fenix/app/metrics.yaml
     ping_files:
-      - fenix/app/pings.yaml
+      - mobile/android/fenix/app/pings.yaml
     tag_files:
-      - fenix/app/tags.yaml
+      - mobile/android/fenix/app/tags.yaml
     dependencies:
       - gecko
       - glean-core
@@ -750,15 +750,14 @@ applications:
   - app_name: focus_android
     canonical_app_name: Firefox Focus for Android
     app_description: Firefox Focus on Android. Klar is the sibling application
-    url: https://github.com/mozilla-mobile/firefox-android
+    url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - jalmeida@mozilla.com
       - tlong@mozilla.com
-    branch: main
     metrics_files:
-      - focus-android/app/metrics.yaml
+      - mobile/android/focus-android/app/metrics.yaml
     ping_files:
-      - focus-android/app/pings.yaml
+      - mobile/android/focus-android/app/pings.yaml
     dependencies:
       - glean-core
       - org.mozilla.components:service-glean
@@ -788,15 +787,14 @@ applications:
   - app_name: klar_android
     canonical_app_name: Firefox Klar for Android
     app_description: Firefox Klar on Android. Focus is the sibling application
-    url: https://github.com/mozilla-mobile/firefox-android
+    url: https://github.com/mozilla/gecko-dev
     notification_emails:
       - jalmeida@mozilla.com
       - tlong@mozilla.com
-    branch: main
     metrics_files:
-      - focus-android/app/metrics.yaml
+      - mobile/android/focus-android/app/metrics.yaml
     ping_files:
-      - focus-android/app/pings.yaml
+      - mobile/android/focus-android/app/pings.yaml
     dependencies:
       - glean-core
       - org.mozilla.components:service-glean


### PR DESCRIPTION
Fenix and co will move into m-c.
Metrics will be fetched by the already-existing nightly gecko task, we just need to point probe-scraper to it.

This uses the current paths from the branch that's preparing the merge.
This is not yet ready. It should land shortly after the m-c merge actually happened and work moved over there.