### PR TITLE
Mark Mozilla Social Mastodon Backend as deprecated

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1817,6 +1817,7 @@ applications:
     canonical_app_name: Mozilla Social Mastodon Backend
     app_description: |
       Mastodon instance for Mozilla Social
+    deprecated: true
     url: https://github.com/MozillaSocial/mastodon
     notification_emails:
       - breyes@mozilla.com


### PR DESCRIPTION
The repository is archived. The project shut down.