### PR TITLE
Bug 1874935 - Allow reserved metrics for accounts-backend

### DIFF
--- a/probe_scraper/runner.py
+++ b/probe_scraper/runner.py
@@ -448,7 +448,15 @@ def load_glean_metrics(
                 ]
 
                 try:
-                    config = {"allow_reserved": repo_name.startswith("glean")}
+                    config = {
+                        "allow_reserved": repo_name.startswith("glean")
+                        # Temporarily allow reserved metrics in accounts-backend
+                        # We need this because `accounts-events` pings was deployed to BQ
+                        # with internal Glean metrics. These metrics are now defined in
+                        # FxA repository. FxA is moving away from custom ping to `events` ping.
+                        # When this happens we'll be able to remove this special case.
+                        or repo_name == "accounts-backend"
+                    }
                     repo = next(
                         r for r in repositories if r.name == repo_name
                     ).to_dict()


### PR DESCRIPTION
Requires https://github.com/mozilla/fxa/pull/16872

I have confirmed that this works by running:
```
OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/ python3 -m probe_scraper.glean_push '{
    "url": "https://github.com/mozilla/fxa",
    "commit":"5e45c0350082d20c6082a66caeaa7f5c11bedfd6",
    "branch":"16872/merge"
  }'
```
Which returns:
```
HTTP 200: update is valid, but not published
```