### PR TITLE
Add note about what won't be deleted in data expiry alert

### DIFF
--- a/probe_scraper/ping_expiry_alert.py
+++ b/probe_scraper/ping_expiry_alert.py
@@ -13,6 +13,8 @@ EMAIL_SUBJECT_TEMPLATE = "Glean Pings Expiring for {app_name}"
 
 EMAIL_TEMPLATE = """
 The following BigQuery tables are set to start expiring collected data soon based on their retention policies.
+Note that this expiration will only delete data from the raw telemetry ("ping") tables listed below.
+Aggregated/analytics tables derived from the telemetry data, such as "clients_daily" and "clients_last_seen" tables, will not be affected and will continue to retain all historical data.
 
 {tables}
 


### PR DESCRIPTION
Clarify that only the listed raw tables will have data dropped from expiry.  From discussion here: https://mozilla.slack.com/archives/CEE12R4E8/p1730390507313309