### PR TITLE
Bug 1959916 - Remove dependencies from Focus Android/iOS

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1191,9 +1191,7 @@ applications:
       - focus-ios/Blockzilla/metrics.yaml
     ping_files:
       - focus-ios/Blockzilla/pings.yaml
-    dependencies:
-      - glean-core
-      - nimbus
+    dependencies: []
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 720
@@ -1213,9 +1211,7 @@ applications:
       - focus-ios/Blockzilla/metrics.yaml
     ping_files:
       - focus-ios/Blockzilla/pings.yaml
-    dependencies:
-      - glean-core
-      - nimbus
+    dependencies: []
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 720
@@ -1234,13 +1230,7 @@ applications:
       - mobile/android/focus-android/app/metrics.yaml
     ping_files:
       - mobile/android/focus-android/app/pings.yaml
-    dependencies:
-      - glean-core
-      - org.mozilla.components:service-glean
-      - org.mozilla.components:lib-crash
-      - nimbus
-      - org.mozilla.components:service-nimbus
-      - gecko
+    dependencies: []
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 760
@@ -1279,13 +1269,7 @@ applications:
       - mobile/android/focus-android/app/metrics.yaml
     ping_files:
       - mobile/android/focus-android/app/pings.yaml
-    dependencies:
-      - glean-core
-      - org.mozilla.components:service-glean
-      - org.mozilla.components:lib-crash
-      - nimbus
-      - org.mozilla.components:service-nimbus
-      - gecko
+    dependencies: []
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 760


### PR DESCRIPTION
These apps do not send general telemetry anymore, only 2 custom pings.

**Question**: Will anything break by us completely removing the glean-core dependency?