### PR TITLE
Bug 1874935 - Add new glean-server library to define pings for server-side Glean

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -21,6 +21,19 @@ libraries:
         branch: main
         dependency_name: glean-core
 
+  - library_name: glean-server
+    description: Modern cross-platform telemetry (server usage)
+    notification_emails:
+      - glean-team@mozilla.com
+    url: https://github.com/mozilla/glean_parser
+    metrics_files: []
+    ping_files:
+      - server-side-pings.yaml
+    variants:
+      - v1_name: glean-server
+        branch: main
+        dependency_name: glean-server
+
   - library_name: glean-android
     description: Modern cross-platform telemetry (Android-specific)
     notification_emails:
@@ -1355,7 +1368,8 @@ applications:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
-    dependencies: []
+    dependencies:
+      - glean-server
     channels:
       - v1_name: accounts-backend
         app_id: accounts.backend
@@ -1461,7 +1475,8 @@ applications:
     metrics_files:
       - .glean/metrics.yaml
     ping_files: []
-    dependencies: []
+    dependencies:
+      - glean-server
     channels:
       - v1_name: moso-mastodon-backend
         app_id: moso.mastodon.backend


### PR DESCRIPTION
Right now this just re-uses the Glean SDK repo and its defintions of all builtin pings.
Technically server-side Glean would only send the `events` ping.

Should we:

1. ~~Create a `server-side-pings.yaml` in the Glean SDK to reference here?~~
2. Create a `server-side-pings.yaml` in the `glean_parser` repo to reference here (as that's where all the code for server-side lives)
3. ~~Create a `mozilla/glean-server` repository that only exists for that file?~~