### PR TITLE
Move Firefox Desktop 'sync' pings.yaml to firefox_desktop

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -330,7 +330,6 @@ libraries:
       - xpcom/metrics.yaml
     ping_files:
       - dom/pings.yaml
-      - services/sync/pings.yaml
       - toolkit/components/antitracking/bouncetrackingprotection/pings.yaml
       - toolkit/components/backgroundhangmonitor/pings.yaml
       - toolkit/components/captchadetection/pings.yaml
@@ -403,6 +402,7 @@ applications:
       - browser/components/urlbar/pings.yaml
       - browser/modules/pings.yaml
       - services/fxaccounts/pings.yaml
+      - services/sync/pings.yaml
       - toolkit/components/crashes/pings.yaml
       - toolkit/components/nimbus/pings.yaml
       - toolkit/components/reportbrokensite/pings.yaml


### PR DESCRIPTION
The in-tree change for this didn't land until after last night's fog-bot run.