### PR TITLE
Bug 1887962 - Add mozbuild metrics to mach

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -696,6 +696,7 @@ applications:
       - mhentges@mozilla.com
     metrics_files:
       - python/mach/metrics.yaml
+      - python/mozbuild/metrics.yaml
     ping_files:
       - python/mach/pings.yaml
     dependencies:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1887962

Reverts https://github.com/mozilla/probe-scraper/pull/231

These are the metrics being added https://github.com/mozilla/gecko-dev/blob/master/python/mozbuild/metrics.yaml.  `mozbuild.project` is the only metric that's currently missing from the schema