### PR TITLE
Bug 2054438 - Add `firefox_enterprise_desktop` application

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2393,7 +2393,6 @@ applications:
       - gecko
       - glean-core
       - crashping
-    prototype: true
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 400

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2329,6 +2329,7 @@ applications:
       - browser/components/controlcenter/metrics.yaml
       - browser/components/customkeys/metrics.yaml
       - browser/components/downloads/metrics.yaml
+      - browser/components/enterprisepolicies/metrics.yaml
       - browser/components/extensions/metrics.yaml
       - browser/components/firefoxview/metrics.yaml
       - browser/components/genai/metrics.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2324,11 +2324,11 @@ applications:
       - browser/components/asrouter/metrics.yaml
       - browser/components/attribution/metrics.yaml
       - browser/components/backup/metrics.yaml
-      - browser/components/contentsharing/metrics.yaml
       - browser/components/contextualidentity/metrics.yaml
       - browser/components/controlcenter/metrics.yaml
       - browser/components/customkeys/metrics.yaml
       - browser/components/downloads/metrics.yaml
+      - browser/components/enterprise/metrics.yaml
       - browser/components/enterprisepolicies/metrics.yaml
       - browser/components/extensions/metrics.yaml
       - browser/components/firefoxview/metrics.yaml
@@ -2343,9 +2343,12 @@ applications:
       - browser/components/profiles/metrics.yaml
       - browser/components/protections/metrics.yaml
       - browser/components/protocolhandler/metrics.yaml
+      - browser/components/referrals/metrics.yaml
       - browser/components/screenshots/metrics.yaml
       - browser/components/search/metrics.yaml
       - browser/components/sessionstore/metrics.yaml
+      - browser/components/sharing/metrics.yaml
+      - browser/components/shell/metrics.yaml
       - browser/components/sidebar/metrics.yaml
       - browser/components/tabbrowser/metrics.yaml
       - browser/components/tabnotes/metrics.yaml
@@ -2377,6 +2380,7 @@ applications:
       - browser/components/enterprisepolicies/pings.yaml
       - browser/components/newtab/pings.yaml
       - browser/components/profiles/pings.yaml
+      - browser/components/referrals/pings.yaml
       - browser/components/search/pings.yaml
       - browser/components/urlbar/pings.yaml
       - browser/modules/pings.yaml

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2310,3 +2310,93 @@ applications:
     moz_pipeline_metadata_defaults:
       expiration_policy:
         delete_after_days: 400
