### PR TITLE
Remove skip metric hacks, remove engine-gecko

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -139,10 +139,6 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
 
         duplicate_sources = {}
         for k, v in metric_sources.items():
-            # Exempt cases when one of the sources is Geckoview Streaming to
-            # avoid false positive duplication accross app channels.
-            v = [dep for dep in v if "engine-gecko" not in dep]
-
             if len(v) > 1:
                 duplicate_sources[k] = v
 

--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -16,14 +16,6 @@ from probe_scraper import probe_expiry_alert
 
 from .scrapers.git_scraper import Commit
 
-# Ugly hack to skip certain metrics which we know aren't duplicated,
-# but show up duplicated due to them being moved from one
-# to the other application/library.
-SKIP_METRICS = {
-    "gecko.version": ["gecko", "pine", "firefox-desktop"],
-    "gecko.build_id": ["gecko", "pine", "firefox-desktop"],
-}
-
 
 def _metric_sort_key(metric: Dict[str, Any]):
     return (
@@ -150,11 +142,6 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
             # Exempt cases when one of the sources is Geckoview Streaming to
             # avoid false positive duplication accross app channels.
             v = [dep for dep in v if "engine-gecko" not in dep]
-
-            if k in SKIP_METRICS.keys():
-                potential_deps = SKIP_METRICS[k]
-                if any([dep for dep in potential_deps if dep in v]):
-                    continue
 
             if len(v) > 1:
                 duplicate_sources[k] = v

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -63,23 +63,6 @@ libraries:
     variants:
       - v1_name: sync
         dependency_name: org.mozilla.appservices:syncmanager
-  - library_name: engine-gecko
-    description: GeckoView metrics
-    notification_emails:
-      - aplacitelli@mozilla.com
-      - android-components-team@mozilla.com
-      - geckoview-team@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
-    metrics_files: []
-    variants:
-      - v1_name: engine-gecko
-        branch: release
-        dependency_name: org.mozilla.components:browser-engine-gecko
-      - v1_name: engine-gecko-beta
-        branch: beta
-        dependency_name: org.mozilla.components:browser-engine-gecko-beta
-      - v1_name: engine-gecko-nightly
-        dependency_name: org.mozilla.components:browser-engine-gecko-nightly
 
   - library_name: logins-store
     description: >-
@@ -434,22 +417,16 @@ applications:
       - v1_name: firefox-android-release
         app_id: org.mozilla.firefox
         app_channel: release
-        additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko
         description: >-
           Release channel of Firefox for Android.
       - v1_name: firefox-android-beta
         app_id: org.mozilla.firefox_beta
         app_channel: beta
-        additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko-beta
         description: >-
           Beta channel of Firefox for Android.
       - v1_name: fenix
         app_id: org.mozilla.fenix
         app_channel: nightly
-        additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko-beta
         description: >-
           Nightly channel of Firefox for Android.
           Prior to June 2020, this app_id was used for the beta channel
@@ -457,15 +434,11 @@ applications:
       - v1_name: fenix-nightly
         app_id: org.mozilla.fenix.nightly
         app_channel: nightly
-        additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko-nightly
         description: >-
           Nightly channel of Firefox Preview.
       - v1_name: firefox-android-nightly
         app_id: org.mozilla.fennec.aurora
         app_channel: nightly
-        additional_dependencies:
-          - org.mozilla.components:browser-engine-gecko-beta
         description: >-
           Nightly channel of Firefox for Android users migrated to Fenix;
           delisted in June 2020.


### PR DESCRIPTION
Fixes #697

---

I _think_ we can do this now?
A dry-run locally succeeds.

```
python3 -m probe_scraper.runner --dry-run --cache-dir tmp/cache --out-dir tmp/out --glean --glean-repo firefox-klar-android --glean-repo service-nimbus --glean-repo nimbus --glean-limit-date 2024-04-01 --update --output-bucket=gs://probe-scraper-prod-artifacts/ --glean-repo firefox-desktop --glean-repo gecko --glean-repo engine-gecko --glean-repo firefox-android-release
```

might want some more testing before we actually land this.