### PR TITLE
Skip update.* metrics in dupe checks

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -156,6 +156,12 @@ SKIP_METRICS = {
         "fenix",
         "firefox-desktop",
     ],
+    "update.bitshresult": ["gecko", "firefox-desktop-background-update"],
+    "update.move_result": ["gecko", "firefox-desktop-background-update"],
+    "update.no_window_auto_restarts": ["gecko", "firefox-desktop-background-update"],
+    "update.skip_startup_update_reason": ["gecko", "firefox-desktop-background-update"],
+    "update.suppress_prompts": ["gecko", "firefox-desktop-background-update"],
+    "update.version_pin": ["gecko", "firefox-desktop-background-update"],
 }
 
 


### PR DESCRIPTION
These got moved in bug 1938657.
They should probably be firefox-desktop, not gecko, metrics

---

I'm figuring out if we can move the metrics.
I don't think this should break anything in the schemas.