### PR TITLE
Deprecate Mozilla VPN as a Glean app

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1486,6 +1486,7 @@ applications:
       Mozilla VPN is a VPN client application. The first
       Mozilla premium service.
     url: https://github.com/mozilla-mobile/mozilla-vpn-client
+    deprecated: true
     notification_emails:
       - vpn@mozilla.com
       - amarchesini@mozilla.com


### PR DESCRIPTION
Telemetry has been removed from the VPN client in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11245