### PR TITLE
Bug 1901844 - Add new Glean app "ads.backend"

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1653,3 +1653,23 @@ applications:
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 400
+
+  - app_name: ads_backend
+    canonical_app_name: Mozilla Ads Backend Service
+    app_description: |
+      Mozilla Ads Backend Service
+    url: https://github.com/mozilla-services/mars-telemetry
+    notification_emails:
+      - gleonard@mozilla.com
+    branch: main
+    metrics_files:
+      - telemetry/glean/metrics.yaml
+    ping_files: []
+    dependencies:
+      - glean-server
+    channels:
+      - v1_name: ads-backend
+        app_id: ads.backend
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400


### PR DESCRIPTION
Tested with:
```
export COMMAND='python -m probe_scraper.runner --glean --glean-repo ads-backend --dry-run'
make run
```
Which finished successfully:
```
Getting commits for repository ads-backend
Cloning https://github.com/mozilla-services/mars-telemetry into /tmp/tmppmrfhojp/mozilla-services/mars-telemetry.git
  Got 2 commits

writing output:
(...)
```