### PR TITLE
Handle underscores in use counter method names

### DIFF
--- a/probe_scraper/parsers/third_party/usecounters.py
+++ b/probe_scraper/parsers/third_party/usecounters.py
@@ -17,7 +17,7 @@ def read_conf(conf_filename):
             if not line or line.startswith("//"):
                 # empty line or comment
                 continue
-            m = re.match(r"method ([A-Za-z0-9]+)\.([A-Za-z0-9]+)$", line)
+            m = re.match(r"method ([A-Za-z0-9]+)\.([A-Za-z0-9_]+)$", line)
             if m:
                 interface_name, method_name = m.groups()
                 yield {


### PR DESCRIPTION
This is [failing](https://workflow.telemetry.mozilla.org/dags/probe_scraper/grid?dag_run_id=scheduled__2026-08-10T00%3A00%3A00%2B00%3A00&task_id=probe_scraper_moz_central&tab=details) with
```
Traceback (most recent call last):   File "<frozen runpy>", line 198, in _run_module_as_main   File "<frozen runpy>", line 88, in _run_code   File "/app/probe_scraper/runner.py", line 906, in <module>     main(   File "/app/probe_scraper/runner.py", line 707, in main     upload_paths += load_moz_central_probes(
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/runner.py", line 319, in load_moz_central_probes
    revision_probes = parse_moz_central_probes(revision_data)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/runner.py", line 218, in parse_moz_central_probes
    results = PARSERS[probe_type].parse(paths, details["version"], channel)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/parsers/histograms.py", line 88, in parse
    parsed_probes = list(histogram_tools.from_files(filenames))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/parsers/third_party/histogram_tools.py", line 666, in from_files
    histograms = parser(filename)
                 ^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/parsers/third_party/histogram_tools.py", line 551, in from_UseCounters_conf
    return usecounters.generate_histograms(filename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/probe_scraper/parsers/third_party/usecounters.py", line 57, in generate_histograms
    for counter in read_conf(filename):
  File "/app/probe_scraper/parsers/third_party/usecounters.py", line 48, in parse_counters
    raise ValueError("error parsing %s at line %d" % (conf_filename, line_num))
ValueError: error parsing /app/probe_cache/hg/1e704c6738f494b411bce8840fcabc790f704e8b/dom/base/UseCounters.conf at line 543
```

https://github.com/mozilla-firefox/firefox/commit/546b6eb4118af08a2ede983f9403606f8a183100 added methods with underscores and changed the function to allow underscores. The `parse_counters` function here is being updated to match the one in firefox