### PR TITLE
Bug 2056699 - CI: Auto-merge PRs from admins that are only touching repositories.yaml

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -181,3 +181,76 @@ jobs:
           --set-env-vars=BOTO_PATH=.gce_boto,OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/ \
           --trigger-http --service-account="$FUNCTION_RUNTIME_SERVICE_ACCOUNT" --timeout=540s \
           --source=.
+
+  automerge:
+    runs-on: ubuntu-latest
+    needs: build_and_test
+    if:
+      ${{
+        github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
+      }}
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
+      with:
+        base_sha: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ vars.APP_CLIENT_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        permission-contents: write
+        permission-pull-requests: write
+        owner: mozilla
+        repositories: probe-scraper
+
+    - name: Auto-merge
+      env:
+        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        ACTOR: ${{ github.actor }}
+        EVENT: ${{ toJSON(github.event) }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        echo "pr=$PR_NUMBER"
+        echo "actor=$ACTOR"
+
+        if [[ "$actor" != "glean-ci[bot]" ]]; then
+          echo "Insufficient permission. Stopping."
+          exit 0
+        fi
+
+        for file in ${ALL_CHANGED_FILES}; do
+          if [[ "$file" != "repositories.txt" ]]; then
+            echo "$file was modified. Only repositories.txt changes are merged automatically."
+            echo "Bailing out."
+            gh pr comment "$PR_NUMBER" \
+              --body "Auto-merge aborted. '${file}' was modified. Only repositories.txt changes are merged automatically."
+            exit 0
+          fi
+        done
+
+        permission=$(gh api /repos/mozilla/probe-scraper/collaborators/${ACTOR}/permission | jq -r .permission)
+        echo "permission=$permission"
+
+        pr_info=$(gh api "/repos/mozilla/probe-scraper/pulls/${PR_NUMBER}")
+        pr_state=$(echo "$pr_info" | jq -r .state)
+        if [[ "$pr_state" != "open" ]]; then
+          echo "PR is not open. State: ${pr_state}. Stopping."
+          exit 0
+        fi
+
+        echo "Tests succeeded. Merging this PR automatically."
+        gh pr comment "$PR_NUMBER" \
+          --body "Tests succeeded. This PR will be automatically merged now."
+        gh pr merge --admin --rebase "$PR_NUMBER"

--- a/.github/workflows/update-fog.yml
+++ b/.github/workflows/update-fog.yml
@@ -32,10 +32,17 @@ jobs:
       - name: Setup Python
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: "Update FOG"
         id: fog-updater
         if: github.repository == 'mozilla/probe-scraper'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           uv run --project fog-updater fog-updater

--- a/fog-updater/src/fog_updater/__init__.py
+++ b/fog-updater/src/fog_updater/__init__.py
@@ -274,9 +274,6 @@ def run(argv, repo, author, debug=False, dry_run=False):
         base=release_branch_name,
     )
 
-    # Enable auto-merge on the new pull request
-    pr.enable_automerge(merge_method="REBASE")
-
     print(f"{ts()} Pull request at {pr.html_url}")
 
 


### PR DESCRIPTION
They are ONLY merged after tests succeed!

---

We could add additional checks to make sure this only applies to PRs opened by the fog-updater.
It's also currently missing a secret (`GH_PAT`) that is a Personal Access Token from one of us (e.g. me) with admin privileges, so that the github action can force the merge (and overwriting our "requires a reviewer" protection).

Alternatively we could use either a bot account or a GitHub app with the right permissions, both of which are a bit more involved to do. 