### PR TITLE
Reassigns login-store notification email from teshaq to mhammond

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -116,7 +116,7 @@ libraries:
       A collection of Android libraries to build browsers or browser-like
       applications
     notification_emails:
-      - teshaq@mozilla.com
+      - mhammond@mozilla.com
       - sync-team@mozilla.com
     url: https://github.com/mozilla/application-services
     metrics_files:


### PR DESCRIPTION
I'm offboarding so changing the notification email that points to me, to point to @mhammond