### PR TITLE
focus/klar iOS: Scan pings definitions

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1275,6 +1275,8 @@ applications:
     branch: main
     metrics_files:
       - focus-ios/Blockzilla/metrics.yaml
+    ping_files:
+      - focus-ios/Blockzilla/pings.yaml
     dependencies:
       - glean-core
       - nimbus
@@ -1295,6 +1297,8 @@ applications:
     branch: main
     metrics_files:
       - focus-ios/Blockzilla/metrics.yaml
+    ping_files:
+      - focus-ios/Blockzilla/pings.yaml
     dependencies:
       - glean-core
       - nimbus


### PR DESCRIPTION
dry-run locally works as expected.

Needs to be triggered once this lands so probe-scraper has the data.