### PR TITLE
Bug 1874935 - Update accounts_backend metrics definitions

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1388,6 +1388,7 @@ applications:
     branch: main
     metrics_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
+      - packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
     dependencies:


### PR DESCRIPTION
Requires https://github.com/mozilla/fxa/pull/16864

This adds definitions of internal Glean metrics to be included in a the custom FxA ping. This is a temporary solution until we fully migrate FxA to use `events` ping.