### PR TITLE
DENG-8874 - Set iOS fx-accounts retention to 30 days

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -855,6 +855,9 @@ applications:
       expiration_policy:
         delete_after_days: 775
     moz_pipeline_metadata:
+      fx-accounts:
+        expiration_policy:
+          delete_after_days: 30
       topsites-impression:
         expiration_policy:
           delete_after_days: 30


### PR DESCRIPTION
Similar to https://github.com/mozilla/probe-scraper/pull/779, see https://mozilla-hub.atlassian.net/browse/DENG-8874 and parent tickets.