### PR TITLE
Add Thunderbird in-app notifications metrics file

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1931,6 +1931,7 @@ applications:
       - mail/components/compose/metrics.yaml
       - mail/components/addrbook/metrics.yaml
       - mail/components/cloudfile/metrics.yaml
+      - mail/components/inappnotifications/metrics.yaml
       - calendar/metrics.yaml
     # While bug 1910995 asks to use comm/mail/pings.yaml, this
     # file is currently empty in the repo and we won't add it


### PR DESCRIPTION
Add the [new metrics file](https://hg-edge.mozilla.org/comm-central/file/tip/mail/components/inappnotifications/metrics.yaml) to the registration for Thunderbird desktop.