### PR TITLE
Increase cloud function memory to 2048 MB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
             --region=us-west1
             --allow-unauthenticated
             --entry-point=glean_push
-            --memory=1024
+            --memory=2048
             --runtime=python310
             --set-env-vars=BOTO_PATH=.gce_boto,OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/
             --trigger-http


### PR DESCRIPTION
(fixes #713)

Also increases vCPUs from 0.583 to 1: https://cloud.google.com/functions/docs/configuring/memory
This will approximately double costs for the cloud function but it will go from negligible to 2 * negligible.

This should fix some (most?) of the recent flakiness with the cloud function.  We seem to be getting ~10 errors per day ([experimental dashboard](https://earthangel-b40313e5.influxcloud.net/d/eXUKp2JSk/probe-scraper?orgId=1)) and at least some of these are OOM errors but cloud logging doesn't always show all the logs so I can't tell which ones are OOM. 
