### PR TITLE
Upgrade gsutil dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3==1.28.7
 Flask==2.3.3
 glean-parser~=13.0.0
 google-cloud-storage==2.2.1
-gsutil==5.10
+gsutil==5.27
 Jinja2==3.1.3
 jsonschema==3.1.1
 python-dateutil==2.8.0


### PR DESCRIPTION
This makes probe-scraper run on Python 3.12
Previous versions of gsutil load in `boto`, which is not compatible with Python 3.12