### PR TITLE
DENG-8875 - Set Fenix fx-accounts retention to 30 days

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -692,6 +692,9 @@ applications:
       expiration_policy:
         delete_after_days: 400
     moz_pipeline_metadata:
+      fx-accounts:
+        expiration_policy:
+          delete_after_days: 30
       topsites-impression:
         expiration_policy:
           delete_after_days: 30


### PR DESCRIPTION
Similar to https://github.com/mozilla/probe-scraper/pull/928, see https://mozilla-hub.atlassian.net/browse/DENG-8875 and parent tickets.