### PR TITLE
Deprecate Treeherder

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1643,6 +1643,7 @@ applications:
     app_description: |
       Internal Developer dashboard for CI results
     url: https://github.com/mozilla/treeherder
+    deprecated: true
     notification_emails:
       - jmaher@mozilla.com
     branch: master


### PR DESCRIPTION
This was removed in https://github.com/mozilla/treeherder/pull/8267