### PR TITLE
rename enum and structure fields when serializing metrics

### DIFF
--- a/probe_scraper/parsers/metrics.py
+++ b/probe_scraper/parsers/metrics.py
@@ -27,7 +27,12 @@ class GleanMetricsParser:
         errors = [err for err in results]
 
         metrics = {
-            metric.identifier(): metric.serialize()
+            metric.identifier(): metric.serialize(
+                rename_fields={
+                    "_generate_structure": "structure",
+                    "_generate_enums": "enums",
+                }
+            )
             for category, probes in results.value.items()
             for probe_name, metric in probes.items()
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.8.2
 GitPython==3.1.41
 boto3==1.28.7
 Flask==2.3.3
-glean-parser~=20.1.0
+glean-parser~=20.2.0
 google-cloud-bigquery==3.23.1
 google-cloud-storage==2.2.1
 gsutil==5.28

--- a/tests/resources/metrics-v2.yaml
+++ b/tests/resources/metrics-v2.yaml
@@ -1,0 +1,26 @@
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+example:
+  object_metric:
+    type: object
+    lifetime: application
+    send_in_pings:
+      - baseline
+    description: |
+      The object metric for testing
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1497894
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1512938#c3
+    notification_emails:
+      - telemetry-client-dev@mozilla.com
+    expires: never
+    structure:
+      type: array
+      items:
+        type: object
+        properties:
+          prop_a:
+            type: string
+          prop_b:
+            type: boolean

--- a/tests/test_metrics_parser.py
+++ b/tests/test_metrics_parser.py
@@ -25,6 +25,22 @@ def test_metrics_parser():
     assert "session-end" in parsed_metrics["example.os"]["send_in_pings"]
 
 
+def test_metrics_parser_schema_v2():
+    # Parse the histograms from the test definitions.
+    parser = GleanMetricsParser()
+    parsed_metrics, errs = parser.parse(["tests/resources/metrics-v2.yaml"], {})
+
+    assert errs == []
+
+    # Make sure we loaded all the metrics.
+    # Notably, we do not check the contents; that is left up to the
+    # glean parser to handle.
+    assert len(parsed_metrics) == 1
+    for name, data in parsed_metrics.items():
+        assert is_string(name)
+        assert "structure" in data
+
+
 def test_source_url():
     parser = GleanMetricsParser()
     parsed_metrics, errs = parser.parse(


### PR DESCRIPTION
This renames enum and structure internal fields so that we can have that data in the probe info service.