### PR TITLE
fog updater: Use only the team slug

### DIFF
--- a/fog-updater/src/fog_update.py
+++ b/fog-updater/src/fog_update.py
@@ -15,7 +15,7 @@ DEFAULT_ORGANIZATION = "mozilla"
 DEFAULT_AUTHOR_NAME = "data-updater"
 DEFAULT_AUTHOR_EMAIL = "telemetry-alerts@mozilla.com"
 USAGE = "usage: fog-update"
-REVIEWERS = ["@mozilla/glean"]
+REVIEWERS = ["glean"]
 INDEX_URL = "https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/glean/metrics_index.py"  # noqa
 BODY_TEMPLATE = f"""This (automated) patch updates the list from metrics_index.py.
 


### PR DESCRIPTION
Turns out the CI jobs have actually been failing with:

  Reviews may only be requested from collaborators.
  One or more of the teams you specified is not a collaborator of the mozilla/probe-scraper repository

See https://github.com/mozilla/probe-scraper/actions/runs/8889252923/job/24407338315

The team slug should be enough.
(Luckily we rely on CODEOWNERS anyway to automatically add reviewers)