### PR TITLE
Revert "Add new glean-server library to define pings for server-side Glean"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -21,19 +21,6 @@ libraries:
         branch: main
         dependency_name: glean-core
 
-  - library_name: glean-server
-    description: Modern cross-platform telemetry (server usage)
-    notification_emails:
-      - glean-team@mozilla.com
-    url: https://github.com/mozilla/glean_parser
-    metrics_files: []
-    ping_files:
-      - server-side-pings.yaml
-    variants:
-      - v1_name: glean-server
-        branch: main
-        dependency_name: glean-server
-
   - library_name: glean-android
     description: Modern cross-platform telemetry (Android-specific)
     notification_emails:
@@ -1368,8 +1355,7 @@ applications:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
-    dependencies:
-      - glean-server
+    dependencies: []
     channels:
       - v1_name: accounts-backend
         app_id: accounts.backend
@@ -1475,8 +1461,7 @@ applications:
     metrics_files:
       - .glean/metrics.yaml
     ping_files: []
-    dependencies:
-      - glean-server
+    dependencies: []
     channels:
       - v1_name: moso-mastodon-backend
         app_id: moso.mastodon.backend


### PR DESCRIPTION
This reverts https://github.com/mozilla/probe-scraper/pull/717 which broke `mozilla_schema_generator` [task](https://workflow.telemetry.mozilla.org/dags/probe_scraper/grid?tab=logs&dag_run_id=scheduled__2024-04-10T00%3A00%3A00%2B00%3A00&task_id=mozilla_schema_generator).
It turns out that before, when dependency list was empty, schema generator pulled `glean-core` as a default dependency. This added internal Glean metrics to `accounts-events` schema. Now when we add `glean-server` dependency these metrics are not added to the schema and generator fails at validation stage.