### PR TITLE
Ignore recently changed retention settings in ping expiry validation

### DIFF
--- a/probe_scraper/ping_expiry_alert.py
+++ b/probe_scraper/ping_expiry_alert.py
@@ -66,7 +66,10 @@ SELECT
   dataset_id,
   ARRAY_AGG(
     STRUCT(
-        table_id, partition_expiration_days, actual_partition_expiration_days, next_deletion_date
+        table_id, partition_expiration_days,
+        actual_partition_expiration_days,
+        next_deletion_date,
+        expiration_changed
     ) ORDER BY table_id
   ) AS tables,
 FROM
@@ -189,7 +192,10 @@ def validate_retention_settings(
         else:
             metadata_retention_days = default_retention_days
 
-        if metadata_retention_days != applied_retention_days:
+        if (
+            metadata_retention_days != applied_retention_days
+            and table_info["expiration_changed"] is False
+        ):
             errors.append(
                 (
                     f"{dataset_info['dataset_id']}.{table_info['table_id']}",


### PR DESCRIPTION
The check that compares metadata retention settings with the actual table gives a false positive when the setting was just changed and this job runs before settings get applied to the table

Uses the new column from https://github.com/mozilla/bigquery-etl/pull/6557