### PR TITLE
[Bug 1984451] Use github instead of hg for probe expiry alerts

### DIFF
--- a/probe_scraper/probe_expiry_alert.py
+++ b/probe_scraper/probe_expiry_alert.py
@@ -28,7 +28,8 @@ BUGZILLA_USER_URL = "https://bugzilla.mozilla.org/rest/user"
 BUGZILLA_BUG_LINK_TEMPLATE = "https://bugzilla.mozilla.org/show_bug.cgi?id={bug_id}"
 
 BASE_URI = (
-    "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/"
+    "https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/main/"
+    "toolkit/components/telemetry/"
 )
 HISTOGRAMS_FILE = "Histograms.json"
 SCALARS_FILE = "Scalars.yaml"


### PR DESCRIPTION
hg.mozilla.org seemed to have some issues that caused https://bugzilla.mozilla.org/show_bug.cgi?id=1984451 and https://bugzilla.mozilla.org/show_bug.cgi?id=1984449 (CDN related? idk).  Switching to github since that's where most of our other things pull from