### PR TITLE
Update mozilla_vpn section in repositories.yaml 

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1464,6 +1464,7 @@ applications:
       - mcleinman@mozilla.com
     branch: main
     metrics_files:
+      - src/telemetry/extension_metrics.yaml
       - src/telemetry/metrics.yaml
       - src/telemetry/impression_metrics.yaml
       - src/telemetry/interaction_metrics.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1460,7 +1460,6 @@ applications:
     notification_emails:
       - vpn@mozilla.com
       - amarchesini@mozilla.com
-      - brizental@mozilla.com
       - mcleinman@mozilla.com
     branch: main
     metrics_files:


### PR DESCRIPTION
Hey! 👋  
We added `extension_metrics.yaml` to the repo and i noticed it was not getting picked up by the Glean Dictionary, this should be adding this.
Also Bea is no longer on the team :( - so while at it i removed the now disabled email account from the notification list. 

Greetings! 
Basti :) 