### PR TITLE
[DENG-577] Add retention policy expiry alerts for stable table data

### DIFF
--- a/probe_scraper/ping_expiry_alert.py
+++ b/probe_scraper/ping_expiry_alert.py
@@ -1,0 +1,289 @@
+import argparse
+import re
+from collections import defaultdict
+from datetime import date, datetime
+from typing import Any, Dict, List, Tuple
+
+import requests
+from google.cloud import bigquery
+
+from probe_scraper.emailer import send_ses
+
+EMAIL_SUBJECT_TEMPLATE = "Glean Pings Expiring for {app_name}"
+
+EMAIL_TEMPLATE = """
+The following BigQuery tables are set to start deleting collected data soon based on the retention policies.
+
+{tables}
+
+What to do about this:
+
+1. If this is expected and you do not need data for any of these tables past the listed dates, then no action is needed.
+
+2. If you wish to continue collecting data for a longer period of time for any of these tables, please file Jira ticket for the data org, requesting the changes to retention settings at https://mozilla-hub.atlassian.net/secure/CreateIssue.jspa?issuetype=10180&pid=10057
+
+Retention policies are defined in probe-scraper [1], with options to either stop collecting data after a certain or delete data older than the specified number of days.
+
+For more information on requesting help from the data team, see https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/6849444/Getting+Help+Jira+documentation
+If you have any questions, please ask on the #data-help Slack channel. We'll give you a hand.
+
+Your Friendly, Neighborhood Data Team
+
+[1] - https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
+
+This is an automated message sent from probe-scraper.  See https://github.com/mozilla/probe-scraper for details.
+"""  # noqa
+
+APP_GROUP_TEMPLATE = """
+{app_name}:
+{messages}
+"""
+
+RETENTION_DAYS_MESSAGE_TEMPLATE = '\t- The "{table_name}" table for will start deleting data older than {retention_days} days starting on {expiry_date} ({num_weeks} weeks from now)'  # noqa
+
+# emails in this list will receive alerts for all pings
+DEFAULT_EMAILS = ["bewu@mozilla.com"]
+
+NOTIFICATION_DAYS_MAX = 25
+NOTIFICATION_DAYS_MIN = 5
+
+EXPIRATIONS_QUERY_TEMPLATE = """
+SELECT
+  project_id,
+  dataset_id,
+  ARRAY_AGG(
+    STRUCT(table_id, partition_expiration_days, next_deletion_date) ORDER BY table_id
+  ) AS tables,
+FROM
+  `moz-fx-data-shared-prod.monitoring_derived.table_partition_expirations_v1`
+WHERE
+  run_date = "{run_date}"
+  AND project_id = "{project}"
+  AND ENDS_WITH(dataset_id, "_stable")
+GROUP BY
+  project_id,
+  dataset_id
+ORDER BY
+  dataset_id
+"""
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--run-date",
+        "--run_date",
+        type=date.fromisoformat,
+        required=True,
+        help="The date to use to check for expiring pings",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "--dry_run",
+        "--dryrun",
+        action="store_true",
+        help="Whether emails should be sent, used for testing",
+    )
+    parser.add_argument(
+        "--bigquery-project",
+        "--bigquery_project",
+        default="moz-fx-data-shared-prod",
+        help="Bigquery project in which ping tables are located",
+    )
+    return parser.parse_args()
+
+
+def request_get(url: str) -> Dict:
+    response = requests.get(url)
+    response.raise_for_status()
+    return response.json()
+
+
+def send_emails(messages_by_email: Dict[str, Dict[str, List[str]]], dryrun: bool):
+    for email, messages_by_app in messages_by_email.items():
+        combined_messages = [
+            APP_GROUP_TEMPLATE.format(app_name=app, messages="\n".join(messages))
+            for app, messages in messages_by_app.items()
+        ]
+        email_body = EMAIL_TEMPLATE.format(tables="".join(combined_messages))
+        email_subject = EMAIL_SUBJECT_TEMPLATE.format(
+            app_name=(
+                f"{len(messages_by_app)} apps"
+                if len(messages_by_app) > 1
+                else list(messages_by_app.keys())[0]
+            )
+        )
+        send_ses(
+            fromaddr="telemetry-alerts@mozilla.com",
+            subject=email_subject,
+            body=email_body,
+            recipients=[email],
+            dryrun=dryrun,
+        )
+
+
+def table_name_to_doctype(table_name: str) -> str:
+    """Convert a bigquery table name to the associated telemetry document type."""
+    return re.sub("_v[0-9]+$", "", table_name).replace("_", "-")
+
+
+def validate_retention_settings(
+    dataset_info: bigquery.Row, app_info: Dict[str, Any]
+) -> List[Tuple[str, int, int]]:
+    """Return a list of tables that have retention settings that do not match metadata.
+
+    :param dataset_info: Row from the query on monitoring_derived.table_partition_expirations_v1.
+    :param app_info: Entry from probeinfo app listings
+
+    :return: List of tuples of (table_id, retention set in metadata, retention set in bigquery)
+    """
+    errors = []
+
+    pipeline_metadata = app_info.get("moz_pipeline_metadata", {})
+
+    default_retention_days = (
+        app_info.get("moz_pipeline_metadata_defaults", {})
+        .get("expiration_policy", {})
+        .get("delete_after_days")
+    )
+    for table_info in dataset_info["tables"]:
+        document_type = table_name_to_doctype(table_info["table_id"])
+        applied_retention_days = table_info["partition_expiration_days"]
+
+        if (
+            delete_after_days := pipeline_metadata.get(document_type, {})
+            .get("expiration_policy", {})
+            .get("delete_after_days")
+        ) is not None:
+            metadata_retention_days = delete_after_days
+        else:
+            metadata_retention_days = default_retention_days
+
+        if metadata_retention_days != applied_retention_days:
+            errors.append(
+                (
+                    f"{dataset_info['dataset_id']}.{table_info['table_id']}",
+                    metadata_retention_days,
+                    applied_retention_days,
+                )
+            )
+
+    return errors
+
+
+def get_expiring_pings(
+    run_date: datetime.date,
+    project_id: str,
+) -> Tuple[Dict[str, Dict[str, List[str]]], Dict[str, List]]:
+    """
+    Get expiring pings across all apps and a tuple of expiring pings and errors encountered.
+
+    Expiring pings are stored in a dict where the key is an email to send to and the value
+    is a dict with list of messages per app.
+
+    Errors are stored in a dict where the key is a bigquery table name and the value is a list of
+    errors related to the associated ping.
+
+    Ping expiration is based on the most recent data in the
+    moz-fx-data-shared-prod.monitoring_derived.table_partition_expirations_v1 bigquery table.
+    """
+    client = bigquery.Client()
+
+    app_listings = request_get(
+        "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
+    )
+    bq_dataset_to_app_listing = {app["bq_dataset_family"]: app for app in app_listings}
+
+    errors = defaultdict(list)
+
+    # dict structure: {email: {app_name: [messages]}}
+    expiring_pings_by_email = defaultdict(lambda: defaultdict(list))
+
+    current_expirations = list(
+        client.query_and_wait(
+            EXPIRATIONS_QUERY_TEMPLATE.format(run_date=run_date, project=project_id)
+        )
+    )
+
+    for dataset_info in current_expirations:
+        document_namespace = re.sub("_stable$", "", dataset_info["dataset_id"])
+        app_info = bq_dataset_to_app_listing.get(document_namespace)
+
+        # check if retention settings in metadata match applied settings (glean apps only)
+        if app_info is not None:
+            for (
+                table_id,
+                metadata_retention_days,
+                applied_retention_days,
+            ) in validate_retention_settings(dataset_info, app_info):
+                errors[f"{project_id}.{table_id}"].append(
+                    f"Retention period in metadata ({metadata_retention_days} days) "
+                    f"does not match period applied to table ({applied_retention_days} days)"
+                )
+
+            app_pings = request_get(
+                f"https://probeinfo.telemetry.mozilla.org/glean/{app_info['v1_name']}/pings"
+            )
+
+        # Find expiring pings and create list of emails to send
+        for table_info in dataset_info["tables"]:
+            # Send to app and ping owners for glean apps
+            if app_info is not None:
+                app_name = app_info["app_name"]
+                document_type = table_name_to_doctype(table_info["table_id"])
+
+                email_list = {
+                    *(
+                        app_pings[document_type]["history"][-1]["notification_emails"]
+                        if document_type in app_pings
+                        else []
+                    ),
+                    *app_info["notification_emails"],
+                    *DEFAULT_EMAILS,
+                }
+            # send to telemetry-alerts@mozilla.com for legacy telemetry
+            else:
+                app_name = "legacy telemetry"
+                email_list = {
+                    "telemetry-alerts@mozilla.com",
+                    *DEFAULT_EMAILS,
+                }
+
+            expires_in_days = (
+                (table_info["next_deletion_date"] or run_date) - run_date
+            ).days
+
+            if NOTIFICATION_DAYS_MIN <= expires_in_days <= NOTIFICATION_DAYS_MAX:
+                message = RETENTION_DAYS_MESSAGE_TEMPLATE.format(
+                    table_name=f"{document_namespace}."
+                    f"{re.sub('_v[0-9]+$', '', table_info['table_id'])}",
+                    retention_days=table_info["partition_expiration_days"],
+                    expiry_date=table_info["next_deletion_date"],
+                    num_weeks=expires_in_days // 7,
+                )
+                for email in email_list:
+                    expiring_pings_by_email[email][app_name].append(message)
+
+    return expiring_pings_by_email, errors
+
+
+def main():
+    args = parse_args()
+
+    expiring_pings_by_email, errors = get_expiring_pings(
+        run_date=args.run_date,
+        project_id=args.bigquery_project,
+    )
+
+    # Only send emails on Wednesday, dry run on other days for error checking
+    dry_run = args.dry_run or args.run_date.weekday() != 2
+
+    send_emails(expiring_pings_by_email, dry_run)
+
+    if len(errors) > 0:
+        error_string = "\n".join([f"{ping}: {msg}" for ping, msg in errors.items()])
+        raise RuntimeError(f"Encountered {len(errors)} errors: \n{error_string}")
+
+
+if __name__ == "__main__":
+    main()

