### PR TITLE
Reduce max table expiration days from 10,000 to 9,985

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -413,28 +413,28 @@ applications:
           delete_after_days: 90
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       crash:
         expiration_policy:
           delete_after_days: 1130
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       first-startup:
         expiration_policy:
           delete_after_days: 1130
       fog-validation:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       messaging-system:
         expiration_policy:
           delete_after_days: 1130
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       new-metric-capture-emulation:
         expiration_policy:
           delete_after_days: 1130
@@ -500,25 +500,25 @@ applications:
     moz_pipeline_metadata:
       background-update:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       crash:
         expiration_policy:
           delete_after_days: 1130
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       fog-validation:
         expiration_policy:
           delete_after_days: 1130
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: firefox_desktop_background_defaultagent
     canonical_app_name: Firefox Desktop Default Agent Task
@@ -653,16 +653,16 @@ applications:
           delete_after_days: 180
       activation:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       addresses-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       bookmarks-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       client-deduplication:
         expiration_policy:
           delete_after_days: 1130
@@ -674,46 +674,46 @@ applications:
           delete_after_days: 1130
       creditcards-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       first-session:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       fog-validation:
         expiration_policy:
           delete_after_days: 1130
       history-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       installation:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       logins-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       migration:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       pageload:
         expiration_policy:
           delete_after_days: 400
       startup-timeline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       tabs-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
     channels:
       - v1_name: firefox-android-release
         app_id: org.mozilla.firefox
@@ -789,16 +789,16 @@ applications:
         submission_timestamp_granularity: "seconds"
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
     channels:
       - v1_name: firefox-ios-release
         app_id: org.mozilla.ios.Firefox
@@ -840,16 +840,16 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: firefox_fire_tv
     canonical_app_name: Firefox for Fire TV
@@ -872,16 +872,16 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: firefox_reality
     canonical_app_name: Firefox Reality
@@ -910,40 +910,40 @@ applications:
     moz_pipeline_metadata:
       addresses-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       bookmarks-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       creditcards-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       history-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       logins-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       session-end:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       tabs-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: lockwise_android
     canonical_app_name: Lockwise for Android
@@ -968,37 +968,37 @@ applications:
     moz_pipeline_metadata:
       addresses-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       bookmarks-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       creditcards-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       history-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       logins-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       tabs-sync:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: lockwise_ios
     canonical_app_name: Lockwise for iOS
@@ -1020,16 +1020,16 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: mozregression
     canonical_app_name: mozregression
@@ -1055,19 +1055,19 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       usage:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: burnham
     canonical_app_name: Burnham
@@ -1100,25 +1100,25 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       discovery:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       space-ship-ready:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       starbase46:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: mozphab
     canonical_app_name: mozphab
@@ -1144,19 +1144,19 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       usage:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: firefox_echo_show
     canonical_app_name: Firefox for Echo Show
@@ -1179,16 +1179,16 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: firefox_reality_pc
     canonical_app_name: Firefox Reality for PC-connected VR platforms
@@ -1212,19 +1212,19 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       launch:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: mach
     canonical_app_name: mach
@@ -1251,19 +1251,19 @@ applications:
     moz_pipeline_metadata:
       baseline:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       deletion-request:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       events:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       metrics:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
       usage:
         expiration_policy:
-          delete_after_days: 10000
+          delete_after_days: 9985
 
   - app_name: focus_ios
     canonical_app_name: Firefox Focus for iOS


### PR DESCRIPTION
Tables can have a maximum of 10,000 partitions, but when partitions expire they apparently continue to count toward the table's partition quota for up to 14 days afterwards (7 days of time travel and 7 days of fail-safe), per the [BigQuery docs](https://cloud.google.com/bigquery/docs/managing-partitioned-tables#partition-expiration):
> When a partition expires, BigQuery deletes that partition. The partition data is retained in accordance with [time travel](https://cloud.google.com/bigquery/docs/time-travel) and [fail-safe](https://cloud.google.com/bigquery/docs/time-travel#fail-safe) policies, and can be charged for, depending on your billing model. Until then, the partition counts for purposes of [table quotas](https://cloud.google.com/bigquery/quotas#partitioned_tables).

And I subtracted one additional day just to make sure we don't hit the table partition limit.