### PR TITLE
Revert "fog-updater: Always enable auto-merge on the newly created pull request

### DIFF
--- a/fog-updater/src/fog_updater/__init__.py
+++ b/fog-updater/src/fog_updater/__init__.py
@@ -273,10 +273,6 @@ def run(argv, repo, author, debug=False, dry_run=False):
         head=pr_branch_name,
         base=release_branch_name,
     )
-
-    # Enable auto-merge on the new pull request
-    pr.enable_automerge(merge_method="REBASE")
-
     print(f"{ts()} Pull request at {pr.html_url}")
 
 


### PR DESCRIPTION
This reverts commit 463d4a7f798abcaa5c7a8d769d7a55e175d4a220.

The default auto-merge here caused an additional issue: Now a PR is merged immediately as an engineer approves it, it's considered merged by the bot, which means CI never automatically runs for it, not even for `main`!
As this is not the long-term solution we're going for (instead probably having a GitHub app as the authenticator), we can just remove it. One more click for the actual reviewer to also merge, but that's good enough.