### PR TITLE
Bug 2056699: fog-updater: Always enable auto-merge on the newly created pull request

### DIFF
--- a/fog-updater/src/fog_updater/__init__.py
+++ b/fog-updater/src/fog_updater/__init__.py
@@ -267,6 +267,10 @@ def run(argv, repo, author, debug=False, dry_run=False):
         head=pr_branch_name,
         base=release_branch_name,
     )
+
+    # Enable auto-merge on the new pull request
+    pr.enable_automerge(merge_method="REBASE")
+
     print(f"{ts()} Pull request at {pr.html_url}")
 
 


### PR DESCRIPTION
This is step 1 to make fog-updater PRs auto-merge if they pass CI.