### PR TITLE
Bug 2056550 - Run expiry checks for up to 2 versions ahead for Fenix too

### DIFF
--- a/probe_scraper/glean_checks.py
+++ b/probe_scraper/glean_checks.py
@@ -445,12 +445,16 @@ def check_for_expired_metrics(
         if repo.deprecated:
             continue
 
-        target_version = None
+        target_versions = None
         if repo.name == "fenix":
             try:
-                target_version = (
-                    int(probe_expiry_alert.get_latest_nightly_version()) + 2
+                latest_nightly_version = int(
+                    probe_expiry_alert.get_latest_nightly_version()
                 )
+                target_versions = [
+                    latest_nightly_version + 1,
+                    latest_nightly_version + 2,
+                ]
             except ValueError:
                 # Can't parse the version as an int. Welp.
                 pass
@@ -468,9 +472,11 @@ def check_for_expired_metrics(
 
             if isinstance(metric["expires"], int):
                 # Uses expire-by-version.
-                if target_version is not None:
-                    if metric["expires"] == target_version:
-                        expired_metrics.append(f" - {metric_name} in {target_version}")
+                if target_versions is not None:
+                    if metric["expires"] in target_versions:
+                        expired_metrics.append(
+                            f" - {metric_name} in {metric['expires']}"
+                        )
                         addresses.update(metric["notification_emails"])
                 continue
 


### PR DESCRIPTION
I accidentally had #1056 auto-merge while I was still working on a followup.

I changed parts of #1056 to actually check both version+1 and version+2, but hadn't fixed that for Fenix just yet. This is the missing part.