### PR TITLE
remove unused VPN files

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1415,9 +1415,6 @@ applications:
     metrics_files:
       - src/telemetry/extension_metrics.yaml
       - src/telemetry/metrics.yaml
-      - src/telemetry/impression_metrics.yaml
-      - src/telemetry/interaction_metrics.yaml
-      - src/telemetry/outcome_metrics.yaml
     ping_files:
       - src/telemetry/pings.yaml
     dependencies: []  # Empty. Dependencies are set per channel.


### PR DESCRIPTION
[This PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10783) removes the files, and probe-scraper is failing because of it.