### PR TITLE
feat(bug-1891646): add firefox_bridge app to repositories.yaml

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1568,3 +1568,25 @@ applications:
     channels:
       - v1_name: tiktokreporter-android
         app_id: org.mozilla.tiktokreporter
+
+  - app_name: firefox_bridge
+    canonical_app_name: Firefox Bridge
+    app_description: |
+      This is a chromium & firefox extension that allows the user to easily swap
+      between browsers on their device.
+    url: https://github.com/mozilla-extensions/firefox-bridge
+    notification_emails:
+      - ahabibi@mozilla.com
+    branch: main
+    metrics_files:
+      - "./metrics.yaml"
+    ping_files:
+      - "./pings.yaml"
+    dependencies:
+      - glean-js
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400
+    channels:
+      - v1_name: firefox-bridge
+        app_id: org.mozilla.firefox-bridge

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1572,16 +1572,16 @@ applications:
   - app_name: firefox_bridge
     canonical_app_name: Firefox Bridge
     app_description: |
-      This is a chromium & firefox extension that allows the user to easily swap
+      A Chromium & Firefox extension that allows the user to easily swap
       between browsers on their device.
     url: https://github.com/mozilla-extensions/firefox-bridge
     notification_emails:
       - ahabibi@mozilla.com
     branch: main
     metrics_files:
-      - "./metrics.yaml"
+      - metrics.yaml
     ping_files:
-      - "./pings.yaml"
+      - pings.yaml
     dependencies:
       - glean-js
     moz_pipeline_metadata_defaults:
@@ -1589,4 +1589,4 @@ applications:
         delete_after_days: 400
     channels:
       - v1_name: firefox-bridge
-        app_id: org.mozilla.firefox-bridge
+        app_id: firefox.bridge


### PR DESCRIPTION
# feat(bug-1891646): add firefox_bridge app to repositories.yaml

Bug link: https://bugzilla.mozilla.org/show_bug.cgi?id=1891646

[ ] Make sure the project repository has [Validate and publish metrics](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics) Github Action set up.