### PR TITLE
Bug 1874935 - Roll back dependency updates to backend apps

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1389,7 +1389,6 @@ applications:
     branch: main
     metrics_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
-      - packages/fxa-shared/metrics/glean/glean-backend-metrics-compat.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
     dependencies:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1391,8 +1391,7 @@ applications:
       - packages/fxa-shared/metrics/glean/fxa-backend-metrics.yaml
     ping_files:
       - packages/fxa-shared/metrics/glean/fxa-backend-pings.yaml
-    dependencies:
-      - glean-server-metrics-compat
+    dependencies: []
     channels:
       - v1_name: accounts-backend
         app_id: accounts.backend
@@ -1498,8 +1497,7 @@ applications:
     metrics_files:
       - .glean/metrics.yaml
     ping_files: []
-    dependencies:
-      - glean-server-metrics-compat
+    dependencies: []
     channels:
       - v1_name: moso-mastodon-backend
         app_id: moso.mastodon.backend


### PR DESCRIPTION
This should fix `probe_scraper.mozilla_schema_generator` Airflow task that is currently failing.

The reason for failure is metrics added to FxA in https://github.com/mozilla/fxa/pull/16864 not being picked up by probe scraper. This is caused by the wrong schema identifier in the metrics file. This will get fixed in https://github.com/mozilla/fxa/pull/16872/files.

Nevertheless, these metrics still will not go through probe scraper because their names start with `glean` and are treated as internal by glean_parser. I'd rather revert here to the last known working configuration and think about a fix tomorrow.