### PR TITLE
fix: Set `firefox_desktop_background_defaultagent` ping table retention to 775 days

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -603,7 +603,7 @@ applications:
         app_id: firefox.desktop.background.defaultagent
     moz_pipeline_metadata_defaults:
       expiration_policy:
-        delete_after_days: 400
+        delete_after_days: 775
 
   - app_name: pine
     canonical_app_name: Pinebuild


### PR DESCRIPTION
The [original request to add the Glean app `firefox.desktop.background.defaultagent`](https://bugzilla.mozilla.org/show_bug.cgi?id=1857141) asked for the retention to match Firefox Desktop (which at the time had unlimited retention).

However, as successive Glean data retention changes were made that original intent of matching Firefox Desktop retention was accidentally not preserved:
- #780 set the default retention for both `firefox_desktop` and `firefox_desktop_background_defaultagent` to 400 days, but exempted the core `firefox_desktop` pings from that.
- #870 set the retention for the core `firefox_desktop` pings to 775 days.

I've reconfirmed with the original requester @PrototypeNM1 that retention for `firefox_desktop_background_defaultagent` should match the retention for `firefox_desktop`, which is [effectively 775 days when it comes to the core pings](https://github.com/mozilla/probe-scraper/blob/fc8fead47ae8329014fb86ade58571fc920a7434/repositories.yaml#L466-L489).