### PR TITLE
Repository check: Ignore files for deprecated apps

### DIFF
--- a/probe_scraper/check_repositories.py
+++ b/probe_scraper/check_repositories.py
@@ -36,6 +36,9 @@ for repo in repos:
         app_id_channels[repo.app_id][repo.channel] += 1
 
     for metric_file in metrics_files:
+        if repo.deprecated:
+            continue  # ignore missing files for deprecated apps
+
         if (repo.name, metric_file) in EXPECTED_MISSING_FILES:
             continue  # ignore missing files
 


### PR DESCRIPTION
No need to check them, they might go away at any point.

Fixes #764