### PR TITLE
Bug 1887995 - Add relay_backend app

### DIFF
--- a/probe_scraper/scrapers/git_scraper.py
+++ b/probe_scraper/scrapers/git_scraper.py
@@ -41,6 +41,7 @@ MIN_DATES = {
     "mozilla-vpn-android": "2021-05-25 00:00:00",
     "rally-markup-fb-pixel-hunt": "2021-12-04 00:00:00",
     "rally-citp-search-engine-usage": "2022-04-15 00:00:00",
+    "relay-backend": "2024-05-09 00:00:00",
 }
 
 # Some commits in projects might contain invalid metric files.

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1549,3 +1549,23 @@ applications:
     channels:
       - v1_name: tiktokreporter-android
         app_id: org.mozilla.tiktokreporter
+
+  - app_name: relay_backend
+    canonical_app_name: Firefox Accounts Backend
+    app_description: |
+      Firefox accounts is Mozilla's authentication solution
+      for account-based end-user services and features.
+    url: https://github.com/mozilla/fx-private-relay
+    notification_emails:
+      - jwhitlock@mozilla.com
+    branch: main
+    metrics_files:
+      - telemetry/glean/relay-server-metrics.yaml
+    ping_files: []
+    dependencies: []
+    channels:
+      - v1_name: relay-backend
+        app_id: relay.backend
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1551,7 +1551,7 @@ applications:
         app_id: org.mozilla.tiktokreporter
 
   - app_name: relay_backend
-    canonical_app_name: Firefox Accounts Backend
+    canonical_app_name: Firefox Relay Backend
     app_description: |
       Firefox accounts is Mozilla's authentication solution
       for account-based end-user services and features.

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1619,7 +1619,8 @@ applications:
     metrics_files:
       - telemetry/glean/relay-server-metrics.yaml
     ping_files: []
-    dependencies: []
+    dependencies:
+      - glean-server
     channels:
       - v1_name: relay-backend
         app_id: relay.backend

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1553,8 +1553,10 @@ applications:
   - app_name: relay_backend
     canonical_app_name: Firefox Relay Backend
     app_description: |
-      Firefox accounts is Mozilla's authentication solution
-      for account-based end-user services and features.
+      Relay provides email and phone masks to protect users from hackers and
+      trackers. The Relay backend server provides an API for Firefox, the Relay
+      add-on, and the Relay website. It also processes Mozilla account updates,
+      emails, phone calls, and text messages.
     url: https://github.com/mozilla/fx-private-relay
     notification_emails:
       - jwhitlock@mozilla.com


### PR DESCRIPTION
Tested with:
```
python -m probe_scraper.runner --glean --glean-repo glean-server --glean-repo relay-backend --dry-run
```
Which returned:
```
Getting commits for repository glean-server
Cloning https://github.com/mozilla/glean_parser into /var/folders/tj/6t1b0gmd50z6w50b3fn825fm0000gn/T/tmp74ttd2b0/mozilla/glean_parser.git
  Got 2 commits
Getting commits for repository relay-backend
Cloning https://github.com/mozilla/fx-private-relay into /var/folders/tj/6t1b0gmd50z6w50b3fn825fm0000gn/T/tmp74ttd2b0/mozilla/fx-private-relay.git
  Got 1 commits
```