### PR TITLE
glean-push: Use Python 3.12, the newest runtime supported on GCF 1st gen

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -177,7 +177,7 @@ jobs:
         FUNCTION_RUNTIME_SERVICE_ACCOUNT: ${{ vars.FUNCTION_RUNTIME_SERVICE_ACCOUNT }}
       run: |-
         gcloud functions deploy glean-push --region=us-west1 --allow-unauthenticated \
-          --entry-point=glean_push --memory=2048 --runtime=python314 \
+          --entry-point=glean_push --memory=2048 --runtime=python312 \
           --set-env-vars=BOTO_PATH=.gce_boto,OUTPUT_BUCKET=gs://probe-scraper-prod-artifacts/ \
           --trigger-http --service-account="$FUNCTION_RUNTIME_SERVICE_ACCOUNT" --timeout=540s \
           --source=.


### PR DESCRIPTION
Commit f0b28ff bumped the runtime to python314 to clear a gcloud deprecation warning about Python 3.10, but python313 and python314 are 2nd gen only, so every deploy since has failed with:

  ERROR: (gcloud.functions.deploy) argument `--runtime`: python314 is
  not a supported runtime on GCF 1st gen.

glean-push is a 1st gen function, where python312 is the newest GA runtime. That still resolves the Python 3.10 deprecation. Moving to python313/314 would require migrating the function to 2nd gen, which cannot be done in place.