### PR TITLE
Bug 1874935 - Allow duplicate metrics from glean-server-metrics-compat

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -149,7 +149,16 @@ def check_for_duplicate_metrics(repositories, metrics_by_repo, emails):
         for k, v in metric_sources.items():
             # Exempt cases when one of the sources is Geckoview Streaming to
             # avoid false positive duplication accross app channels.
-            v = [dep for dep in v if "engine-gecko" not in dep]
+            # Temporarily exempt cases when one of the sources is server compat library
+            # to avoid raising alarm for metrics defined in fxa's custom ping.
+            v = [
+                dep
+                for dep in v
+                if (
+                    "engine-gecko" not in dep
+                    and "glean-server-metrics-compat" not in dep
+                )
+            ]
 
             if k in SKIP_METRICS.keys():
                 potential_deps = SKIP_METRICS[k]


### PR DESCRIPTION
See Option 2 in https://bugzilla.mozilla.org/show_bug.cgi?id=1874935#c16

This should be merged after https://github.com/mozilla/glean_parser/pull/704