### PR TITLE
fog update bot: don't try to set the team reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@ repositories.yaml @chutten @akkomar @whd @mikaeld @dexterp37 @badboy @travis79
 # The exclusion list in git_scraper.py can cause similar problems (see e.g.
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1745771)
 probe_scraper/scrapers/git_scraper.py @chutten @akkomar @whd @mikaeld @dexterp37 @badboy @travis79
+
+fog_updater/* @chutten @badboy

--- a/fog-updater/src/fog_update.py
+++ b/fog-updater/src/fog_update.py
@@ -15,7 +15,6 @@ DEFAULT_ORGANIZATION = "mozilla"
 DEFAULT_AUTHOR_NAME = "data-updater"
 DEFAULT_AUTHOR_EMAIL = "telemetry-alerts@mozilla.com"
 USAGE = "usage: fog-update"
-REVIEWERS = ["glean"]
 INDEX_URL = "https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/glean/metrics_index.py"  # noqa
 BODY_TEMPLATE = f"""This (automated) patch updates the list from metrics_index.py.
 
@@ -220,7 +219,7 @@ def main(argv, repo, author, debug=False, dry_run=False):
         head=pr_branch_name,
         base=release_branch_name,
     )
-    pr.create_review_request(team_reviewers=REVIEWERS)
+    pr.create_review_request()
     print(f"{ts()} Pull request at {pr.html_url}")
 
 


### PR DESCRIPTION
no idea why but it now fails with a different error: https://github.com/mozilla/probe-scraper/actions/runs/8964004574/job/24632492687

> github.GithubException.GithubException: 422 {"message": "Validation Failed", "errors": ["Could not resolve to a node with the global id of 'MDQ6VGVhbTMyNTAxODc='."], "documentation_url": "https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request"}

we make use of CODEOWNERS anyway, so a bunch of people will be auto-asked for review. 