### PR TITLE
Change probe expiry alerts to refer to end of current Nightly version

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -37,12 +37,14 @@ EVENTS_FILE = "Events.yaml"
 BUG_DEFAULT_PRODUCT = "Firefox"
 BUG_DEFAULT_COMPONENT = "General"
 BUG_WHITEBOARD_TAG = "[probe-expiry-alert]"
-BUG_SUMMARY_TEMPLATE = "Remove or update probes expiring in Firefox {version}: {probe}"
+BUG_SUMMARY_TEMPLATE = (
+    "Remove or update probes expiring at the end of Firefox {version}: {probe}"
+)
 
 # Regex for version and probe names requires bug description to have a certain structure
 # This template should be modified with care
 BUG_DESCRIPTION_TEMPLATE = """
-The following Firefox probes will expire in the next major Firefox nightly release: version {version} [1].
+The following Firefox probes will expire at the end of Firefox nightly release: version {version} [1].
 
 ```
 {probes}
@@ -435,7 +437,8 @@ def main(current_date: datetime.date, dryrun: bool, bugzilla_api_key: str):
     # Only send create bugs on Wednesdays, run the rest for debugging/error detection
     dryrun = dryrun or current_date.weekday() != 2
 
-    next_version = str(int(get_latest_nightly_version()) + 1)
+    current_version = str(int(get_latest_nightly_version()))
+    next_version = str(int(current_version) + 1)
 
     with tempfile.TemporaryDirectory() as tempdir:
         events_file_path = os.path.join(tempdir, EVENTS_FILE)
@@ -474,10 +477,10 @@ def main(current_date: datetime.date, dryrun: bool, bugzilla_api_key: str):
                 email_list.remove(email)
 
     probe_to_bug_id = file_bugs(
-        expiring_probes, next_version, bugzilla_api_key, dryrun=dryrun
+        expiring_probes, current_version, bugzilla_api_key, dryrun=dryrun
     )
 
-    send_emails(emails_wo_accounts, probe_to_bug_id, next_version, dryrun=dryrun)
+    send_emails(emails_wo_accounts, probe_to_bug_id, current_version, dryrun=dryrun)
 
 
 def parse_args():

--- a/tests/test_probe_expiry_alert.py
+++ b/tests/test_probe_expiry_alert.py
@@ -106,14 +106,14 @@ def test_not_dryrun_only_once_per_week(
         probe_expiry_alert.main(base_date + datetime.timedelta(days=weekday), False, "")
 
     mock_file_bugs.assert_has_calls(
-        [mock.call([], "76", "", dryrun=False)]
-        + [mock.call([], "76", "", dryrun=True)] * 6,
+        [mock.call([], "75", "", dryrun=False)]
+        + [mock.call([], "75", "", dryrun=True)] * 6,
         any_order=True,
     )
     assert mock_file_bugs.call_count == 7
     mock_send_emails.assert_has_calls(
-        [mock.call({}, {}, "76", dryrun=False)]
-        + [mock.call({}, {}, "76", dryrun=True)] * 6,
+        [mock.call({}, {}, "75", dryrun=False)]
+        + [mock.call({}, {}, "75", dryrun=True)] * 6,
         any_order=True,
     )
     assert mock_send_emails.call_count == 7
@@ -223,7 +223,7 @@ def test_main_run(
 
     expected_expiring_probes = [ProbeDetails("p1", "Firefox", "General", [], None)]
     mock_file_bugs.assert_called_once_with(
-        expected_expiring_probes, "76", "", dryrun=False
+        expected_expiring_probes, "75", "", dryrun=False
     )
 
 


### PR DESCRIPTION
Similar to GH-895, change the text in the probe expiry alerts so it's clear that fixes are required before the end of the current nightly.