### PR TITLE
glean-push: Use Python 3.14 for the push function

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -177,7 +177,7 @@ jobs:
         FUNCTION_RUNTIME_SERVICE_ACCOUNT: ${{ vars.FUNCTION_RUNTIME_SERVICE_ACCOUNT }}
       run: |-
         gcloud functions deploy glean-push --region=us-west1 --allow-unauthenticated \
-          --entry-point=glean_push --memory=2048 --runtime=python310 \
+          --entry-point=glean_push --memory=2048 --runtime=python314 \
           --set-env-vars=BOTO_PATH=.gce_boto,OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/ \
           --trigger-http --service-account="$FUNCTION_RUNTIME_SERVICE_ACCOUNT" --timeout=540s \
           --source=.


### PR DESCRIPTION
Warning from gcloud functions deploy:

WARNING: Python 3.10 is no longer supported by the Python community as of 4 October, 2026. Python 3.10 will be deprecated on 2026-10-04.
We recommend you to upgrade to the latest version of Python as soon as possible.