--- a/probe_scraper/ping_expiry_alert.py
+++ b/probe_scraper/ping_expiry_alert.py
@@ -12,7 +12,7 @@ from probe_scraper.emailer import send_ses
 EMAIL_SUBJECT_TEMPLATE = "Glean Pings Expiring for {app_name}"
 
 EMAIL_TEMPLATE = """
-The following BigQuery tables are set to start deleting collected data soon based on the retention policies.
+The following BigQuery tables are set to start expiring collected data soon based on their retention policies.
 
 {tables}
 
@@ -27,7 +27,7 @@ Retention policies are defined in probe-scraper [1], with options to either stop
 For more information on requesting help from the data team, see https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/6849444/Getting+Help+Jira+documentation
 If you have any questions, please ask on the #data-help Slack channel. We'll give you a hand.
 
-Your Friendly, Neighborhood Data Team
+Your Friendly Neighborhood Data Team
 
 [1] - https://github.com/mozilla/probe-scraper/blob/main/repositories.yaml
 
@@ -39,10 +39,10 @@ APP_GROUP_TEMPLATE = """
 {messages}
 """
 
-RETENTION_DAYS_MESSAGE_TEMPLATE = '\t- The "{table_name}" table for will start deleting data older than {retention_days} days starting on {expiry_date} ({num_weeks} weeks from now)'  # noqa
+RETENTION_DAYS_MESSAGE_TEMPLATE = '\t- The "{table_name}" table for will start expiring data older than {retention_days} days starting on {expiry_date} ({num_weeks} weeks from now)'  # noqa
 
 # emails in this list will receive alerts for all pings
-DEFAULT_EMAILS = ["bewu@mozilla.com"]
+DEFAULT_EMAILS = ["bewu@mozilla.com", "dataops+alerts@mozilla.com"]
 
 NOTIFICATION_DAYS_MAX = 25
 NOTIFICATION_DAYS_MIN = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ GitPython==3.1.41
 boto3==1.28.7
 Flask==2.3.3
 glean-parser~=15.0.0
+google-cloud-bigquery==3.23.1
 google-cloud-storage==2.2.1
 gsutil==5.28
 Jinja2==3.1.3

--- a/tests/test_ping_expiry_alert.py
+++ b/tests/test_ping_expiry_alert.py
@@ -1,0 +1,270 @@
+import datetime
+import re
+from unittest.mock import MagicMock, patch
+
+from probe_scraper import ping_expiry_alert
+
+APP_LISTINGS = [
+    {
+        "bq_dataset_family": "firefox_desktop",
+        "moz_pipeline_metadata": {
+            "ping-1": {"expiration_policy": {"delete_after_days": 30}},
+            "ping-2": {
+                "expiration_policy": {
+                    "delete_after_days": 40,
+                    "collect_through_date": "2024-01-01",
+                }
+            },
+        },
+        "notification_emails": ["desktop@mozilla.com"],
+        "v1_name": "firefox-desktop",
+        "app_name": "firefox_desktop",
+    },
+    {
+        "bq_dataset_family": "firefox_desktop_background_update",
+        "notification_emails": ["desktop-update@mozilla.com"],
+        "moz_pipeline_metadata": {
+            "ping-1": {"expiration_policy": {"delete_after_days": 25}},
+        },
+        "v1_name": "firefox-desktop-background-update",
+        "app_name": "firefox_desktop_background_update",
+        "moz_pipeline_metadata_defaults": {
+            "expiration_policy": {"delete_after_days": 60}
+        },
+    },
+]
+
+PINGS_BY_APP = {
+    "firefox-desktop": {
+        "ping-1": {
+            "moz_pipeline_metadata": {"expiration_policy": {"delete_after_days": 30}},
+            "history": [{"notification_emails": ["desktop-1@mozilla.com"]}],
+        },
+        "ping-2": {
+            "moz_pipeline_metadata": {
+                "expiration_policy": {
+                    "delete_after_days": 40,
+                    "collect_through_date": "2024-01-01",
+                }
+            },
+            "history": [{"notification_emails": ["desktop-2@mozilla.com"]}],
+        },
+    },
+    "firefox-desktop-background-update": {},  # pings defined in dependency
+}
+
+
+def mock_request(url: str):
+    if url.endswith("/app-listings"):
+        return APP_LISTINGS
+    elif app_name_match := re.search(
+        r"glean/([a-z0-9-]+)/pings$", url, flags=re.IGNORECASE
+    ):
+        app_name = app_name_match.group(1)
+        return PINGS_BY_APP.get(app_name, {})
+    else:
+        raise ValueError(f"invalid url: {url}")
+
+
+@patch("probe_scraper.ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_already_expired(mock_client_class):
+    """Alerts should not be sent for pings that have already expired."""
+
+    mock_retention = [
+        {
+            "project_id": "proj",
+            "dataset_id": "firefox_desktop_stable",
+            "tables": [
+                {
+                    "table_id": "ping_1_v1",
+                    "partition_expiration_days": 30,
+                    "next_deletion_date": datetime.date.fromisoformat("2023-12-22"),
+                },
+                {
+                    "table_id": "ping_2_v1",
+                    "partition_expiration_days": 40,
+                    "next_deletion_date": datetime.date.fromisoformat("2023-12-23"),
+                },
+            ],
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.query_and_wait.return_value = mock_retention
+
+    expiring, errors = ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2023-12-21"),
+        project_id="proj",
+    )
+
+    assert len(expiring) == 0
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_not_expired(mock_client_class):
+    """Alerts should not be sent if future expiry date is out of range."""
+
+    mock_retention = [
+        {
+            "project_id": "proj",
+            "dataset_id": "firefox_desktop_stable",
+            "tables": [
+                {
+                    "table_id": "ping_1_v1",
+                    "partition_expiration_days": 30,
+                    "next_deletion_date": datetime.date.fromisoformat("2024-12-22"),
+                },
+                {
+                    "table_id": "ping_2_v1",
+                    "partition_expiration_days": 40,
+                    "next_deletion_date": datetime.date.fromisoformat("2025-12-22"),
+                },
+            ],
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.query_and_wait.return_value = mock_retention
+
+    expiring, errors = ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2023-12-21"),
+        project_id="proj",
+    )
+
+    assert len(expiring) == 0
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_expired(mock_client_class):
+    """Alerts should be sent if the data will start being dropped soon."""
+
+    mock_retention = [
+        {
+            "project_id": "proj",
+            "dataset_id": "firefox_desktop_stable",
+            "tables": [
+                {
+                    "table_id": "ping_1_v1",
+                    "partition_expiration_days": 30,
+                    # already expired
+                    "next_deletion_date": datetime.date.fromisoformat("2023-12-22"),
+                },
+                {
+                    "table_id": "ping_2_v1",
+                    "partition_expiration_days": 40,
+                    # expiring soon
+                    "next_deletion_date": datetime.date.fromisoformat("2024-01-01"),
+                },
+            ],
+        },
+        {
+            "project_id": "proj",
+            "dataset_id": "firefox_desktop_background_update_stable",
+            "tables": [
+                {
+                    "table_id": "ping_3_v1",
+                    "partition_expiration_days": 60,
+                    # expiring soon
+                    "next_deletion_date": datetime.date.fromisoformat("2024-01-02"),
+                },
+            ],
+        },
+    ]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.query_and_wait.return_value = mock_retention
+
+    expiring, errors = ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2023-12-21"),
+        project_id="proj",
+    )
+
+    assert len(expiring) == len(ping_expiry_alert.DEFAULT_EMAILS) + 3
+
+    # firefox-desktop ping-2 expiry
+    assert set(expiring["desktop@mozilla.com"].keys()) == {"firefox_desktop"}
+    assert len(expiring["desktop@mozilla.com"]["firefox_desktop"]) == 1
+    assert (
+        "firefox_desktop.ping_2"
+        in expiring["desktop@mozilla.com"]["firefox_desktop"][0]
+    )
+    assert "2024-01-01" in expiring["desktop@mozilla.com"]["firefox_desktop"][0]
+
+    # firefox-desktop-background-update ping-3 expiry
+    assert set(expiring["desktop-update@mozilla.com"].keys()) == {
+        "firefox_desktop_background_update"
+    }
+    assert (
+        len(expiring["desktop-update@mozilla.com"]["firefox_desktop_background_update"])
+        == 1
+    )
+    assert (
+        "firefox_desktop_background_update.ping_3"
+        in expiring["desktop-update@mozilla.com"]["firefox_desktop_background_update"][
+            0
+        ]
+    )
+
+    # default email should receive everything
+    assert set(expiring[ping_expiry_alert.DEFAULT_EMAILS[0]].keys()) == {
+        "firefox_desktop",
+        "firefox_desktop_background_update",
+    }
+    assert len(expiring[ping_expiry_alert.DEFAULT_EMAILS[0]]["firefox_desktop"]) == 1
+    assert (
+        len(
+            expiring[ping_expiry_alert.DEFAULT_EMAILS[0]][
+                "firefox_desktop_background_update"
+            ]
+        )
+        == 1
+    )
+
+    assert len(errors) == 0
+
+
+@patch("probe_scraper.ping_expiry_alert.request_get", mock_request)
+@patch("google.cloud.bigquery.Client")
+def test_retention_days_not_matching(mock_client_class):
+    """Errors should be returned if the retention of the table does not match the metadata."""
+    mock_retention = [
+        {
+            "project_id": "proj",
+            "dataset_id": "firefox_desktop_stable",
+            "tables": [
+                {
+                    "table_id": "ping_1_v1",
+                    "partition_expiration_days": 50,
+                    "next_deletion_date": datetime.date.fromisoformat("2025-01-02"),
+                },
+                {
+                    "table_id": "ping_2_v1",
+                    "partition_expiration_days": None,
+                    "next_deletion_date": datetime.date.fromisoformat("2025-01-02"),
+                },
+            ],
+        }
+    ]
+
+    mock_client = MagicMock()
+    mock_client_class.return_value = mock_client
+    mock_client.query_and_wait.return_value = mock_retention
+
+    expiring, errors = ping_expiry_alert.get_expiring_pings(
+        run_date=datetime.date.fromisoformat("2024-01-02"),
+        project_id="proj",
+    )
+
+    assert len(expiring) == 0
+
+    assert len(errors) == 2
+    assert "proj.firefox_desktop_stable.ping_1_v1" in errors
+    assert "proj.firefox_desktop_stable.ping_2_v1" in errors


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-577

Data expiry alerts for raw telemetry following [this proposal](https://docs.google.com/document/d/15_JR2niBY2jZqbt9wzJVrXH_EGL3D2SrS7G7gUVBei8).  No significant changes compared to the proposal except `collect_through_date` settings weren't implemented because we don't have any active uses of that.

Expirations are retrieved from `moz-fx-data-shared-prod.monitoring_derived.table_partition_expirations_v1` and sent weekly between 25 and 5 days before the first day that data is dropped.