### PR TITLE
Bump retention of single doctype

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -747,6 +747,9 @@ applications:
       temp-clients-sync:
         expiration_policy:
           delete_after_days: 1130
+      temp-credit-cards-sync:
+        expiration_policy:
+          delete_after_days: 1130
       temp-history-sync:
         expiration_policy:
           delete_after_days: 1130


### PR DESCRIPTION
This was going to hit 400d retention the day https://github.com/mozilla/probe-scraper/pull/780 landed so safer to extend retention for now. I did that via https://github.com/mozilla-services/cloudops-infra/compare/master...SRELEAD-182-temp to avoid blocking the schemas deploy yesterday.