### PR TITLE
FXIOS-12167 Update Firefox for iOS metrics, pings, and tags YAML file paths.

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -812,12 +812,13 @@ applications:
       - tlong@mozilla.com
     url: https://github.com/mozilla-mobile/firefox-ios
     metrics_files:
-      - firefox-ios/Client/metrics.yaml
+      - firefox-ios/Client/Glean/metrics.yaml
+      - firefox-ios/Client/Glean/settings.yaml
       - firefox-ios/Storage/metrics.yaml
     ping_files:
-      - firefox-ios/Client/pings.yaml
+      - firefox-ios/Client/Glean/pings.yaml
     tag_files:
-      - firefox-ios/Client/tags.yaml
+      - firefox-ios/Client/Glean/tags.yaml
     branch: main
     dependencies:
       - glean-core


### PR DESCRIPTION
Updating the metrics, tags, and pings YAML paths for a restructuring of where the Glean files live in the Firefox for iOS repository.

Related work: https://github.com/mozilla-mobile/firefox-ios/pull/26487