### PR TITLE
Expire `user-characteristics` ping after 90 days (fixes #759)

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -358,6 +358,9 @@ applications:
       spoc:
         expiration_policy:
           delete_after_days: 180
+      user-characteristics:
+        expiration_policy:
+          delete_after_days: 90
 
   - app_name: firefox_desktop_background_update
     canonical_app_name: Firefox for Desktop Background Update Task


### PR DESCRIPTION
This adds a section for the `user-characteristics` ping in Firefox Desktop in repositories.yaml to ensure that data is retained for no longer than 90 days.

@sean-rose Please review :)