### PR TITLE
Update to gsutil 5.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto3==1.28.7
 Flask==2.3.3
 glean-parser~=14.1.0
 google-cloud-storage==2.2.1
-gsutil==5.27
+gsutil==5.28
 Jinja2==3.1.3
 jsonschema==3.1.1
 python-dateutil==2.8.0


### PR DESCRIPTION
This was released 3 days ago, along with gcs-oauth2-boto-plugin 3.1, whereas gcs-oauth2-boto-plugin needs a new dependency but that one is actually added as a dependency of gsutil.
Due to no version limit gcs-oauth2-boto-plugin==3.1 gets pulled in even with gsutil 5.27.