### PR TITLE
Switch `mozillavpn_backend_cirrus` to use `nimbus-cirrus` dependency (bug 1867770)

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -399,6 +399,17 @@ def scrape(
     upload_repos = []
 
     for repo_info in repos:
+        if not (
+            repo_info.metrics_file_paths
+            or repo_info.ping_file_paths
+            or repo_info.tag_file_paths
+        ):
+            print(
+                f"Skipping commits for repository {repo_info.name}"
+                " because it has no metrics/ping/tag files."
+            )
+            continue
+
         print("Getting commits for repository " + repo_info.name)
 
         commits_by_repo[repo_info.name] = {}

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -968,16 +968,15 @@ applications:
     canonical_app_name: Mozilla VPN Cirrus Sidecar
     app_description: |
       The sidecar Cirrus container for the Mozilla VPN server
-    url: https://github.com/mozilla/experimenter
+    url: https://github.com/mozilla-services/guardian-website
     notification_emails:
       - brizental@mozilla.com
     branch: main
-    metrics_files:
-      - cirrus/server/telemetry/metrics.yaml
-    ping_files:
-      - cirrus/server/telemetry/pings.yaml
+    metrics_files: []
+    ping_files: []
     dependencies:
       - glean-core
+      - nimbus-cirrus
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180


### PR DESCRIPTION
## [Bug 1867770](https://bugzilla.mozilla.org/show_bug.cgi?id=1867770): Enable new Glean App `mozillavpn_cirrus`

There should be no functional change, this just makes it clearer what's happening and avoids duplicating the Cirrus metrics/ping files config for VPN.