### PR TITLE
[DENG-577] Add glean ping expiry alerts based on retention policy

### DIFF
--- a/probe_scraper/glean_ping_expiry_alert.py
+++ b/probe_scraper/glean_ping_expiry_alert.py
@@ -1,0 +1,294 @@
+import argparse
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from typing import Dict, List, Tuple
+
+import requests
+from dateutil.tz import tzutc
+from dateutil.utils import today
+from google.cloud import bigquery
+from google.cloud.exceptions import Forbidden
+
+from probe_scraper.emailer import send_ses
+
+EMAIL_SUBJECT_TEMPLATE = "Glean Pings Expiring for {app_name}"
+
+EMAIL_TEMPLATE = """
+The following Glean pings are set to start deleting collected data soon based on the retention policy.
+{pings}
+What to do about this:
+1. If this is expected and you do not need data for any of these pings past the retention dates, then no action is needed.
+2. If you wish to continue collecting data for a longer period of time for any of these pings, TODO: create a jira ticket?
+
+Retention policies are defined in probe-scraper [1], with options to either stop collecting data after a certain or delete data older than the specified number of days.
+
+If you have any problems, please ask for help on the #glean Slack channel. We'll give you a hand.
+
+Your Friendly, Neighborhood Glean Team
+
+[1] - https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+
+This is an automated message sent from probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
+"""  # noqa
+
+APP_GROUP_TEMPLATE = """
+{app_name}:
+{messages}
+"""
+
+RETENTION_DAYS_MESSAGE_TEMPLATE = '\t- The "{ping_name}" ping for will start deleting data older than {retention_days} days starting on {expiry_date}'  # noqa
+
+COLLECT_THROUGH_MESSAGE_TEMPLATE = (
+    '\t- The "{ping_name}" ping for will stop collecting data after {end_date}'
+)
+
+DEFAULT_EMAILS = ["glean-team@mozilla.com"]
+
+NOTIFICATION_DAYS = 17
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--run-date",
+        "--run_date",
+        type=date.fromisoformat,
+        required=True,
+        help="The date to use to check for expiring pings",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "--dry_run",
+        "--dryrun",
+        action="store_true",
+        help="Whether emails should be sent, used for testing",
+    )
+    parser.add_argument(
+        "--bigquery-project",
+        "--bigquery_project",
+        default="moz-fx-data-shared-prod",
+        help="Bigquery project in which ping tables are located",
+    )
+    return parser.parse_args()
+
+
+def request_get(url: str) -> Dict:
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_oldest_partition_date(
+    client: bigquery.Client, full_table_id: str, partition_fallback: bool
+) -> date:
+    """Get the date of the oldest partition in the given table.
+
+    This attempts to get the partitions using the partition summary which requires read
+    access on the table data.  If the client does not have the necessary permissions and
+    `partition_fallback` is set to true, the oldest partition is inferred from the number of
+    partitions in the table.  This can be used for local testing with restricted-access tables.
+    """
+
+    first_partition_date = None
+    try:
+        partitions = [
+            partition
+            for partition in client.list_partitions(full_table_id)
+            if partition != "__NULL__"
+        ]
+        if len(partitions) > 0:
+            first_partition_date = datetime.strptime(min(partitions), "%Y%m%d").date()
+    except Forbidden:
+        if partition_fallback:
+            print(f"Inferring partition from number of partitions for {full_table_id}")
+            table = client.get_table(full_table_id)
+            first_partition_date = (
+                today(tzinfo=tzutc())
+                - timedelta(days=int(table._properties["numPartitions"]) - 1)
+            ).date()
+
+    return first_partition_date
+
+
+def is_reaching_retention_limit(
+    run_date: date, retention_days: int, oldest_partition_date: date
+) -> bool:
+    return (
+        retention_days is not None
+        and oldest_partition_date is not None
+        and 3
+        < retention_days - (run_date - oldest_partition_date).days
+        <= NOTIFICATION_DAYS
+    )
+
+
+def is_reaching_collect_through_date(run_date: date, collect_through_date: str) -> bool:
+    return (
+        collect_through_date is not None
+        and 3
+        < (date.fromisoformat(collect_through_date) - run_date).days
+        <= NOTIFICATION_DAYS
+    )
+
+
+def send_emails(messages_by_email: Dict[str, Dict[str, List[str]]], dryrun: bool):
+    for email, messages_by_app in messages_by_email.items():
+        combined_messages = [
+            APP_GROUP_TEMPLATE.format(app_name=app, messages="\n".join(messages))
+            for app, messages in messages_by_app.items()
+        ]
+        email_body = EMAIL_TEMPLATE.format(pings="".join(combined_messages))
+        email_subject = EMAIL_SUBJECT_TEMPLATE.format(
+            app_name=(
+                f"{len(messages_by_app)} apps"
+                if len(messages_by_app) > 1
+                else list(messages_by_app.keys())[0]
+            )
+        )
+        send_ses(
+            fromaddr="telemetry-alerts@mozilla.com",
+            subject=email_subject,
+            body=email_body,
+            recipients=[email],
+            dryrun=dryrun,
+        )
+
+
+def get_expiring_pings(
+    run_date: datetime.date,
+    project_id: str,
+    partition_fallback: bool = False,
+) -> Tuple[Dict[str, Dict[str, List[str]]], Dict[str, List]]:
+    """
+    Get expiring pings across all apps and a tuple of expiring pings and errors encountered.
+
+    Expiring pings are stored in a dict where the key is an email to send to and the value
+    is a dict with list of messages per app.
+
+    Errors are stored in a dict where the key is a bigquery table name and the value is a list of
+    errors related to the associated ping.
+
+    If partition_fallback is true, calculate the oldest partition date using the number of
+    partitions in a table if missing read permissions on the table.  This is used for local testing.
+    """
+    client = bigquery.Client(project=project_id)
+
+    app_listings = request_get(
+        "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
+    )
+    errors = defaultdict(list)
+    # dict structure: {email: {app_name: [messages]}}
+    expiring_pings_by_email = defaultdict(lambda: defaultdict(list))
+
+    for app in app_listings:
+        if app.get("deprecated", False) is True:
+            continue
+
+        app_name = app["v1_name"]
+        dataset_id = app["bq_dataset_family"] + "_stable"
+
+        # get active tables to include pings defined in dependencies are included
+        tables = client.list_tables(dataset_id)
+
+        pings = request_get(
+            f"https://probeinfo.telemetry.mozilla.org/glean/{app_name}/pings"
+        )
+        default_ping_metadata = {
+            "moz_pipeline_metadata": {},
+            "history": [{"notification_emails": app["notification_emails"]}],
+        }
+
+        for table in tables:
+            table_id = str(table.reference)
+            ping_name = table.table_id.replace("_v1", "").replace("_", "-")
+            ping_metadata = pings.get(ping_name, default_ping_metadata)
+
+            # merge pipeline metadata from /pings and /app-listings to verify metadata is propagated
+            pipeline_metadata = {
+                **ping_metadata["moz_pipeline_metadata"],
+                **app.get("moz_pipeline_metadata", {}).get(ping_name, {}),
+            }
+
+            expiration_policy = pipeline_metadata.get("expiration_policy", {})
+            retention_days_metadata = expiration_policy.get("delete_after_days")
+            collect_through_date = expiration_policy.get("collect_through_date")
+
+            retention_days_applied = (
+                int(table.time_partitioning.expiration_ms / 1000 / 60 / 60 / 24)
+                if table.time_partitioning.expiration_ms is not None
+                else None
+            )
+
+            # If retention is defined in probe scraper, the expiration on the table must match
+            # retention_days_metadata may be null if retention is set in the app defaults
+            if (
+                retention_days_metadata is not None
+                and retention_days_applied != retention_days_metadata
+            ):
+                errors[table_id].append(
+                    f"Retention period in metadata ({retention_days_metadata} days) "
+                    f"does not match period applied to table ({retention_days_applied} days)"
+                )
+
+            # no retention policy
+            if retention_days_applied is None and collect_through_date is None:
+                continue
+
+            oldest_partition_date = get_oldest_partition_date(
+                client, table_id, partition_fallback
+            )
+            if oldest_partition_date is None:
+                errors[table_id].append(
+                    f"Could not get earliest partition for {table.table_id}"
+                )
+
+            # Use emails for ping if they exist, otherwise use emails for app
+            # e.g. for pings from dependencies
+            email_list = set(
+                ping_metadata["history"][-1].get(
+                    "notification_emails", app["notification_emails"]
+                )
+                + DEFAULT_EMAILS
+            )
+
+            if is_reaching_retention_limit(
+                run_date, retention_days_applied, oldest_partition_date
+            ):
+                message = RETENTION_DAYS_MESSAGE_TEMPLATE.format(
+                    ping_name=ping_name,
+                    retention_days=retention_days_applied,
+                    expiry_date=oldest_partition_date
+                    + timedelta(days=retention_days_applied),
+                )
+                for email in email_list:
+                    expiring_pings_by_email[email][app_name].append(message)
+
+            # Approaching collect through date
+            if is_reaching_collect_through_date(run_date, collect_through_date):
+                message = COLLECT_THROUGH_MESSAGE_TEMPLATE.format(
+                    ping_name=ping_name,
+                    end_date=collect_through_date,
+                )
+                for email in email_list:
+                    expiring_pings_by_email[email][app_name].append(message)
+
+    return expiring_pings_by_email, errors
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    expiring_pings_by_email, errors = get_expiring_pings(
+        run_date=args.run_date,
+        project_id=args.bigquery_project,
+        partition_fallback=args.dry_run,
+    )
+
+    # Only send emails on Wednesday, dry run on other days for error checking
+    dry_run = args.dry_run or args.run_date.weekday() != 2
+
+    send_emails(expiring_pings_by_email, dry_run)
+
+    if len(errors) > 0:
+        error_string = "\n".join([f"{ping}: {msg}" for ping, msg in errors.items()])
+        raise RuntimeError(f"Encountered {len(errors)} errors: \n{error_string}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ GitPython==3.1.41
 boto3==1.28.7
 Flask==2.3.3
 glean-parser~=14.1.0
+google-cloud-bigquery==3.23.1
 google-cloud-storage==2.2.1
 gsutil==5.28
 Jinja2==3.1.3

--- a/tests/test_glean_ping_expiry_alert.py
+++ b/tests/test_glean_ping_expiry_alert.py
@@ -1,0 +1,329 @@
+import datetime
+import re
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+from probe_scraper import glean_ping_expiry_alert
+
+
+def test_is_reaching_retention_limit_expired():
+    assert not glean_ping_expiry_alert.is_reaching_retention_limit(
+        run_date=datetime.date(year=2024, month=1, day=21),
+        retention_days=20,
+        oldest_partition_date=datetime.date(year=2024, month=1, day=1),
+    )
+
+
+def test_is_reaching_retention_limit_not_expired():
+    assert not glean_ping_expiry_alert.is_reaching_retention_limit(
+        run_date=datetime.date(year=2024, month=1, day=2),
+        retention_days=30,
+        oldest_partition_date=datetime.date(year=2024, month=1, day=1),
+    )
+
+
+def test_is_reaching_retention_limit_expiring():
+    assert glean_ping_expiry_alert.is_reaching_retention_limit(
+        run_date=datetime.date(year=2024, month=1, day=20),
+        retention_days=30,
+        oldest_partition_date=datetime.date(year=2024, month=1, day=1),
+    )
+
+
+def test_is_reaching_collect_through_date_expired():
+    assert not glean_ping_expiry_alert.is_reaching_collect_through_date(
+        run_date=datetime.date(year=2024, month=1, day=20),
+        collect_through_date="2024-01-10",
+    )
+
+
+def test_is_reaching_collect_through_date_not_expired():
+    assert not glean_ping_expiry_alert.is_reaching_collect_through_date(
+        run_date=datetime.date(year=2024, month=1, day=1),
+        collect_through_date="2024-01-30",
+    )
+
+
+def test_is_reaching_collect_through_date_expiring():
+    assert glean_ping_expiry_alert.is_reaching_collect_through_date(
+        run_date=datetime.date(year=2024, month=1, day=20),
+        collect_through_date="2024-01-30",
+    )
+
+
+APP_LISTINGS = [
+    {
+        "bq_dataset_family": "firefox_desktop",
+        "moz_pipeline_metadata": {
+            "ping-1": {"expiration_policy": {"delete_after_days": 30}},
+            "ping-2": {
+                "expiration_policy": {
+                    "delete_after_days": 40,
+                    "collect_through_date": "2024-01-01",
+                }
+            },
+        },
+        "notification_emails": ["desktop@mozilla.com"],
+        "v1_name": "firefox-desktop",
+    },
+    {
+        "bq_dataset_family": "firefox_desktop_background_update",
+        "notification_emails": ["desktop-update@mozilla.com"],
+        "moz_pipeline_metadata": {
+            "ping-1": {"expiration_policy": {"delete_after_days": 25}},
+        },
+        "v1_name": "firefox-desktop-background-update",
+    },
+]
+
+PINGS_BY_APP = {
+    "firefox-desktop": {
+        "ping-1": {
+            "moz_pipeline_metadata": {"expiration_policy": {"delete_after_days": 30}},
+            "history": [{}],
+        },
+        "ping-2": {
+            "moz_pipeline_metadata": {
+                "expiration_policy": {
+                    "delete_after_days": 40,
+                    "collect_through_date": "2024-01-01",
+                }
+            },
+            "history": [{"notification_emails": ["desktop-2@mozilla.com"]}],
+        },
+    },
+    "firefox-desktop-background-update": {},  # pings defined in dependency
+}
+
+
+def mock_request(url: str):
+    if url.endswith("/app-listings"):
+        return APP_LISTINGS
+    elif app_name_match := re.search(
+        r"glean/([a-z0-9-]+)/pings$", url, flags=re.IGNORECASE
+    ):
+        app_name = app_name_match.group(1)
+        return PINGS_BY_APP.get(app_name, {})
+    else:
+        raise ValueError(f"invalid url: {url}")
+
+
+class MockTable(MagicMock):
+    def __init__(
+        self, name: str, dataset: str, retention_days: Optional[int], *args, **kw
+    ):
+        super().__init__(*args, **kw)
+        self.table_id = name
+        self.reference = f"proj.{dataset}.{name}"
+        self.time_partitioning = MagicMock()
+        self.time_partitioning.expiration_ms = (
+            retention_days * 24 * 60 * 60 * 1000 if retention_days is not None else None
+        )
+
+    def __repr__(self):
+        return self.reference
+
+
+@patch("probe_scraper.glean_ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_already_expired(mock_client_class):
+    """Alerts should not be sent for pings that have already expired."""
+
+    def mock_tables(dataset: str):
+        return {
+            "firefox_desktop_stable": [
+                MockTable("ping_1_v1", dataset, 30),
+                MockTable("ping_2_v1", dataset, 40),
+            ],
+            "firefox_desktop_background_update_stable": [],
+        }[dataset]
+
+    def mock_partitions(table_id: str):
+        return {
+            "proj.firefox_desktop_stable.ping_1_v1": [
+                "20240101",
+                "20240402",
+                "20240419",
+                "__NULL__",
+            ],
+            "proj.firefox_desktop_stable.ping_2_v1": [
+                "20231221",
+                "20240101",
+                "20240419",
+            ],
+        }[table_id]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.list_tables = mock_tables
+    mock_client.list_partitions = mock_partitions
+
+    expiring, errors = glean_ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2024-01-31"),
+        project_id="proj",
+        partition_fallback=False,
+    )
+
+    assert len(expiring) == 0
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.glean_ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_not_expired(mock_client_class):
+    """Alerts should not be sent if future expiry date is out of range."""
+
+    def mock_tables(dataset: str):
+        return {
+            "firefox_desktop_stable": [
+                MockTable("ping_1_v1", dataset, 30),
+                MockTable("ping_2_v1", dataset, 40),
+            ],
+            "firefox_desktop_background_update_stable": [],
+        }[dataset]
+
+    def mock_partitions(table_id: str):
+        return {
+            "proj.firefox_desktop_stable.ping_1_v1": ["20240101"],
+            "proj.firefox_desktop_stable.ping_2_v1": ["20240101"],
+        }[table_id]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.list_tables = mock_tables
+    mock_client.list_partitions = mock_partitions
+
+    expiring, errors = glean_ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2024-01-02"),
+        project_id="proj",
+        partition_fallback=False,
+    )
+
+    assert len(expiring) == 0
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.glean_ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_expired(mock_client_class):
+    """Alerts should be sent if the data will start being dropped soon."""
+
+    def mock_tables(dataset: str):
+        return {
+            "firefox_desktop_stable": [
+                MockTable("ping_1_v1", dataset, 30),
+                MockTable("ping_2_v1", dataset, 40),
+            ],
+            "firefox_desktop_background_update_stable": [
+                MockTable("ping_1_v1", dataset, 25),
+            ],
+        }[dataset]
+
+    def mock_partitions(table_id: str):
+        return {
+            "proj.firefox_desktop_stable.ping_1_v1": [
+                "20231205",
+            ],
+            "proj.firefox_desktop_stable.ping_2_v1": [
+                "20231220",
+            ],
+            "proj.firefox_desktop_background_update_stable.ping_1_v1": [
+                "20231210",
+            ],
+        }[table_id]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.list_tables = mock_tables
+    mock_client.list_partitions = mock_partitions
+
+    expiring, errors = glean_ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2023-12-21"),
+        project_id="proj",
+        partition_fallback=False,
+    )
+
+    assert len(expiring) == 4
+
+    # firefox-desktop ping-1 expiry
+    assert set(expiring["desktop@mozilla.com"].keys()) == {"firefox-desktop"}
+    assert len(expiring["desktop@mozilla.com"]["firefox-desktop"]) == 1
+    assert "ping-1" in expiring["desktop@mozilla.com"]["firefox-desktop"][0]
+
+    # firefox-desktop ping-2 collect through date
+    assert set(expiring["desktop-2@mozilla.com"].keys()) == {"firefox-desktop"}
+    assert len(expiring["desktop-2@mozilla.com"]["firefox-desktop"]) == 1
+    assert "ping-2" in expiring["desktop-2@mozilla.com"]["firefox-desktop"][0]
+    assert "2024-01-01" in expiring["desktop-2@mozilla.com"]["firefox-desktop"][0]
+
+    # firefox-desktop-background-update ping-1 expiry
+    assert set(expiring["desktop-update@mozilla.com"].keys()) == {
+        "firefox-desktop-background-update"
+    }
+    assert (
+        len(expiring["desktop-update@mozilla.com"]["firefox-desktop-background-update"])
+        == 1
+    )
+    assert (
+        "ping-1"
+        in expiring["desktop-update@mozilla.com"]["firefox-desktop-background-update"][
+            0
+        ]
+    )
+
+    # default email should receive everything
+    assert set(expiring[glean_ping_expiry_alert.DEFAULT_EMAILS[0]].keys()) == {
+        "firefox-desktop",
+        "firefox-desktop-background-update",
+    }
+    assert (
+        len(expiring[glean_ping_expiry_alert.DEFAULT_EMAILS[0]]["firefox-desktop"]) == 2
+    )
+    assert (
+        len(
+            expiring[glean_ping_expiry_alert.DEFAULT_EMAILS[0]][
+                "firefox-desktop-background-update"
+            ]
+        )
+        == 1
+    )
+
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.glean_ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_retention_days_not_matching(mock_client_class):
+    """Errors should be returned if the retention of the table does not match the metadata."""
+
+    def mock_tables(dataset: str):
+        return {
+            "firefox_desktop_stable": [
+                MockTable("ping_1_v1", dataset, 50),
+                MockTable("ping_2_v1", dataset, None),
+            ],
+            "firefox_desktop_background_update_stable": [],
+        }[dataset]
+
+    def mock_partitions(table_id: str):
+        return {
+            "proj.firefox_desktop_stable.ping_1_v1": ["20240101"],
+            "proj.firefox_desktop_stable.ping_2_v1": ["20240101"],
+        }[table_id]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.list_tables = mock_tables
+    mock_client.list_partitions = mock_partitions
+
+    expiring, errors = glean_ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2024-01-02"),
+        project_id="proj",
+        partition_fallback=False,
+    )
+
+    assert len(expiring) == 0
+
+    assert len(errors) == 2
+    assert "proj.firefox_desktop_stable.ping_1_v1" in errors
+    assert "proj.firefox_desktop_stable.ping_2_v1" in errors


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-577

Email alerts for glean pings that are reaching either the `collect_through_date` or `delete_after_days`.

WIP, behaviour that needs some discussion:
- Meant to run weekly, with alerts when the expiration date is between 3 and 17 days in the future
- Sends alerts per-ping in each app channel
  - should it only send one alert for the first expiring ping across all channels, send again for pings with retention different from the app default
- need to decide on the email wording and where to direct users who need to update the retention
- sends to emails in ping metadata for custom pings, emails in app metadata for inherited pings
