### PR TITLE
Bug 1874935 - Add new glean-server libraries to define pings for server-side Glean

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -21,6 +21,36 @@ libraries:
         branch: main
         dependency_name: glean-core
 
+  - library_name: glean-server
+    description: Modern cross-platform telemetry (server usage)
+    notification_emails:
+      - glean-team@mozilla.com
+    url: https://github.com/mozilla/glean_parser
+    metrics_files: []
+    ping_files:
+      - server_telemetry/server-side-pings.yaml
+    variants:
+      - v1_name: glean-server
+        branch: main
+        dependency_name: glean-server
+
+  - library_name: glean-server-metrics-compat
+    description: >-
+      Modern cross-platform telemetry (server usage).
+      This is a temporary library to transition existing server applications to
+      the new glean-server library. It is not intended for new applications.
+    notification_emails:
+      - glean-team@mozilla.com
+    url: https://github.com/mozilla/glean_parser
+    metrics_files:
+      - server_telemetry/sdk-metrics-compat.yaml
+    ping_files:
+      - server_telemetry/server-side-pings.yaml
+    variants:
+      - v1_name: glean-server-metrics-compat
+        branch: main
+        dependency_name: glean-server-metrics-compat
+
   - library_name: glean-android
     description: Modern cross-platform telemetry (Android-specific)
     notification_emails:
@@ -1358,7 +1388,8 @@ applications:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
-    dependencies: []
+    dependencies:
+      - glean-server-metrics-compat
     channels:
       - v1_name: accounts-backend
         app_id: accounts.backend
@@ -1464,7 +1495,8 @@ applications:
     metrics_files:
       - .glean/metrics.yaml
     ping_files: []
-    dependencies: []
+    dependencies:
+      - glean-server-metrics-compat
     channels:
       - v1_name: moso-mastodon-backend
         app_id: moso.mastodon.backend


### PR DESCRIPTION
Requires https://github.com/mozilla/glean_parser/pull/695 for tests to pass.

This is a follow up to https://github.com/mozilla/probe-scraper/pull/717 which was reverted in https://github.com/mozilla/probe-scraper/pull/726.

This should be merged together with https://github.com/mozilla/mozilla-schema-generator/pull/262 to avoid probe-scraper DAG failure.