### PR TITLE
Set commits_by_repo with repo name before skipping commits

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -399,6 +399,14 @@ def scrape(
     upload_repos = []
 
     for repo_info in repos:
+        print("Getting commits for repository " + repo_info.name)
+
+        commits_by_repo[repo_info.name] = {}
+        emails[repo_info.name] = {
+            "addresses": repo_info.notification_emails,
+            "emails": [],
+        }
+
         if not (
             repo_info.metrics_file_paths
             or repo_info.ping_file_paths
@@ -409,14 +417,6 @@ def scrape(
                 " because it has no metrics/ping/tag files."
             )
             continue
-
-        print("Getting commits for repository " + repo_info.name)
-
-        commits_by_repo[repo_info.name] = {}
-        emails[repo_info.name] = {
-            "addresses": repo_info.notification_emails,
-            "emails": [],
-        }
 
         try:
             commits, upload_repo = retrieve_files(


### PR DESCRIPTION
Follow-up to #708.  This currently fails for repos with no ping/metrics/tag files because it fails the schema validation in `glean_checks.check_glean_metric_structure` due to no items in `commits_by_repo`.  This initializes `commits_by_repo` to `{"repo_name": {}}` instead of an empty dict.  Alternative is to allow an empty dict but I think it makes more sense to list the repos explicitly with no commits to scrape.  Output is the same either way