### PR TITLE
Add pings.yaml to ads_backend ping files

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2018,7 +2018,8 @@ applications:
     branch: main
     metrics_files:
       - telemetry/glean/metrics.yaml
-    ping_files: []
+    ping_files:
+      - telemetry/glean/pings.yaml
     dependencies:
       - glean-server
     channels:


### PR DESCRIPTION
### Problem
We're adding custom ping definitions, so will need that configuration file to be read in for our app https://github.com/mozilla-services/mars-telemetry/pull/1

### Solution
Add the pings.yaml to the list of ping files for the ads_backend app

### Testing
Checked https://github.com/mozilla/probe-scraper/pull/774 to see what testing steps were done in the past when ads_backend was initially added and tried to repeat those.
```
[dmueller probe-scraper probe-scraper@(dmueller/AE-577)]$ export COMMAND='python -m probe_scraper.runner --glean --glean-repo ads-backend --dry-run'
[dmueller probe-scraper probe-scraper@(dmueller/AE-577)]$ make run
docker-compose build
...
docker-compose run app python -m probe_scraper.runner --glean --glean-repo ads-backend --dry-run
[+] Creating 1/0
 ✔ Network probe-scraper_default  Created                                                                                                                 0.0s
Unable to parse whitelist (/app/probe_scraper/parsers/third_party/histogram-whitelists.json). Assuming all histograms are acceptable.
Getting commits for repository ads-backend
Cloning https://github.com/mozilla-services/mars-telemetry into /tmp/tmpng4v9_8g/mozilla-services/mars-telemetry.git
  Got 2 commits

writing output:
  glean/ads-backend/dependencies
  glean/ads-backend/general
  glean/glean-core/pings
  ...
```
