### PR TITLE
Remove obsolete `version` from docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
 
 # Upgrade pip
 RUN pip install --upgrade pip
+# Ensure setuptools is new enough, to avoid issues with wheels
+RUN pip install 'setuptools>=70.1'
 
 WORKDIR ${HOME}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.11
-MAINTAINER Harold Woo <hwoo@mozilla.com>
 
 ENV PYTHONUNBUFFERED=1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2'
-
 services:
   app:
     build:


### PR DESCRIPTION
I was getting annoyed by this warning:

> WARN[0000] /home/circleci/mozilla/probe-scraper/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 