### PR TITLE
Ingest gleanjs telemetry events for GLAM

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2005,3 +2005,24 @@ applications:
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 400
+
+  - app_name: glam
+    canonical_app_name: GLAM
+    app_description: |
+      The Glean Aggregated Metrics Dashboard.
+    url: https://github.com/mozilla/glam
+    notification_emails:
+      - efilho@mozilla.com
+    branch: main
+    metrics_files:
+      - src/telemetry/metrics.yaml
+    ping_files:
+      - src/telemetry/pings.yaml
+    dependencies:
+      - glean-js
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400
+    channels:
+      - v1_name: glam
+        app_id: glam

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2014,10 +2014,8 @@ applications:
     notification_emails:
       - efilho@mozilla.com
     branch: main
-    metrics_files:
-      - src/telemetry/metrics.yaml
-    ping_files:
-      - src/telemetry/pings.yaml
+    metrics_files: []
+    ping_files: []
     dependencies:
       - glean-js
     moz_pipeline_metadata_defaults:


### PR DESCRIPTION
GLAM was recently instrumented with GleanJS's auto events and we want to ingest the events data in order to visualize them on the [Website Sessions Dashboard](https://mozilla.cloud.looker.com/dashboards/websites::website_sessions?App+ID=glam&Submission+Date=7+day&Country+Name=&External+Referrer=&App+Channel=&UA+-+Browser=&Traffic+Source=). 