### PR TITLE
Change to new mozilla-firefox/firefox URL for all apps

### DIFF
--- a/fog-updater/README.md
+++ b/fog-updater/README.md
@@ -2,7 +2,7 @@
 
 Automation to update `repositories.yaml` of `probe-scraper` with the latest `metrics_index.py` list.
 
-Fetches and parses the `metrics_index.py` from `gecko-dev`, extracts the relevant list of YAML files
+Fetches and parses the `metrics_index.py` from `mozilla-firefox/firefox`, extracts the relevant list of YAML files
 and creates a new Pull Request against `probe-scraper` if it contains any changes.
 
 ## Environment variables

--- a/fog-updater/src/fog_update.py
+++ b/fog-updater/src/fog_update.py
@@ -19,7 +19,7 @@ USAGE = "usage: fog-update"
 HTTP_HEADERS = {
     "user-agent": "probe-scraper/1.0",
 }
-INDEX_URL = "https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/glean/metrics_index.py"  # noqa
+INDEX_URL = "https://raw.githubusercontent.com/mozilla-firefox/firefox/main/toolkit/components/glean/metrics_index.py"  # noqa
 BODY_TEMPLATE = f"""This (automated) patch updates the list from metrics_index.py.
 
 For reviewers:

--- a/fog-updater/src/test_util.py
+++ b/fog-updater/src/test_util.py
@@ -14,7 +14,7 @@ libraries:
     description: The browser engine developed by Mozilla
     notification_emails:
       - chutten@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
     metrics_files:
       - LIB_METRICS_FILES
     ping_files:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -72,7 +72,7 @@ libraries:
       - aplacitelli@mozilla.com
       - glean-team@mozilla.com
       - android-probes@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
     metrics_files:
       - mobile/android/android-components/components/lib/crash/metrics.yaml
     ping_files:
@@ -80,6 +80,7 @@ libraries:
     variants:
       - v1_name: lib-crash
         dependency_name: org.mozilla.components:lib-crash
+        branch: main
 
   - library_name: sync
     description: Sync telemetry helper functionality
@@ -99,7 +100,7 @@ libraries:
       - aplacitelli@mozilla.com
       - android-components-team@mozilla.com
       - geckoview-team@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
     metrics_files: []
     variants:
       - v1_name: engine-gecko
@@ -109,6 +110,7 @@ libraries:
         branch: beta
         dependency_name: org.mozilla.components:browser-engine-gecko-beta
       - v1_name: engine-gecko-nightly
+        branch: main
         dependency_name: org.mozilla.components:browser-engine-gecko-nightly
 
   - library_name: logins-store
@@ -220,18 +222,19 @@ libraries:
       The Nimbus Android-Component used by Fenix and Focus
     notification_emails:
       - sync-team@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
     metrics_files:
       - mobile/android/android-components/components/service/nimbus/metrics.yaml
     variants:
       - v1_name: service-nimbus
         dependency_name: org.mozilla.components:service-nimbus
+        branch: main
 
   - library_name: gecko
     description: The browser engine developed by Mozilla
     notification_emails:
       - chutten@mozilla.com
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
     metrics_files:
       - accessible/metrics.yaml
       - browser/base/content/metrics.yaml
@@ -337,13 +340,15 @@ libraries:
     variants:
       - v1_name: gecko
         dependency_name: gecko
+        branch: main
 
 # See https://mozilla.github.io/probe-scraper/#tag/application
 applications:
   - app_name: firefox_desktop
     canonical_app_name: Firefox for Desktop
     app_description: The desktop version of Firefox
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
@@ -483,7 +488,8 @@ applications:
     canonical_app_name: Firefox Crash Reporter
     app_description: >-
       The Firefox desktop crash reporter client.
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - afranchuk@mozilla.com
     metrics_files:
@@ -511,7 +517,8 @@ applications:
       Firefox Desktop's background update task. This is
       considered a separate application because it has its own client
       id and sends its own version of the standard pings.
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
@@ -564,7 +571,8 @@ applications:
       deceptive patterns.
 
       Also known as Windows Default Browser Agent (WDBA).
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - nrishel@mozilla.com
       - install-update@mozilla.com
@@ -587,7 +595,8 @@ applications:
     canonical_app_name: Pinebuild
     app_description: >-
       The pine build of mozilla-central.
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - chutten@mozilla.com
     metrics_files:
@@ -654,7 +663,8 @@ applications:
   - app_name: fenix
     app_description: Firefox for Android (Fenix)
     canonical_app_name: Firefox for Android
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - aplacitelli@mozilla.com
     metrics_files:
@@ -1145,7 +1155,8 @@ applications:
   - app_name: mach
     canonical_app_name: mach
     app_description: Mach build telemetry
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - mhentges@mozilla.com
     metrics_files:
@@ -1228,7 +1239,8 @@ applications:
   - app_name: focus_android
     canonical_app_name: Firefox Focus for Android
     app_description: Firefox Focus on Android. Klar is the sibling application
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - jalmeida@mozilla.com
       - tlong@mozilla.com
@@ -1273,7 +1285,8 @@ applications:
   - app_name: klar_android
     canonical_app_name: Firefox Klar for Android
     app_description: Firefox Klar on Android. Focus is the sibling application
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - jalmeida@mozilla.com
       - tlong@mozilla.com
@@ -1562,12 +1575,12 @@ applications:
     app_description: |
       Background tasks of Firefox Desktop.
       Currently used by `BackgroundTask_removeDirectory`.
-    url: https://github.com/mozilla/gecko-dev
+    url: https://github.com/mozilla-firefox/firefox
+    branch: main
     notification_emails:
       - necko@mozilla.com
       - krosylight@mozilla.com
       - vgosu@mozilla.com
-    branch: master
     metrics_files:
       - browser/components/metrics.yaml
       - toolkit/components/backgroundtasks/metrics.yaml


### PR DESCRIPTION
Fixes #873

should not be merged before the end of the month.