### PR TITLE
Set geoip skip entries for bedrock due to fastly migration

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1607,6 +1607,7 @@ applications:
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 180
+      geoip_skip_entries: 2
     channels:
       - v1_name: bedrock
         app_id: bedrock


### PR DESCRIPTION
/CC @bkochendorfer

https://mozilla-hub.atlassian.net/browse/SE-4251
https://github.com/mozilla-it/webservices-infra/pull/3513#pullrequestreview-2485559559

I double checked from PBR that bedrock has the same number of IPs in the chain as MDN so it probably needs the same config. Even if it's wrong GeoIP has been incorrect for a month or so this isn't going to make it worse.