+
+  - app_name: firefox_enterprise
+    canonical_app_name: "Firefox Enterprise"
+    app_description: Managed, open-source browsing at scale
+    notification_emails:
+      - enterprise-telemetry@mozilla.org
+    url: https://github.com/mozilla/enterprise-firefox
+    branch: enterprise-main
+    metrics_files:
+      - browser/actors/metrics.yaml
+      - browser/components/aiwindow/metrics.yaml
+      - browser/components/asrouter/metrics.yaml
+      - browser/components/attribution/metrics.yaml
+      - browser/components/backup/metrics.yaml
+      - browser/components/contentsharing/metrics.yaml
+      - browser/components/contextualidentity/metrics.yaml
+      - browser/components/controlcenter/metrics.yaml
+      - browser/components/customkeys/metrics.yaml
+      - browser/components/downloads/metrics.yaml
+      - browser/components/extensions/metrics.yaml
+      - browser/components/firefoxview/metrics.yaml
+      - browser/components/genai/metrics.yaml
+      - browser/components/ipprotection/metrics.yaml
+      - browser/components/metrics.yaml
+      - browser/components/migration/metrics.yaml
+      - browser/components/newtab/metrics.yaml
+      - browser/components/places/metrics.yaml
+      - browser/components/preferences/metrics.yaml
+      - browser/components/privatebrowsing/metrics.yaml
+      - browser/components/profiles/metrics.yaml
+      - browser/components/protections/metrics.yaml
+      - browser/components/protocolhandler/metrics.yaml
+      - browser/components/screenshots/metrics.yaml
+      - browser/components/search/metrics.yaml
+      - browser/components/sessionstore/metrics.yaml
+      - browser/components/sidebar/metrics.yaml
+      - browser/components/tabbrowser/metrics.yaml
+      - browser/components/tabnotes/metrics.yaml
+      - browser/components/taskbartabs/metrics.yaml
+      - browser/components/textrecognition/metrics.yaml
+      - browser/components/urlbar/metrics.yaml
+      - browser/extensions/search-detection/metrics.yaml
+      - browser/modules/metrics.yaml
+      - dom/media/platforms/wmf/metrics.yaml
+      - services/fxaccounts/metrics.yaml
+      - toolkit/components/contentanalysis/metrics.yaml
+      - toolkit/components/contentrelevancy/metrics.yaml
+      - toolkit/components/crashes/metrics.yaml
+      - toolkit/components/nimbus/metrics.yaml
+      - toolkit/components/pictureinpicture/metrics.yaml
+      - toolkit/components/places/metrics.yaml
+      - toolkit/components/reportbrokensite/metrics.yaml
+      - toolkit/components/satchel/megalist/metrics.yaml
+      - toolkit/components/search/metrics.yaml
+      - toolkit/components/telemetry/metrics.yaml
+      - toolkit/modules/metrics.yaml
+      - toolkit/mozapps/update/shared_metrics.yaml
+      - widget/cocoa/metrics.yaml
+      - widget/gtk/metrics.yaml
+      - widget/windows/metrics.yaml
+    ping_files:
+      - browser/components/asrouter/pings.yaml
+      - browser/components/backup/pings.yaml
+      - browser/components/enterprisepolicies/pings.yaml
+      - browser/components/newtab/pings.yaml
+      - browser/components/profiles/pings.yaml
+      - browser/components/search/pings.yaml
+      - browser/components/urlbar/pings.yaml
+      - browser/modules/pings.yaml
+      - services/fxaccounts/pings.yaml
+      - services/sync/pings.yaml
+      - toolkit/components/nimbus/pings.yaml
+      - toolkit/components/reportbrokensite/pings.yaml
+      - toolkit/components/telemetry/pings.yaml
+      - toolkit/modules/pings.yaml
+      - toolkit/mozapps/update/shared_pings.yaml
+      - toolkit/profile/pings.yaml
+    tag_files:
+      - toolkit/components/glean/tags.yaml
+    dependencies:
+      - gecko
+      - glean-core
+      - crashping
+    prototype: true
+    moz_pipeline_metadata_defaults:
+      expiration_policy:
+        delete_after_days: 400
+    channels:
+      - v1_name: firefox-enteprise
+        app_id: firefox-enterprise.desktop

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2311,8 +2311,8 @@ applications:
       expiration_policy:
         delete_after_days: 400
 
-  - app_name: firefox_enterprise
-    canonical_app_name: "Firefox Enterprise"
+  - app_name: firefox_enterprise_desktop
+    canonical_app_name: Firefox Enterprise for Desktop
     app_description: Managed, open-source browsing at scale
     notification_emails:
       - enterprise-telemetry@mozilla.org
@@ -2397,5 +2397,5 @@ applications:
       expiration_policy:
         delete_after_days: 400
     channels:
-      - v1_name: firefox-enteprise
-        app_id: firefox-enterprise.desktop
+      - v1_name: firefox-enteprise-desktop
+        app_id: firefox.enterprise.desktop

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -2402,5 +2402,5 @@ applications:
       expiration_policy:
         delete_after_days: 400
     channels:
-      - v1_name: firefox-enteprise-desktop
+      - v1_name: firefox-enterprise-desktop
         app_id: firefox.enterprise.desktop


### PR DESCRIPTION
This patch sets up probe scraping for the Firefox Enterprise Browser Application source in https://github.com/mozilla/enterprise-firefox