### PR TITLE
Deprecate Mastodon Android & Web

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1444,6 +1444,7 @@ applications:
     channels:
       - v1_name: moso-mastodon-web
         app_id: moso-mastodon-web
+        deprecated: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 1110  # 37 months

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1466,6 +1466,7 @@ applications:
       - v1_name: moso-mastodon-android-nightly
         app_id: org.mozilla.social.nightly
         app_channel: nightly
+        deprecated: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 1110  # 37 months


### PR DESCRIPTION
Android repository has been archived as of 2024-02-15
and [mozilla.social switched back to the standard Mastodon web frontend](https://mozilla.social/@mozilla/112095207133579776)